### PR TITLE
Change wind movement so script can be used without scene

### DIFF
--- a/addons/godot-xr-tools/functions/Function_JumpDetect_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_JumpDetect_movement.gd
@@ -38,7 +38,7 @@ export var body_jump_threshold := 2.5
 export var arms_jump_enable := false
 
 ## Arms jump detection threshold (M/S^2)
-export var arms_jump_threshold := 10.0
+export var arms_jump_threshold := 5.0
 
 
 # Sliding Average class

--- a/addons/godot-xr-tools/functions/Function_Wind_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Wind_movement.gd
@@ -2,8 +2,10 @@ tool
 class_name Function_WindMovement
 extends MovementProvider
 
+
 ## Signal invoked when changing active wind areas
 signal wind_area_changed(active_wind_area)
+
 
 ## Movement provider order
 export var order := 25
@@ -11,8 +13,12 @@ export var order := 25
 ## Drag multiplier for the player
 export var drag_multiplier := 1.0
 
+# Set our collision mask
+export (int, LAYERS_3D_PHYSICS) var collision_mask = 524288 setget set_collision_mask
+
+
 # Wind area
-onready var _sense_area: Area = $Area
+var _sense_area: Area
 
 # Array of wind areas the player is in
 var _in_wind_areas := Array()
@@ -20,21 +26,46 @@ var _in_wind_areas := Array()
 # Currently active wind area
 var _active_wind_area: WindArea = null
 
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Skip if running in the editor
 	if Engine.editor_hint:
 		return
-
-	# Reparent the sense area to the camera
+	
+	# Skip if we don't have a camera
 	var camera := ARVRHelpers.get_arvr_camera(self)
-	if camera:
-		self.remove_child(_sense_area)
-		camera.add_child(_sense_area)
+	if !camera:
+		return
+		
+	# Construct the sphere shape
+	var sphere_shape := SphereShape.new()
+	sphere_shape.radius = 0.3
+	
+	# Construct the collision shape
+	var collision_shape := CollisionShape.new()
+	collision_shape.set_name("WindSensorShape")
+	collision_shape.shape = sphere_shape
+
+	# Construct the sense area
+	_sense_area = Area.new()
+	_sense_area.set_name("WindSensorArea")
+	_sense_area.collision_mask = collision_mask
+	_sense_area.add_child(collision_shape)
+
+	# Add the sense area to the camera
+	camera.add_child(_sense_area)
 
 	# Subscribe to area notifications
 	_sense_area.connect("area_entered", self, "_on_area_entered")
 	_sense_area.connect("area_exited", self, "_on_area_exited")
+
+
+func set_collision_mask(new_mask: int) -> void:
+	collision_mask = new_mask
+	if is_inside_tree() and _sense_area:
+		_sense_area.collision_mask = collision_mask
+
 
 func _on_area_entered(area: Area):
 	# Skip if not wind area
@@ -48,6 +79,7 @@ func _on_area_entered(area: Area):
 
 	# Report the wind area change
 	emit_signal("wind_area_changed", _active_wind_area)
+
 
 func _on_area_exited(area: Area):
 	# Erase from the wind area
@@ -66,6 +98,7 @@ func _on_area_exited(area: Area):
 	# Report the wind area change
 	emit_signal("wind_area_changed", _active_wind_area)
 
+
 # Perform jump movement
 func physics_movement(delta: float, player_body: PlayerBody):
 	# Skip if no active wind area
@@ -79,6 +112,7 @@ func physics_movement(delta: float, player_body: PlayerBody):
 	var drag_factor := _active_wind_area.drag * drag_multiplier * delta
 	drag_factor = clamp(drag_factor, 0.0, 1.0)
 	player_body.velocity = lerp(player_body.velocity, wind_velocity, drag_factor)
+
 
 # This method verifies the MovementProvider has a valid configuration.
 func _get_configuration_warning():

--- a/addons/godot-xr-tools/functions/Function_Wind_movement.tscn
+++ b/addons/godot-xr-tools/functions/Function_Wind_movement.tscn
@@ -1,16 +1,6 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/functions/Function_Wind_movement.gd" type="Script" id=1]
 
-[sub_resource type="SphereShape" id=1]
-radius = 0.3
-
 [node name="Function_Wind_movement" type="Node" groups=["movement_providers"]]
 script = ExtResource( 1 )
-
-[node name="Area" type="Area" parent="."]
-collision_layer = 0
-collision_mask = 524288
-
-[node name="CollisionShape" type="CollisionShape" parent="Area"]
-shape = SubResource( 1 )


### PR DESCRIPTION
This pull request is related to #99 and makes the wind movement provider usable from the "Add Child Node" menu without needing the scene added.

It also contains modifications to conform better to the gdscript style guide, and contains a minor tuning-tweak to the JumpDetect default arm-jump threshold based on testing.