### PR TITLE
Added functionality to highlight and snap

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -1,3 +1,8 @@
+2.1 (in progress)
+=================
+- added option to highlight object that can be picked up
+- added option to snap object to given location (if reset transform is true)
+
 2.0
 ===
 - Renamed add on to **godot-xr-tools**

--- a/addons/godot-xr-tools/materials/highlight.tres
+++ b/addons/godot-xr-tools/materials/highlight.tres
@@ -1,0 +1,9 @@
+[gd_resource type="SpatialMaterial" format=2]
+
+[resource]
+albedo_color = Color( 0.133333, 0.203922, 0.32549, 1 )
+emission_enabled = true
+emission = Color( 0.301961, 0.47451, 0.933333, 1 )
+emission_energy = 1.0
+emission_operator = 0
+emission_on_uv2 = false

--- a/addons/godot-xr-tools/misc/VR_Common_Shader_Cache.tscn
+++ b/addons/godot-xr-tools/misc/VR_Common_Shader_Cache.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/misc/VR_Common_Shader_Cache.gd" type="Script" id=1]
 [ext_resource path="res://addons/godot-xr-tools/materials/teleport.tres" type="Material" id=2]
 [ext_resource path="res://addons/godot-xr-tools/materials/target.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/materials/capule.tres" type="Material" id=4]
 [ext_resource path="res://addons/godot-xr-tools/materials/pointer.tres" type="Material" id=5]
+[ext_resource path="res://addons/godot-xr-tools/materials/highlight.tres" type="Material" id=6]
 
-[sub_resource type="PlaneMesh" id=2]
+[sub_resource type="PlaneMesh" id=1]
 size = Vector2( 0.001, 0.001 )
 
 [node name="vr_common_shader_cache" type="Spatial"]
@@ -14,20 +15,25 @@ script = ExtResource( 1 )
 
 [node name="teleport" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2 )
-mesh = SubResource( 2 )
+mesh = SubResource( 1 )
 material/0 = ExtResource( 2 )
 
 [node name="target" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2 )
-mesh = SubResource( 2 )
+mesh = SubResource( 1 )
 material/0 = ExtResource( 3 )
 
 [node name="capsule" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2 )
-mesh = SubResource( 2 )
+mesh = SubResource( 1 )
 material/0 = ExtResource( 4 )
 
 [node name="pointer" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2 )
-mesh = SubResource( 2 )
+mesh = SubResource( 1 )
 material/0 = ExtResource( 5 )
+
+[node name="highlight" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2 )
+mesh = SubResource( 1 )
+material/0 = ExtResource( 6 )

--- a/addons/godot-xr-tools/objects/Object_pickable.gd
+++ b/addons/godot-xr-tools/objects/Object_pickable.gd
@@ -3,6 +3,8 @@ extends RigidBody
 # Set hold mode
 export (bool) var press_to_hold = true
 export (bool) var reset_transform_on_pickup = true
+export (NodePath) var center_pickup_on = null
+export (NodePath) var highlight_mesh_instance = null
 export  (int, FLAGS, "Layer 1", "Layer 2", "Layer 3", "Layer 4", "Layer 5", "Layer 6", "Layer 7", "Layer 8", "Layer 9", "Layer 10", "Layer 11", "Layer 12", "Layer 13", "Layer 14", "Layer 15", "Layer 16", "Layer 17", "Layer 18", "Layer 19", "Layer 20") var picked_up_layer = 0
 
 # Remember some state so we can return to it when the user drops the object
@@ -10,8 +12,13 @@ onready var original_parent = get_parent()
 onready var original_collision_mask = collision_mask
 onready var original_collision_layer = collision_layer
 
+onready var highlight_material = preload("res://addons/godot-xr-tools/materials/highlight.tres")
+var original_materials = Array()
+var highlight_mesh_instance_node : MeshInstance = null
+
 # Who picked us up?
 var picked_up_by = null
+var center_pickup_on_node = null
 var by_controller : ARVRController = null
 var closest_count = 0
 
@@ -23,8 +30,16 @@ func is_picked_up():
 	return false
 
 func _update_highlight():
-	# should probably implement this in our subclass
-	pass
+	if highlight_mesh_instance_node:
+		# if we can find a node remember which materials are currently set on each surface
+		for i in range(0, highlight_mesh_instance_node.get_surface_material_count()):
+			if closest_count > 0:
+				highlight_mesh_instance_node.set_surface_material(i, highlight_material)
+			else:
+				highlight_mesh_instance_node.set_surface_material(i, original_materials[i])
+	else:
+		# should probably implement this in our subclass
+		pass
 
 func increase_is_closest():
 	closest_count += 1
@@ -63,8 +78,11 @@ func pick_up(by, with_controller):
 	picked_up_by.add_child(self)
 	
 	if reset_transform_on_pickup:
-		# reset our transform
-		transform = Transform()
+		if center_pickup_on_node:
+			transform = center_pickup_on_node.global_transform.inverse() * global_transform
+		else:
+			# reset our transform
+			transform = Transform()
 	else:
 		# make sure we keep its original position
 		global_transform = original_transform
@@ -93,3 +111,16 @@ func let_go(starting_linear_velocity = Vector3(0.0, 0.0, 0.0)):
 		# we are no longer picked up
 		picked_up_by = null
 		by_controller = null
+
+func _ready():
+	if highlight_mesh_instance:
+		# if we have a highlight mesh instance selected obtain our node
+		highlight_mesh_instance_node = get_node(highlight_mesh_instance)
+		if highlight_mesh_instance_node:
+			# if we can find a node remember which materials are currently set on each surface
+			for i in range(0, highlight_mesh_instance_node.get_surface_material_count()):
+				original_materials.push_back(highlight_mesh_instance_node.get_surface_material(i))
+	
+	if center_pickup_on:
+		# if we have center pickup on set obtain our node
+		center_pickup_on_node = get_node(center_pickup_on) 


### PR DESCRIPTION
Added functionality to highlight an object in range of being picked up and added a snap to location when picking up.

There are two new properties on the `Object Pickable` subscene:
![image](https://user-images.githubusercontent.com/1945449/80302465-941aba80-87ed-11ea-9bbe-e8233d9cd819.png)

`Center Pickup On` only works if `Reset Transform On Pickup` is true. If so the object will positioned so the controller is centered on the indicated node when the object is picked up.

![image](https://user-images.githubusercontent.com/1945449/80302859-eeb51600-87ef-11ea-8bd4-f0ec260e4189.png)

![image](https://user-images.githubusercontent.com/1945449/80302885-0db3a800-87f0-11ea-8cac-21b7c1635e93.png)

`Highlight Mesh Instance` provides a mechanism where you can indicate the MeshInstance in your subscene that  represents the object being picked up. When the object is recognised as being the object closest to the hand the material entries for this MeshInstance will be temporarily replaced by a material that shows the object in highlight. 

![image](https://user-images.githubusercontent.com/1945449/80302897-1efcb480-87f0-11ea-9529-08ec945aecce.png)
