### PR TITLE
Fix disabling movement providers with active states

### DIFF
--- a/addons/godot-xr-tools/functions/Function_Glide_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Glide_movement.gd
@@ -27,6 +27,11 @@ signal player_glide_start
 ## Signal invoked when the player ends gliding
 signal player_glide_end
 
+
+# Horizontal vector (multiply by this to get only the horizontal components
+const HORIZONTAL := Vector3(1.0, 0.0, 1.0)
+
+
 ## Movement provider order
 export var order := 35
 
@@ -48,34 +53,33 @@ export var horizontal_slew_rate := 1.0
 ## Slew rate to transition to gliding
 export var vertical_slew_rate := 2.0
 
+
 # Node references
-onready var _left_controller_node := ARVRHelpers.get_left_controller(self)
-onready var _right_controller_node := ARVRHelpers.get_right_controller(self)
+onready var _left_controller := ARVRHelpers.get_left_controller(self)
+onready var _right_controller := ARVRHelpers.get_right_controller(self)
 
-# Is the player gliding
-var is_gliding := false
-
-# Horizontal vector (multiply by this to get only the horizontal components
-const horizontal := Vector3(1.0, 0.0, 1.0)
 
 func physics_movement(delta: float, player_body: PlayerBody):
-	# Skip if either controller is off
-	if !_left_controller_node.get_is_active() or !_right_controller_node.get_is_active():
+	# Skip if disabled or either controller is off
+	if !enabled or !_left_controller.get_is_active() or !_right_controller.get_is_active():
+		_set_gliding(false)
 		return
 
 	# If on the ground, or not falling, then not gliding
 	if player_body.on_ground || player_body.velocity.y >= glide_min_fall_speed:
-		_set_is_gliding(false)
+		_set_gliding(false)
 		return
 
-	# Get the controller left ands right global horizontal positions
-	var left_position := _left_controller_node.global_transform.origin * horizontal
-	var right_position := _right_controller_node.global_transform.origin * horizontal
-	var left_to_right := right_position - left_position
+	# Get the controller left and right global horizontal positions
+	var left_position := _left_controller.global_transform.origin
+	var right_position := _right_controller.global_transform.origin
+	var left_to_right := (right_position - left_position) * HORIZONTAL
 
-	# If the hands are too close then not gliding
-	if left_to_right.length() < glide_detect_distance:
-		_set_is_gliding(false)
+	# Set gliding based on hand separation
+	_set_gliding(left_to_right.length() >= glide_detect_distance)
+
+	# Skip if not gliding
+	if !is_active:
 		return
 
 	# Lerp the vertical velocity to glide_fall_speed
@@ -83,7 +87,7 @@ func physics_movement(delta: float, player_body: PlayerBody):
 	vertical_velocity = lerp(vertical_velocity, glide_fall_speed, vertical_slew_rate * delta)
 
 	# Lerp the horizontal velocity towards forward_speed
-	var horizontal_velocity := player_body.velocity * horizontal
+	var horizontal_velocity := player_body.velocity * HORIZONTAL
 	var dir_forward := left_to_right.rotated(Vector3.UP, PI/2).normalized()
 	var forward_velocity := dir_forward * glide_forward_speed
 	horizontal_velocity = lerp(horizontal_velocity, forward_velocity, horizontal_slew_rate * delta)
@@ -95,17 +99,17 @@ func physics_movement(delta: float, player_body: PlayerBody):
 	# Report exclusive motion performed (to bypass gravity)
 	return true
 
-# Set the is_gliding flag and fire any signals
-func _set_is_gliding(gliding: bool):
+# Set the gliding state and fire any signals
+func _set_gliding(active: bool) -> void:
 	# Skip if no change
-	if gliding == is_gliding:
+	if active == is_active:
 		return
 
 	# Update the is_gliding flag
-	is_gliding = gliding;
-	
+	is_active = active;
+
 	# Report transition
-	if is_gliding:
+	if is_active:
 		emit_signal("player_glide_start")
 	else:
 		emit_signal("player_glide_end")

--- a/addons/godot-xr-tools/functions/MovementProvider.gd
+++ b/addons/godot-xr-tools/functions/MovementProvider.gd
@@ -18,6 +18,11 @@ extends Node
 ## Enable movement provider
 export var enabled := true
 
+
+# Is the movement provider actively performing a move
+var is_active := false
+
+
 # Get our player body, this should be a node on our ARVROrigin node.
 func get_player_body() -> PlayerBody:
 	# get our origin node
@@ -36,7 +41,7 @@ func get_player_body() -> PlayerBody:
 
 	return null
 
-# If missing we need to add our player body 
+# If missing we need to add our player body
 func _create_player_body_node():
 	# get our origin node
 	var arvr_origin := ARVRHelpers.get_arvr_origin(self)
@@ -55,7 +60,8 @@ func _create_player_body_node():
 
 # Function run when node is added to scene
 func _ready():
-	# If we're in the editor, help the user out by creating our player body node automatically when needed.
+	# If we're in the editor, help the user out by creating our player body node
+	# automatically when needed.
 	if Engine.editor_hint:
 		var player_body = get_player_body()
 		if !player_body:
@@ -63,7 +69,7 @@ func _ready():
 			call_deferred("_create_player_body_node")
 
 # Override this function to apply motion to the PlayerBody
-func physics_movement(delta: float, player_body: PlayerBody):
+func physics_movement(_delta: float, _player_body: PlayerBody):
 	pass
 
 # This method verifies the MovementProvider has a valid configuration.


### PR DESCRIPTION
This pull request fixes issue #100 by allowing movement providers to be serviced after disabling to perform any final activities such as updating state and reporting signals.

In addition the modified files have some code cleanups suggested by gdlint (https://pypi.org/project/gdtoolkit/) to bring the modules closer to the official gdscript style-guide such as:
 - Removal of unnecessary white-space at end of lines
 - Order of items in the script 

