### PR TITLE
Add scrolling to Viewport_2D_in_3D

### DIFF
--- a/addons/godot-xr-tools/functions/Function_pointer.gd
+++ b/addons/godot-xr-tools/functions/Function_pointer.gd
@@ -35,6 +35,7 @@ export var collide_with_areas = false setget set_collide_with_areas
 var target = null
 var last_target = null
 var last_collided_at = Vector3(0, 0, 0)
+var scrolling = null
 
 var ws = 1.0
 
@@ -142,6 +143,7 @@ func _process(delta):
 	
 	if enabled and $RayCast.is_colliding():
 		var new_at = $RayCast.get_collision_point()
+		var top_bottom = get_parent().get_joystick_axis(1)
 		
 		if is_instance_valid(target):
 			# if target is set our mouse must be down, we keep "focus" on our target
@@ -176,6 +178,19 @@ func _process(delta):
 					new_target.emit_signal("pointer_moved", last_collided_at, new_at)
 				elif new_target.has_method("pointer_moved"):
 					new_target.pointer_moved(last_collided_at, new_at)
+
+			if abs(top_bottom) > 0.25:
+				scrolling = true
+				if new_target.has_signal("pointer_started_scroll"):
+					new_target.emit_signal("pointer_started_scroll", last_collided_at, top_bottom)
+				elif new_target.has_method("pointer_started_scroll"):
+					new_target.pointer_started_scroll(last_collided_at, top_bottom)
+			elif (scrolling):
+				scrolling = false
+				if new_target.has_signal("pointer_stopped_scroll"):
+					new_target.emit_signal("pointer_stopped_scroll", last_collided_at)
+				elif new_target.has_method("pointer_stopped_scroll"):
+					new_target.pointer_stopped_scroll(last_collided_at)
 
 		if last_target and show_target:
 			$Target.global_transform.origin = last_collided_at

--- a/addons/godot-xr-tools/objects/Interactable_area.gd
+++ b/addons/godot-xr-tools/objects/Interactable_area.gd
@@ -5,5 +5,7 @@ class_name XRToolsInteractableArea
 signal pointer_pressed(at)
 signal pointer_released(at)
 signal pointer_moved(from, to)
+signal pointer_started_scroll(at, direction)
+signal pointer_stopped_scroll(at)
 signal pointer_entered()
 signal pointer_exited()

--- a/addons/godot-xr-tools/objects/Interactable_body.gd
+++ b/addons/godot-xr-tools/objects/Interactable_body.gd
@@ -5,5 +5,7 @@ class_name XRToolsInteractableBody
 signal pointer_pressed(at)
 signal pointer_released(at)
 signal pointer_moved(from, to)
+signal pointer_started_scroll(at, direction)
+signal pointer_stopped_scroll(at)
 signal pointer_entered()
 signal pointer_exited()

--- a/addons/godot-xr-tools/objects/Viewport_2D_in_3D.tscn
+++ b/addons/godot-xr-tools/objects/Viewport_2D_in_3D.tscn
@@ -49,3 +49,5 @@ shape = SubResource( 4 )
 [connection signal="pointer_moved" from="StaticBody" to="StaticBody" method="_on_pointer_moved"]
 [connection signal="pointer_pressed" from="StaticBody" to="StaticBody" method="_on_pointer_pressed"]
 [connection signal="pointer_released" from="StaticBody" to="StaticBody" method="_on_pointer_released"]
+[connection signal="pointer_started_scroll" from="StaticBody" to="StaticBody" method="_on_pointer_started_scroll"]
+[connection signal="pointer_stopped_scroll" from="StaticBody" to="StaticBody" method="_on_pointer_stopped_scroll"]

--- a/addons/godot-xr-tools/objects/Viewport_2D_in_3D_body.gd
+++ b/addons/godot-xr-tools/objects/Viewport_2D_in_3D_body.gd
@@ -65,3 +65,42 @@ func _on_pointer_released(at):
 	if vp:
 		vp.input(event)
 
+func _on_pointer_started_scroll(at, direction):
+	var local_at = global_to_viewport(at)
+
+	# Let's mimic a mouse
+	mouse_mask = 0
+	var event = InputEventMouseButton.new()
+	event.set_button_index(BUTTON_WHEEL_UP if direction > 0 else BUTTON_WHEEL_DOWN)
+	event.set_pressed(true)
+	event.set_position(local_at)
+	event.set_global_position(local_at)
+	event.set_button_mask(mouse_mask)
+
+	if vp:
+		vp.input(event)
+
+func _on_pointer_stopped_scroll(at):
+	var local_at = global_to_viewport(at)
+
+	# Let's mimic a mouse
+	mouse_mask = 0
+	var event = InputEventMouseButton.new()
+	event.set_button_index(BUTTON_WHEEL_UP)
+	event.set_pressed(false)
+	event.set_position(local_at)
+	event.set_global_position(local_at)
+	event.set_button_mask(mouse_mask)
+
+	if vp:
+		vp.input(event)
+
+	event = InputEventMouseButton.new()
+	event.set_button_index(BUTTON_WHEEL_DOWN)
+	event.set_pressed(false)
+	event.set_position(local_at)
+	event.set_global_position(local_at)
+	event.set_button_mask(mouse_mask)
+
+	if vp:
+		vp.input(event)


### PR DESCRIPTION
I needed a way to scroll a long container with buttons, and thought it might be a nice addition to the tools!

It scrolls when the joystick is up or down (if more than 0.25 in value). If it stops scrolling, it sends a signal, to "unpress" the BUTTON_SCROLL_DOWN and BUTTON_SCROLL_UP. I found if I didn't put that it messed up the rest of the controls afterwards. If there's a better way to implement it, I'd be happy to use that instead!