### PR TITLE
Use distance_squared method in function_pickup comparisons

### DIFF
--- a/addons/godot-xr-tools/functions/Function_Pickup.gd
+++ b/addons/godot-xr-tools/functions/Function_Pickup.gd
@@ -93,12 +93,11 @@ func _update_closest_object():
 		for o in object_in_area:
 			# only check objects that aren't already picked up
 			if o.is_picked_up() == false:
-				var delta_pos = o.global_transform.origin - global_transform.origin
-				var distance = delta_pos.length()
-				if distance < new_closest_distance:
+				var distance_squared = global_transform.origin.distance_squared_to(o.global_transform.origin)
+				if distance_squared < new_closest_distance:
 					new_closest_obj = o
-					new_closest_distance = distance
 	
+					new_closest_distance = distance_squared
 	if closest_object != new_closest_obj:
 		# remove highlight on old object
 		if closest_object:


### PR DESCRIPTION
I noticed that this code for calculating the distance for nearby objects was equivalent to the `distance_to()` method, but that could also be replaced with `distance_squared_to()` since we are only using the distances for comparisons. 

As the [documentation](https://docs.godotengine.org/en/stable/classes/class_vector3.html#class-vector3-method-distance-squared-to) for the `distance_squared_to()` method describes, it's faster than the regular distance method and is preferred for situations like this.