### PR TITLE
Made sliding on slope an optional feature

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -3,6 +3,7 @@
 - Added Function_JumpDetect_movement to detect jumping via the players body and/or arms
 - Improved responsiveness of snap-turning
 - Moved flight logic from Function_Direct_movement to Function_Flight_movement
+- Added option to disable player sliding on slopes
 
 # 2.3.0
 - Added vignette

--- a/addons/godot-xr-tools/assets/PlayerBody.gd
+++ b/addons/godot-xr-tools/assets/PlayerBody.gd
@@ -201,7 +201,12 @@ func _physics_process(delta):
 	# If no controller has performed an exclusive-update then apply gravity and
 	# perform any ground-control
 	if !exclusive:
-		velocity.y += gravity * delta
+		if on_ground and ground_physics.stop_on_slope and ground_angle < ground_physics.move_max_slope:
+			# Apply gravity towards slope to prevent sliding
+			velocity += ground_vector * gravity * delta
+		else:
+			# Apply gravity down
+			velocity += Vector3.UP * gravity * delta
 		_apply_velocity_and_control(delta)
 
 	# Apply the player-body movement to the ARVR origin

--- a/addons/godot-xr-tools/overrides/GroundPhysicsSettings.gd
+++ b/addons/godot-xr-tools/overrides/GroundPhysicsSettings.gd
@@ -20,6 +20,9 @@ export var move_drag := 5.0
 ## Movement traction factor
 export var move_traction := 30.0
 
+## Stop sliding on slope
+export var stop_on_slope := true
+
 ## Movement maximum slope
 export (float, 0.0, 85.0) var move_max_slope := 45.0
 


### PR DESCRIPTION
This pull request fixes issue #102 to control whether the player slides on slopes due to gravity. In some areas slope-sliding is desirable (ski ramps) and in others it's not desired (walking ramps). This change adds an option to the GroundPhysicsSettings resource to control whether the player will stop on the slope.
