### PR TITLE
Fixed enable/disable rules for movement providers

### DIFF
--- a/addons/godot-xr-tools/assets/PlayerBody.gd
+++ b/addons/godot-xr-tools/assets/PlayerBody.gd
@@ -197,7 +197,7 @@ func _physics_process(delta):
 	ground_control_velocity = Vector2.ZERO
 	var exclusive := false
 	for p in _movement_providers:
-		if p.enabled or p.is_active or !exclusive:
+		if p.is_active or (p.enabled and not exclusive):
 			if p.physics_movement(delta, self, exclusive):
 				exclusive = true
 


### PR DESCRIPTION
This fixes issue #139 where movement providers were inappropriately invoked. Now the movement provider is invoked if either of the following is true:
 * The movement provider is 'active'. An active movement provider is always invoked, even if it's to let the provider deactivate and send finished events.
 * The movement provider is 'enabled' and no higher priority movement provider has pre-empted control with an exclusive movement.