### PR TITLE
Modified jumping to use ground slope

### DIFF
--- a/addons/godot-xr-tools/assets/PlayerBody.gd
+++ b/addons/godot-xr-tools/assets/PlayerBody.gd
@@ -239,7 +239,7 @@ func request_jump(var skip_jump_velocity := false):
 
 	# Perform the jump
 	if !skip_jump_velocity:
-		velocity.y = jump_velocity * ARVRServer.world_scale
+		velocity += ground_vector * jump_velocity * ARVRServer.world_scale
 
 	# Report the jump
 	emit_signal("player_jumped")

--- a/addons/godot-xr-tools/functions/Function_Flight_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Flight_movement.gd
@@ -140,8 +140,7 @@ func _ready():
 		_controller = _right_controller
 
 
-# Process physics movement for
-func physics_movement(delta: float, player_body: PlayerBody):
+func _process(_delta: float):
 	# Skip if disabled or the controller isn't active
 	if !enabled or !_controller.get_is_active():
 		set_flying(false)
@@ -153,6 +152,9 @@ func physics_movement(delta: float, player_body: PlayerBody):
 	if _flight_button and !old_flight_button:
 		set_flying(!is_active)
 
+
+# Process physics movement for
+func physics_movement(delta: float, player_body: PlayerBody):
 	# Skip if not flying
 	if !is_active:
 		return


### PR DESCRIPTION
This pull request fixes #104 by using the ground surface-normal when applying the jump velocity.

Additionally this contains a minor fix to flight movement where the flight toggling button check is performed _process. This allows flying to be disabled even if a higher-priority exclusive movement (such as climbing) is being performed.