### PR TITLE
Changed default physics settings and fixed up some issues

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -1,3 +1,10 @@
+# 2.2
+- Changed default physics layers to make more sense (minor breaking change)
+- Replaced Center On Node property with PickupCenter node you can place
+- Made Object_pickable script work by itself and registers as class `XRToolsPickable`
+- New Object_interactable convenience script that registers as class `XRToolsInteractable` that reacts to our pointer function
+- Removed ducktype switch from pointer, pointer will use signals over ducktyping automatically (minor breaking change)
+
 # 2.1
 - added option to highlight object that can be picked up
 - added option to snap object to given location (if reset transform is true)

--- a/addons/godot-xr-tools/assets/LeftHand.glb.import
+++ b/addons/godot-xr-tools/assets/LeftHand.glb.import
@@ -16,6 +16,7 @@ nodes/root_name="Scene Root"
 nodes/root_scale=1.0
 nodes/custom_script=""
 nodes/storage=0
+nodes/use_legacy_names=true
 materials/location=1
 materials/storage=1
 materials/keep_on_reimport=true

--- a/addons/godot-xr-tools/assets/LeftHandBlendTree.tres
+++ b/addons/godot-xr-tools/assets/LeftHandBlendTree.tres
@@ -35,4 +35,4 @@ nodes/SetGrip/position = Vector2( 360, 40 )
 nodes/SetIndex/node = SubResource( 7 )
 nodes/SetIndex/position = Vector2( 360, 240 )
 nodes/output/position = Vector2( 1020, 80 )
-node_connections = [ "Blend2", 0, "GripTimeScale", "Blend2", 1, "IndexTimeScale", "GripTimeScale", 0, "SetGrip", "output", 0, "Blend2", "IndexTimeScale", 0, "SetIndex", "SetGrip", 0, "GripAnimation", "SetIndex", 0, "Animation 2" ]
+node_connections = [ "output", 0, "Blend2", "SetIndex", 0, "Animation 2", "IndexTimeScale", 0, "SetIndex", "GripTimeScale", 0, "SetGrip", "Blend2", 0, "GripTimeScale", "Blend2", 1, "IndexTimeScale", "SetGrip", 0, "GripAnimation" ]

--- a/addons/godot-xr-tools/assets/RightHand.glb.import
+++ b/addons/godot-xr-tools/assets/RightHand.glb.import
@@ -16,6 +16,7 @@ nodes/root_name="Scene Root"
 nodes/root_scale=1.0
 nodes/custom_script=""
 nodes/storage=0
+nodes/use_legacy_names=true
 materials/location=1
 materials/storage=1
 materials/keep_on_reimport=true

--- a/addons/godot-xr-tools/assets/RightHandBlend.tres
+++ b/addons/godot-xr-tools/assets/RightHandBlend.tres
@@ -35,4 +35,4 @@ nodes/SetGrip/position = Vector2( 360, 40 )
 nodes/SetIndex/node = SubResource( 7 )
 nodes/SetIndex/position = Vector2( 360, 240 )
 nodes/output/position = Vector2( 1020, 80 )
-node_connections = [ "Blend2", 0, "GripTimeScale", "Blend2", 1, "IndexTimeScale", "GripTimeScale", 0, "SetGrip", "output", 0, "Blend2", "IndexTimeScale", 0, "SetIndex", "SetGrip", 0, "GripAnimation", "SetIndex", 0, "Animation 2" ]
+node_connections = [ "output", 0, "Blend2", "SetIndex", 0, "Animation 2", "IndexTimeScale", 0, "SetIndex", "GripTimeScale", 0, "SetGrip", "Blend2", 0, "GripTimeScale", "Blend2", 1, "IndexTimeScale", "SetGrip", 0, "GripAnimation" ]

--- a/addons/godot-xr-tools/functions/Function_Direct_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Direct_movement.gd
@@ -56,10 +56,10 @@ onready var collision_shape: CollisionShape = get_node("KinematicBody/CollisionS
 onready var tail : RayCast = get_node("KinematicBody/Tail")
 
 # Set our collision layer
-export  (int, LAYERS_3D_PHYSICS) var collision_layer = 1 setget set_collision_layer, get_collision_layer
+export  (int, LAYERS_3D_PHYSICS) var collision_layer = 1 << 19 setget set_collision_layer, get_collision_layer
 
 # Set our collision mask
-export  (int, LAYERS_3D_PHYSICS) var collision_mask = 1022 setget set_collision_mask, get_collision_mask
+export  (int, LAYERS_3D_PHYSICS) var collision_mask = 1023 setget set_collision_mask, get_collision_mask
 
 
 func set_enabled(new_value):

--- a/addons/godot-xr-tools/functions/Function_Direct_movement.tscn
+++ b/addons/godot-xr-tools/functions/Function_Direct_movement.tscn
@@ -2,17 +2,16 @@
 
 [ext_resource path="res://addons/godot-xr-tools/functions/Function_Direct_movement.gd" type="Script" id=1]
 
-
 [sub_resource type="CapsuleShape" id=1]
 radius = 0.3
 height = 1.2
 
 [node name="Function_Direct_movement" type="Node"]
 script = ExtResource( 1 )
-max_speed = 10.0
 
 [node name="KinematicBody" type="KinematicBody" parent="."]
-collision_mask = 1048574
+collision_layer = 524288
+collision_mask = 1023
 
 [node name="CollisionShape" type="CollisionShape" parent="KinematicBody"]
 transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.9, 0 )
@@ -22,4 +21,4 @@ shape = SubResource( 1 )
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0 )
 enabled = true
 cast_to = Vector3( 0, -0.6, 0 )
-collision_mask = 1048574
+collision_mask = 1023

--- a/addons/godot-xr-tools/functions/Function_Pickup.gd
+++ b/addons/godot-xr-tools/functions/Function_Pickup.gd
@@ -35,6 +35,7 @@ var picked_up_object = null
 var last_transform = Transform()
 var linear_velocities = Array()
 var angular_velocities = Array()
+var deltas = Array()
 
 func set_pickup_range(new_range):
 	pickup_range = new_range
@@ -44,24 +45,32 @@ func set_pickup_range(new_range):
 func _get_linear_velocity():
 	var velocity = Vector3(0.0, 0.0, 0.0)
 	var count = linear_velocities.size()
-	
-	if count > 0:
+	var delta = 0.0
+
+	for d in deltas:
+		delta = delta + d
+
+	if delta > 0.0 and count > 0:
 		for v in linear_velocities:
 			velocity = velocity + v
-		
-		velocity = velocity / count
+
+		velocity = velocity / delta
 	
 	return velocity
 
 func _get_angular_velocity():
 	var velocity = Vector3(0.0, 0.0, 0.0)
 	var count = angular_velocities.size()
-	
-	if count > 0:
+	var delta = 0.0
+
+	for d in deltas:
+		delta = delta + d
+
+	if delta > 0.0 and count > 0:
 		for v in angular_velocities:
 			velocity = velocity + v
-		
-		velocity = velocity / count
+
+		velocity = velocity / delta
 	
 	return velocity
 
@@ -147,17 +156,21 @@ func _ready():
 
 func _process(delta):
 	# Calculate our linear velocity
-	var linear_velocity = (global_transform.origin - last_transform.origin) / delta
+	var linear_velocity = (global_transform.origin - last_transform.origin)
 	linear_velocities.push_back(linear_velocity)
 	if linear_velocities.size() > max_samples:
 		linear_velocities.pop_front()
 	
 	# Calculate our angular velocity
 	var delta_basis = global_transform.basis * last_transform.basis.inverse()
-	var angular_velocity = delta_basis.get_euler() / delta
+	var angular_velocity = delta_basis.get_euler()
 	angular_velocities.push_back(angular_velocity)
 	if angular_velocities.size() > max_samples:
 		angular_velocities.pop_front()
+	
+	deltas.push_back(delta)
+	if deltas.size() > max_samples:
+		deltas.pop_front()
 	
 	last_transform = global_transform
 	_update_closest_object()

--- a/addons/godot-xr-tools/functions/Function_Pickup.tscn
+++ b/addons/godot-xr-tools/functions/Function_Pickup.tscn
@@ -2,16 +2,17 @@
 
 [ext_resource path="res://addons/godot-xr-tools/functions/Function_Pickup.gd" type="Script" id=1]
 
-
 [sub_resource type="SphereShape" id=1]
 radius = 0.5
 
 [node name="Function_Pickup" type="Area"]
-collision_mask = 2
+collision_layer = 524288
+collision_mask = 1023
 script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
 shape = SubResource( 1 )
+
 [connection signal="area_entered" from="." to="." method="_on_Function_Pickup_entered"]
 [connection signal="area_exited" from="." to="." method="_on_Function_Pickup_exited"]
 [connection signal="body_entered" from="." to="." method="_on_Function_Pickup_entered"]

--- a/addons/godot-xr-tools/functions/Function_Teleport.tscn
+++ b/addons/godot-xr-tools/functions/Function_Teleport.tscn
@@ -21,9 +21,12 @@ height = 0.1
 
 [node name="Function_Teleport" type="KinematicBody"]
 input_ray_pickable = false
+collision_layer = 524288
+collision_mask = 1023
 collision/safe_margin = 0.01
 script = ExtResource( 1 )
 no_collision_color = Color( 0.176471, 0.313726, 0.862745, 1 )
+camera = null
 
 [node name="Teleport" type="MeshInstance" parent="."]
 mesh = SubResource( 1 )

--- a/addons/godot-xr-tools/functions/Function_pointer.tscn
+++ b/addons/godot-xr-tools/functions/Function_pointer.tscn
@@ -15,15 +15,15 @@ radial_segments = 16
 rings = 8
 
 [node name="Function_pointer" type="Spatial"]
-transform = Transform( 1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )
 script = ExtResource( 2 )
-collision_mask = 1048575
+collision_mask = 524287
 
 [node name="RayCast" type="RayCast" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0 )
 enabled = true
 cast_to = Vector3( 0, 0, -10 )
-collision_mask = 1048575
+collision_mask = 524287
 
 [node name="Laser" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, -5 )

--- a/addons/godot-xr-tools/images/teleport_arrow.png.import
+++ b/addons/godot-xr-tools/images/teleport_arrow.png.import
@@ -3,16 +3,16 @@
 importer="texture"
 type="StreamTexture"
 path.s3tc="res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.s3tc.stex"
-path.etc2="res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc2.stex"
+path.etc="res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
+"imported_formats": [ "s3tc", "etc" ],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://addons/godot-xr-tools/images/teleport_arrow.png"
-dest_files=[ "res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.s3tc.stex", "res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc2.stex" ]
+dest_files=[ "res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.s3tc.stex", "res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc.stex" ]
 
 [params]
 

--- a/addons/godot-xr-tools/images/teleport_target.png.import
+++ b/addons/godot-xr-tools/images/teleport_target.png.import
@@ -3,16 +3,16 @@
 importer="texture"
 type="StreamTexture"
 path.s3tc="res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.s3tc.stex"
-path.etc2="res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc2.stex"
+path.etc="res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
+"imported_formats": [ "s3tc", "etc" ],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://addons/godot-xr-tools/images/teleport_target.png"
-dest_files=[ "res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.s3tc.stex", "res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc2.stex" ]
+dest_files=[ "res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.s3tc.stex", "res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc.stex" ]
 
 [params]
 

--- a/addons/godot-xr-tools/materials/highlight.tres
+++ b/addons/godot-xr-tools/materials/highlight.tres
@@ -17,6 +17,8 @@ operator = 2
 
 [sub_resource type="VisualShader" id=6]
 code = "shader_type spatial;
+render_mode specular_schlick_ggx;
+
 uniform vec4 Color : hint_color;
 
 
@@ -38,9 +40,8 @@ void fragment() {
 	vec3 n_out3p0 = n_out2p0 * vec3(n_out4p0);
 
 // Fresnel:5
-	bool n_in5p2 = false;
 	float n_in5p3 = 1.00000;
-	float n_out5p0 = n_in5p2 ? (pow(clamp(dot(NORMAL, VIEW), 0.0, 1.0), n_in5p3)) : (pow(1.0 - clamp(dot(NORMAL, VIEW), 0.0, 1.0), n_in5p3));
+	float n_out5p0 = pow(1.0 - clamp(dot(NORMAL, VIEW), 0.0, 1.0), n_in5p3);
 
 // VectorOp:6
 	vec3 n_out6p0 = n_out2p0 * vec3(n_out5p0);

--- a/addons/godot-xr-tools/objects/Interactable_area.gd
+++ b/addons/godot-xr-tools/objects/Interactable_area.gd
@@ -1,0 +1,9 @@
+extends Area
+
+class_name XRToolsInteractableArea
+
+signal pointer_pressed(at)
+signal pointer_released(at)
+signal pointer_moved(from, to)
+signal pointer_entered()
+signal pointer_exited()

--- a/addons/godot-xr-tools/objects/Interactable_body.gd
+++ b/addons/godot-xr-tools/objects/Interactable_body.gd
@@ -1,0 +1,9 @@
+extends PhysicsBody
+
+class_name XRToolsInteractableBody
+
+signal pointer_pressed(at)
+signal pointer_released(at)
+signal pointer_moved(from, to)
+signal pointer_entered()
+signal pointer_exited()

--- a/addons/godot-xr-tools/objects/Object_pickable.tscn
+++ b/addons/godot-xr-tools/objects/Object_pickable.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource path="res://addons/godot-xr-tools/objects/Object_pickable.gd" type="Script" id=1]
 
-
 [node name="PickableObject" type="RigidBody"]
-collision_layer = 6
-collision_mask = 6
 script = ExtResource( 1 )
+highlight_mesh_instance = null
+
+[node name="PickupCenter" type="Spatial" parent="."]
 
 [node name="CollisionShape" type="CollisionShape" parent="."]

--- a/addons/godot-xr-tools/objects/Viewport_2D_in_3D.gd
+++ b/addons/godot-xr-tools/objects/Viewport_2D_in_3D.gd
@@ -81,3 +81,9 @@ func _ready():
 	set_scene(scene)
 	set_collision_layer(collision_layer)
 	set_transparent(transparent)
+
+func _on_pointer_entered():
+	emit_signal("pointer_entered")
+
+func _on_pointer_exited():
+	emit_signal("pointer_exited")

--- a/addons/godot-xr-tools/objects/Viewport_2D_in_3D.tscn
+++ b/addons/godot-xr-tools/objects/Viewport_2D_in_3D.tscn
@@ -22,6 +22,7 @@ extents = Vector3( 1.5, 1, 0.01 )
 
 [node name="Viewport2Din3D" type="Spatial"]
 script = ExtResource( 1 )
+collision_layer = 1023
 
 [node name="Viewport" type="Viewport" parent="."]
 size = Vector2( 300, 200 )
@@ -42,3 +43,9 @@ viewport_size = Vector2( 300, 200 )
 
 [node name="CollisionShape" type="CollisionShape" parent="StaticBody"]
 shape = SubResource( 4 )
+
+[connection signal="pointer_entered" from="StaticBody" to="." method="_on_pointer_entered"]
+[connection signal="pointer_exited" from="StaticBody" to="." method="_on_pointer_exited"]
+[connection signal="pointer_moved" from="StaticBody" to="StaticBody" method="_on_pointer_moved"]
+[connection signal="pointer_pressed" from="StaticBody" to="StaticBody" method="_on_pointer_pressed"]
+[connection signal="pointer_released" from="StaticBody" to="StaticBody" method="_on_pointer_released"]

--- a/addons/godot-xr-tools/objects/Viewport_2D_in_3D_body.gd
+++ b/addons/godot-xr-tools/objects/Viewport_2D_in_3D_body.gd
@@ -1,4 +1,4 @@
-extends StaticBody
+extends XRToolsInteractableBody
 
 export var screen_size = Vector2(3.0, 2.0)
 export var viewport_size = Vector2(100.0, 100.0)
@@ -21,13 +21,7 @@ func global_to_viewport(p_at):
 	
 	return Vector2(at.x, at.y)
 
-func pointer_entered():
-	get_parent().emit_signal("pointer_entered")
-
-func pointer_exited():
-	get_parent().emit_signal("pointer_exited")
-
-func pointer_moved(from, to):
+func _on_pointer_moved(from, to):
 	var local_from = global_to_viewport(from)
 	var local_to = global_to_viewport(to)
 	
@@ -41,7 +35,7 @@ func pointer_moved(from, to):
 	if vp:
 		vp.input(event)
 
-func pointer_pressed(at):
+func _on_pointer_pressed(at):
 	var local_at = global_to_viewport(at)
 	
 	# Let's mimic a mouse
@@ -56,7 +50,7 @@ func pointer_pressed(at):
 	if vp:
 		vp.input(event)
 
-func pointer_released(at):
+func _on_pointer_released(at):
 	var local_at = global_to_viewport(at)
 	
 	# Let's mimic a mouse
@@ -70,3 +64,4 @@ func pointer_released(at):
 	
 	if vp:
 		vp.input(event)
+


### PR DESCRIPTION
This is a rather big change that I'm planning to merge in pretty soon for the next release.

The main change here is that I've updated the default physics layer playing most of our player related objects into the last two layers and setting the masks such that things will work off the bat with normal objects being in layer 1 which is Godots default.

This removed a lot of frustration for new users trying to figure out how to properly set up the layer system for the toolset to work. Now it just works out of the box but you're still free to move away from the default layers.

Obviously this will likely break existing games as they will have updated their layers and they may need to clean up a little.

There are also a few minor changes especially in how the function pointer works and how the pickup function works.

Fixes #50