### PR TITLE
Fixed filters of AnimationNodeBlend2 to match the bone names

### DIFF
--- a/addons/godot-xr-tools/assets/LeftHandBlendTree.tres
+++ b/addons/godot-xr-tools/assets/LeftHandBlendTree.tres
@@ -5,7 +5,7 @@ animation = "IndexFinger"
 
 [sub_resource type="AnimationNodeBlend2" id=2]
 filter_enabled = true
-filters = [ "Armature_Left/Skeleton:index._distal", "Armature_Left/Skeleton:index._middle", "Armature_Left/Skeleton:index._proximal" ]
+filters = [ "Armature_Left/Skeleton:index_distal", "Armature_Left/Skeleton:index_middle", "Armature_Left/Skeleton:index_proximal" ]
 
 [sub_resource type="AnimationNodeAnimation" id=3]
 animation = "Grip"

--- a/addons/godot-xr-tools/assets/RightHandBlend.tres
+++ b/addons/godot-xr-tools/assets/RightHandBlend.tres
@@ -5,7 +5,7 @@ animation = "IndexFinger"
 
 [sub_resource type="AnimationNodeBlend2" id=2]
 filter_enabled = true
-filters = [ "Armature_Left/Skeleton:index._distal", "Armature_Left/Skeleton:index._middle", "Armature_Left/Skeleton:index._proximal" ]
+filters = [ "Armature_Left/Skeleton:index_distal", "Armature_Left/Skeleton:index_middle", "Armature_Left/Skeleton:index_proximal" ]
 
 [sub_resource type="AnimationNodeAnimation" id=3]
 animation = "Grip"


### PR DESCRIPTION
Fixed filters of AnimationNodeBlend2 to match the bone names in the GLB files. This change allows the AnimationNodeBlend2 to correctly merge the index-finger animation driven by the analog-trigger input with the grip animation driven by the analog-grip input.

This fixes issue #58 