### PR TITLE
Increase pickup grab maximum grab distance

### DIFF
--- a/addons/godot-xr-tools/functions/Function_Pickup.gd
+++ b/addons/godot-xr-tools/functions/Function_Pickup.gd
@@ -29,7 +29,7 @@ enum Buttons {
 }
 
 # Constant for worst-case grab distance
-const MAX_GRAB_DISTANCE2: float = 1000.0
+const MAX_GRAB_DISTANCE2: float = 1000000.0
 
 
 ## Grip controller button


### PR DESCRIPTION
Increase MAX_GRAB_DISTANCE2 to 1000^2 to allow for large objects such as sky-scrapers. This fixes issue #131.