### PR TITLE
Add configuration setting for head height

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -1,5 +1,5 @@
 # 2.4.0
-- 
+- Added configuration setting for head height in player body.
 
 # 2.3.0
 - Added vignette

--- a/addons/godot-xr-tools/assets/PlayerBody.gd
+++ b/addons/godot-xr-tools/assets/PlayerBody.gd
@@ -26,6 +26,9 @@ export var enabled := true setget set_enabled, get_enabled
 ## Player radius
 export var player_radius := 0.4
 
+## Player head height (distance between between camera and top of head)
+export var player_head_height := 0.1
+
 ## Eyes forward offset from center of body in player_radius units
 export (float, 0.0, 1.0) var eye_forward_offset := 0.66
 
@@ -205,7 +208,7 @@ func move_and_slide(var velocity: Vector3) -> Vector3:
 # This method updates the body to match the player position
 func _update_body_under_camera():
 	# Calculate the player height based on the origin and camera position
-	var player_height := camera_node.transform.origin.y + player_radius
+	var player_height := camera_node.transform.origin.y + player_head_height
 	if player_height < player_radius:
 		player_height = player_radius
 


### PR DESCRIPTION
Make head height a separate setting, this height is now added to the camera y position to obtain the player height. Previously it was adding the player radius which is far to large.