### PR TITLE
Added Snap-zone fix for instant drop_and_free()

### DIFF
--- a/addons/godot-xr-tools/assets/PlayerBody.gd
+++ b/addons/godot-xr-tools/assets/PlayerBody.gd
@@ -277,7 +277,7 @@ func _update_body_under_camera():
 # This method updates the information about the ground under the players feet
 func _update_ground_information():
 	# Update the ground information
-	var ground_collision := kinematic_node.move_and_collide(Vector3(0.0, -0.05, 0.0), true, true, true)
+	var ground_collision := kinematic_node.move_and_collide(Vector3(0.0, -0.1, 0.0), true, true, true)
 	if !ground_collision:
 		on_ground = false
 		ground_vector = Vector3.UP

--- a/addons/godot-xr-tools/functions/Function_Pickup.gd
+++ b/addons/godot-xr-tools/functions/Function_Pickup.gd
@@ -137,7 +137,7 @@ func _process(delta):
 		return
 
 	# Calculate average velocity
-	if picked_up_object and picked_up_object.is_picked_up():
+	if is_instance_valid(picked_up_object) and picked_up_object.is_picked_up():
 		# Average velocity of picked up object
 		_velocity_averager.add_transform(delta, picked_up_object.global_transform)
 	else:
@@ -324,9 +324,18 @@ func _pick_up_object(target: Spatial) -> void:
 	if not is_instance_valid(target):
 		return
 
-	# pick up our target
+	# Handle snap-zone
+	var snap := target as XRTSnapZone
+	if snap:
+		target = snap.picked_up_object
+		snap.drop_object()
+
+	# Pick up our target. Note, target may do instant drop_and_free
 	picked_up_ranged = not _object_in_grab_area.has(target)
-	picked_up_object = target.pick_up(self, _controller)
+	picked_up_object = target
+	target.pick_up(self, _controller)
+
+	# If object picked up then emit signal
 	if is_instance_valid(picked_up_object):
 		emit_signal("has_picked_up", picked_up_object)
 

--- a/addons/godot-xr-tools/objects/Object_climbable.gd
+++ b/addons/godot-xr-tools/objects/Object_climbable.gd
@@ -35,9 +35,8 @@ func decrease_is_closest():
 	pass
 
 # Called by Function_pickup when this is picked up by a controller
-func pick_up(by: Spatial, with_controller: ARVRController) -> Spatial:
+func pick_up(by: Spatial, with_controller: ARVRController) -> void:
 	save_grab_location(by)
-	return self
 
 # Called by Function_pickup when this is let go by a controller
 func let_go(p_linear_velocity: Vector3, p_angular_velocity: Vector3) -> void:

--- a/addons/godot-xr-tools/objects/Object_pickable.gd
+++ b/addons/godot-xr-tools/objects/Object_pickable.gd
@@ -170,10 +170,10 @@ func drop_and_free():
 
 
 # Called when this object is picked up
-func pick_up(by: Spatial, with_controller: ARVRController) -> Spatial:
+func pick_up(by: Spatial, with_controller: ARVRController) -> void:
 	# Skip if not idle
 	if _state != PickableState.IDLE:
-		return null
+		return
 
 	if picked_up_by:
 		let_go(Vector3.ZERO, Vector3.ZERO)
@@ -199,8 +199,6 @@ func pick_up(by: Spatial, with_controller: ARVRController) -> Spatial:
 		_do_snap_grab()
 	else:
 		_do_precise_grab()
-
-	return self
 
 
 # Called when this object is dropped

--- a/addons/godot-xr-tools/objects/Snap_Zone.gd
+++ b/addons/godot-xr-tools/objects/Snap_Zone.gd
@@ -107,21 +107,8 @@ func decrease_is_closest():
 
 
 # Pickable Method: Object being grabbed from this snap zone
-func pick_up(by: Spatial, with_controller: ARVRController) -> Spatial:
-	# Ignore if no object in snap-zone
-	if not is_instance_valid(picked_up_object):
-		return null
-
-	# Detach the object from snap-zone
-	var target = picked_up_object
-	picked_up_object = null
-	target.let_go(Vector3.ZERO, Vector3.ZERO)
-
-	# Show snap-zone highlight when empty
-	emit_signal("highlight_updated", self, true)
-
-	# Have the target be picked up by the object
-	return target.pick_up(by, with_controller)
+func pick_up(by: Spatial, with_controller: ARVRController) -> void:
+	pass
 
 
 # Pickable Method: Player never graps snap-zone
@@ -135,9 +122,10 @@ func drop_object() -> void:
 		return
 
 	# let go of this object
-	picked_up_object.let_go()
+	picked_up_object.let_go(Vector3.ZERO, Vector3.ZERO)
 	picked_up_object = null
 	emit_signal("has_dropped")
+	emit_signal("highlight_updated", self, true)
 
 
 func _on_Snap_Zone_body_entered(target: Spatial) -> void:
@@ -191,8 +179,11 @@ func _pick_up_object(target: Spatial) -> void:
 	if not is_instance_valid(target):
 		return
 
-	# pick up our target
-	picked_up_object = target.pick_up(self, null)
+	# Pick up our target. Note, target may do instant drop_and_free
+	picked_up_object = target
+	target.pick_up(self, null)
+
+	# If object picked up then emit signal
 	if is_instance_valid(picked_up_object):
 		emit_signal("has_picked_up", picked_up_object)
 		emit_signal("highlight_updated", self, false)


### PR DESCRIPTION
This change fixes bug #137 by:
 * Reverting the pick_up() method to the original API
 * Explicitly handling Snap Zone pickups in Function_Pickup
 
Additionally this pull-request includes a minor fix for Godot 3.5 where the move_and_collide of 0.05 meters down when on the ground doesn't reliably detect the ground when on slopes. This seems to be releated to change https://github.com/godotengine/godot/pull/59439/commits/65b3200a163388088cce9f373fd986b515cff341 and just increasing the ground-test distance to 0.1 meters is enough to fix it.