### PR TITLE
Object pickable grab feature without reparenting

### DIFF
--- a/addons/godot-xr-tools/images/teleport_arrow.png.import
+++ b/addons/godot-xr-tools/images/teleport_arrow.png.import
@@ -3,16 +3,17 @@
 importer="texture"
 type="StreamTexture"
 path.s3tc="res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.s3tc.stex"
+path.etc2="res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc2.stex"
 path.etc="res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc" ],
+"imported_formats": [ "s3tc", "etc2", "etc" ],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://addons/godot-xr-tools/images/teleport_arrow.png"
-dest_files=[ "res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.s3tc.stex", "res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc.stex" ]
+dest_files=[ "res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.s3tc.stex", "res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc2.stex", "res://.import/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc.stex" ]
 
 [params]
 
@@ -30,6 +31,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=false

--- a/addons/godot-xr-tools/images/teleport_target.png.import
+++ b/addons/godot-xr-tools/images/teleport_target.png.import
@@ -3,16 +3,17 @@
 importer="texture"
 type="StreamTexture"
 path.s3tc="res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.s3tc.stex"
+path.etc2="res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc2.stex"
 path.etc="res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc" ],
+"imported_formats": [ "s3tc", "etc2", "etc" ],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://addons/godot-xr-tools/images/teleport_target.png"
-dest_files=[ "res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.s3tc.stex", "res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc.stex" ]
+dest_files=[ "res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.s3tc.stex", "res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc2.stex", "res://.import/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc.stex" ]
 
 [params]
 
@@ -30,6 +31,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=false

--- a/addons/godot-xr-tools/objects/Viewport_2D_in_3D.tscn
+++ b/addons/godot-xr-tools/objects/Viewport_2D_in_3D.tscn
@@ -7,14 +7,14 @@
 resource_local_to_scene = true
 size = Vector2( 3, 2 )
 
-[sub_resource type="ViewportTexture" id=2]
+[sub_resource type="ViewportTexture" id=5]
 
 [sub_resource type="SpatialMaterial" id=3]
 resource_local_to_scene = true
 flags_transparent = true
 flags_unshaded = true
 params_cull_mode = 2
-albedo_texture = SubResource( 2 )
+albedo_texture = SubResource( 5 )
 
 [sub_resource type="BoxShape" id=4]
 resource_local_to_scene = true
@@ -36,7 +36,7 @@ mesh = SubResource( 1 )
 material/0 = SubResource( 3 )
 
 [node name="StaticBody" type="StaticBody" parent="."]
-collision_layer = 15
+collision_layer = 1023
 collision_mask = 0
 script = ExtResource( 2 )
 viewport_size = Vector2( 300, 200 )


### PR DESCRIPTION
The current implementation moves the grabbed object with the controller by reparenting it under the controller.

This is inconvenient since it makes objects disappear from the node tree so it is impossible to write simple code that depends on objects staying where they were created.

We can get this the same effect by creating a RemoteTransform node under the controller and pointing it to the object that has been grabbed.  (It's not possible to reuse the same RemoteTransform over and over again since it does not allow the remote_path value to be set to null.)