### PR TITLE
Added in signal to inform when shader cache is finished

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -2,6 +2,7 @@
 =================
 - added option to highlight object that can be picked up
 - added option to snap object to given location (if reset transform is true)
+- added callback when shader cache has finished
 
 2.0
 ===

--- a/addons/godot-xr-tools/misc/VR_Common_Shader_Cache.gd
+++ b/addons/godot-xr-tools/misc/VR_Common_Shader_Cache.gd
@@ -1,5 +1,7 @@
 extends Spatial
 
+signal cooldown_finished
+
 var countdown = 2
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -8,3 +10,4 @@ func _process(delta):
 	if countdown == 0:
 		visible = false
 		set_process(false)
+		emit_signal("cooldown_finished")


### PR DESCRIPTION
Somehow lost this change, emit a signal when the shader cache is done so we can hook up other updates.