### PR TITLE
Added grappling movement provider and fixed disabled/bypassed provider signals

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -6,6 +6,8 @@
 - Added option to disable player sliding on slopes
 - Added support for remote grabbing
 - Moved turning logic from Function_Direct_movement to Function_Turn_movement
+- Fixed movement provider servicing so disabled/bypassed providers can report their finished events
+- Added grappling movement provider
 
 # 2.3.0
 - Added vignette

--- a/addons/godot-xr-tools/assets/PlayerBody.gd
+++ b/addons/godot-xr-tools/assets/PlayerBody.gd
@@ -197,10 +197,9 @@ func _physics_process(delta):
 	ground_control_velocity = Vector2.ZERO
 	var exclusive := false
 	for p in _movement_providers:
-		if p.enabled or p.is_active:
-			if p.physics_movement(delta, self):
+		if p.enabled or p.is_active or !exclusive:
+			if p.physics_movement(delta, self, exclusive):
 				exclusive = true
-				break
 
 	# If no controller has performed an exclusive-update then apply gravity and
 	# perform any ground-control

--- a/addons/godot-xr-tools/functions/Function_Climb_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Climb_movement.gd
@@ -59,9 +59,9 @@ onready var _left_pickup_node: Function_Pickup = get_node(left_pickup)
 onready var _right_pickup_node: Function_Pickup = get_node(right_pickup)
 
 
-func physics_movement(delta: float, player_body: PlayerBody):
-	# Skip if disabled
-	if !enabled:
+func physics_movement(delta: float, player_body: PlayerBody, disabled: bool):
+	# Disable climbing if requested
+	if disabled or !enabled:
 		_set_climbing(false, player_body)
 		return
 

--- a/addons/godot-xr-tools/functions/Function_Direct_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Direct_movement.gd
@@ -34,7 +34,7 @@ onready var _controller : ARVRController = get_parent()
 
 
 # Perform jump movement
-func physics_movement(delta: float, player_body: PlayerBody):
+func physics_movement(delta: float, player_body: PlayerBody, _disabled: bool):
 	# Skip if the controller isn't active
 	if !_controller.get_is_active():
 		return

--- a/addons/godot-xr-tools/functions/Function_Flight_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Flight_movement.gd
@@ -140,9 +140,10 @@ func _ready():
 		_controller = _right_controller
 
 
-func _process(_delta: float):
-	# Skip if disabled or the controller isn't active
-	if !enabled or !_controller.get_is_active():
+# Process physics movement for
+func physics_movement(delta: float, player_body: PlayerBody, disabled: bool):
+	# Disable flying if requested, or if no controller
+	if disabled or !enabled or !_controller.get_is_active():
 		set_flying(false)
 		return
 
@@ -152,9 +153,6 @@ func _process(_delta: float):
 	if _flight_button and !old_flight_button:
 		set_flying(!is_active)
 
-
-# Process physics movement for
-func physics_movement(delta: float, player_body: PlayerBody):
 	# Skip if not flying
 	if !is_active:
 		return

--- a/addons/godot-xr-tools/functions/Function_Glide_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Glide_movement.gd
@@ -59,9 +59,9 @@ onready var _left_controller := ARVRHelpers.get_left_controller(self)
 onready var _right_controller := ARVRHelpers.get_right_controller(self)
 
 
-func physics_movement(delta: float, player_body: PlayerBody):
+func physics_movement(delta: float, player_body: PlayerBody, disabled: bool):
 	# Skip if disabled or either controller is off
-	if !enabled or !_left_controller.get_is_active() or !_right_controller.get_is_active():
+	if disabled or !enabled or !_left_controller.get_is_active() or !_right_controller.get_is_active():
 		_set_gliding(false)
 		return
 

--- a/addons/godot-xr-tools/functions/Function_Grapple_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Grapple_movement.gd
@@ -1,0 +1,227 @@
+tool
+class_name Function_Grapple
+extends MovementProvider
+
+
+##
+## Movement Provider for Grapple Movement
+##
+## @desc:
+##     This script provide simple grapple based movement - "bat hook" style where the player moves 
+##     directly to the grapple location. This script works with the PlayerBody attached to the
+##     players ARVROrigin.
+##
+##     The player may have multiple movement nodes attached to different
+##     controllers to provide different types of movement.
+##
+##     The player can have a grapple node attached to each hand and the movement should not break.
+##
+
+
+## Signal emitted when grapple starts
+signal grapple_started()
+
+## Signal emitted when grapple finishes
+signal grapple_finished()
+
+
+# enum our buttons, should find a way to put this more central
+enum Buttons {
+	VR_BUTTON_BY = 1,
+	VR_GRIP = 2,
+	VR_BUTTON_3 = 3,
+	VR_BUTTON_4 = 4,
+	VR_BUTTON_5 = 5,
+	VR_BUTTON_6 = 6,
+	VR_BUTTON_AX = 7,
+	VR_BUTTON_8 = 8,
+	VR_BUTTON_9 = 9,
+	VR_BUTTON_10 = 10,
+	VR_BUTTON_11 = 11,
+	VR_BUTTON_12 = 12,
+	VR_BUTTON_13 = 13,
+	VR_PAD = 14,
+	VR_TRIGGER = 15
+}
+
+# Grapple state
+enum GrappleState {
+	IDLE,			# Idle
+	FIRED,			# Grapple is fired
+	WINCHING,		# Grapple is winching
+}
+
+
+## Movement provider order
+export var order := 20
+
+## Grapple length - use to adjust maximum distance for possible grapple hooking.
+export var grapple_length := 15.0
+
+## Grapple collision mask
+export (int, LAYERS_3D_PHYSICS) var grapple_collision_mask = 1 setget _set_grapple_collision_mask
+
+## Impulse speed applied to the player on first grapple
+export var impulse_speed := 10.0
+
+## Winch speed applied to the player while the grapple is held
+export var winch_speed := 2.0
+
+##Probably need to add export variables for line size, maybe line material at some point so dev does not need to make children editable to do this
+##For now, right click on grapple node and make children editable to edit these facets.
+export var rope_width := 0.02
+
+## Air friction while grappling
+export var friction := 0.1
+
+## Grapple button (triggers grappling movement).  Be sure this button does not conflict with other functions.
+export (Buttons) var grapple_button_id : int = Buttons.VR_TRIGGER
+
+# Hook related variables
+var hook_point := Vector3(0,0,0)
+
+# Grapple button state
+var _grapple_button := false
+
+# Get line creation nodes
+onready var _line_helper : Spatial = $LineHelper
+onready var _line : CSGCylinder = $LineHelper/Line
+
+# Get Controller node - consider way to universalize this if user wanted to attach this
+# to a gun instead of player's hand.  Could consider variable to select controller instead.
+onready var _controller : ARVRController = get_parent()
+
+# Get Raycast node
+onready var _grapple_raycast : RayCast = $Grapple_RayCast
+
+# Get Grapple Target Node 
+onready var _grapple_target : Spatial = $Grapple_Target
+
+
+# Function run when node is added to scene
+func _ready():
+	# Skip if running in the editor
+	if Engine.editor_hint:
+		return
+
+	# Ensure grapple length is valid
+	var min_hook_length := 1.5 * ARVRServer.world_scale
+	if grapple_length < min_hook_length:
+		grapple_length = min_hook_length
+
+	# Set ray-cast
+	_grapple_raycast.cast_to = Vector3(0, 0, -grapple_length) * ARVRServer.world_scale #Is WS necessary here?
+	_grapple_raycast.collision_mask = grapple_collision_mask
+
+	# Deal with line
+	_line.radius = rope_width
+	_line.hide()
+
+
+# Update grapple display objects
+func _process(_delta: float):
+	# Skip if running in the editor
+	if Engine.editor_hint:
+		return
+
+	# Update grapple line
+	if is_active:
+		var line_length := (hook_point - _controller.global_transform.origin).length()
+		_line_helper.look_at(hook_point, Vector3.UP)
+		_line.height = line_length
+		_line.translation.z = line_length / -2
+		_line.visible = true
+	else:
+		_line.visible = false
+
+	# Update grapple target
+	if !is_active and _grapple_raycast.is_colliding():
+		_grapple_target.global_transform.origin  = _grapple_raycast.get_collision_point()
+		_grapple_target.global_transform = _grapple_target.global_transform.orthonormalized()
+		_grapple_target.visible = true
+	else:
+		_grapple_target.visible = false
+
+
+# Perform grapple movement
+func physics_movement(delta: float, player_body: PlayerBody, disabled: bool):
+	# Disable if requested
+	if disabled or !enabled or !_controller.get_is_active():
+		_set_grappling(false)
+		return
+
+	# Update grapple button
+	var old_grapple_button := _grapple_button
+	_grapple_button = _controller.is_button_pressed(grapple_button_id)
+
+	# Enable/disable grappling
+	var do_impulse := false
+	if is_active and !_grapple_button:
+		_set_grappling(false)
+	elif _grapple_button and !old_grapple_button and _grapple_raycast.is_colliding():
+		hook_point = _grapple_raycast.get_collision_point()
+		do_impulse = true
+		_set_grappling(true)
+
+	# Skip if not grappling
+	if !is_active:
+		return
+
+	# Get hook direction
+	var hook_vector := hook_point - _controller.global_transform.origin
+	var hook_length := hook_vector.length()
+	var hook_direction := hook_vector / hook_length
+
+	# Apply gravity 
+	player_body.velocity += Vector3.UP * player_body.gravity * delta
+
+	# Select the grapple speed
+	var speed := impulse_speed if do_impulse else winch_speed
+	if hook_length < 1.0:
+		speed = 0.0
+
+	# Ensure velocity is at least winch_speed towards hook
+	var vdot = player_body.velocity.dot(hook_direction)
+	if vdot < speed:
+		player_body.velocity += hook_direction * (speed - vdot)
+
+	# Scale down velocity
+	player_body.velocity *= 1.0 - friction * delta
+
+	# Perform exclusive movement as we have dealt with gravity
+	player_body.velocity = player_body.move_and_slide(player_body.velocity)
+	return true
+
+
+# Called when the grapple collision mask has been modified
+func _set_grapple_collision_mask(var new_value: int) -> void:
+	grapple_collision_mask = new_value
+	if is_inside_tree() and _grapple_raycast:
+		_grapple_raycast.collision_mask = new_value
+
+
+# Set the grappling state and fire any signals
+func _set_grappling(var active: bool) -> void:
+	# Skip if no change
+	if active == is_active:
+		return
+
+	# Update the is_active flag
+	is_active = active;
+
+	# Report transition
+	if is_active:
+		emit_signal("grapple_started")
+	else:
+		emit_signal("grapple_finished")
+
+
+# This method verifies the MovementProvider has a valid configuration.
+func _get_configuration_warning():
+	# Check the controller node
+	var test_controller = get_parent()
+	if !test_controller or !test_controller is ARVRController:
+		return "Unable to find ARVR Controller node"
+
+	# Call base class
+	return ._get_configuration_warning()

--- a/addons/godot-xr-tools/functions/Function_Grapple_movement.tscn
+++ b/addons/godot-xr-tools/functions/Function_Grapple_movement.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/functions/Function_Grapple_movement.gd" type="Script" id=1]
+[ext_resource path="res://addons/godot-xr-tools/materials/pointer.tres" type="Material" id=2]
+
+[sub_resource type="CubeMesh" id=1]
+resource_local_to_scene = true
+size = Vector3( 0.05, 0.05, 0.05 )
+subdivide_depth = 20
+
+[node name="Function_Grapple_movement" type="Spatial" groups=["movement_providers"]]
+script = ExtResource( 1 )
+
+[node name="Grapple_RayCast" type="RayCast" parent="."]
+enabled = true
+cast_to = Vector3( 0, 0, -15 )
+collision_mask = 3
+debug_shape_custom_color = Color( 0.862745, 0.278431, 0.278431, 1 )
+debug_shape_thickness = 1
+
+[node name="Grapple_Target" type="MeshInstance" parent="."]
+visible = false
+mesh = SubResource( 1 )
+material/0 = ExtResource( 2 )
+
+[node name="LineHelper" type="Spatial" parent="."]
+
+[node name="Line" type="CSGCylinder" parent="LineHelper"]
+transform = Transform( 1.91069e-15, 4.37114e-08, 1, 1, -4.37114e-08, 0, 4.37114e-08, 1, -4.37114e-08, 0, 0, 0 )
+radius = 0.02

--- a/addons/godot-xr-tools/functions/Function_JumpDetect_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_JumpDetect_movement.gd
@@ -94,7 +94,7 @@ onready var _controller_right_node := ARVRHelpers.get_right_controller(self)
 
 
 # Perform jump detection
-func physics_movement(delta: float, player_body: PlayerBody):
+func physics_movement(delta: float, player_body: PlayerBody, _disabled: bool):
 	# Handle detecting body jump
 	if body_jump_enable:
 		_detect_body_jump(delta, player_body)

--- a/addons/godot-xr-tools/functions/Function_Jump_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Jump_movement.gd
@@ -44,7 +44,7 @@ export (Buttons) var jump_button_id = Buttons.VR_TRIGGER
 onready var _controller: ARVRController = get_parent()
 
 # Perform jump movement
-func physics_movement(delta: float, player_body: PlayerBody):
+func physics_movement(delta: float, player_body: PlayerBody, _disabled: bool):
 	# Skip if the jump controller isn't active
 	if !_controller.get_is_active():
 		return

--- a/addons/godot-xr-tools/functions/Function_Turn_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Turn_movement.gd
@@ -40,7 +40,7 @@ onready var _controller : ARVRController = get_parent()
 
 
 # Perform jump movement
-func physics_movement(delta: float, player_body: PlayerBody):
+func physics_movement(delta: float, player_body: PlayerBody, _disabled: bool):
 	# Skip if the controller isn't active
 	if !_controller.get_is_active():
 		return

--- a/addons/godot-xr-tools/functions/Function_Wind_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Wind_movement.gd
@@ -100,7 +100,7 @@ func _on_area_exited(area: Area):
 
 
 # Perform jump movement
-func physics_movement(delta: float, player_body: PlayerBody):
+func physics_movement(delta: float, player_body: PlayerBody, _disabled: bool):
 	# Skip if no active wind area
 	if !_active_wind_area:
 		return

--- a/addons/godot-xr-tools/functions/MovementProvider.gd
+++ b/addons/godot-xr-tools/functions/MovementProvider.gd
@@ -69,7 +69,7 @@ func _ready():
 			call_deferred("_create_player_body_node")
 
 # Override this function to apply motion to the PlayerBody
-func physics_movement(_delta: float, _player_body: PlayerBody):
+func physics_movement(_delta: float, _player_body: PlayerBody, _disabled: bool):
 	pass
 
 # This method verifies the MovementProvider has a valid configuration.


### PR DESCRIPTION
This pull request implements feature request #122 by adding the grappling movement provider based on code from teddybear082.

Additionally this pull request contains a fix to how movement providers are serviced. The change allows an active movement provider to detect:
* When they have been disabled while active
* When they have been preempted by a higher-priority movement provider that has taken exclusive control of movement

In these circumstances the movement provider is able to deactivate itself sending any finished signals - for example to disable movement sound effects. This was found when firing the grappling hook while gliding and the gliding sound continued to play even though grappling motion had taken over.
