### PR TITLE
Added player height control to support mounting climbed objects and crouching

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -1,3 +1,8 @@
+# 2.5.0
+- Added advanced player height control
+- Modified climbing to collapse player to a sphere to allow mounting climbed objects
+- Added crouch movement provider
+
 # 2.4.1
 - Fixed grab distance
 - Fixed snap-zone instance drop and free issue

--- a/addons/godot-xr-tools/functions/Function_Climb_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Climb_movement.gd
@@ -122,11 +122,13 @@ func _set_climbing(active: bool, player_body: PlayerBody) -> void:
 	if is_active:
 		_distances.clear()
 		_deltas.clear()
+		player_body.override_player_height(self, 0.0)
 		emit_signal("player_climb_start")
 	else:
 		var velocity := _average_velocity()
 		var dir_forward = -(player_body.camera_node.global_transform.basis.z * HORIZONTAL).normalized()
 		player_body.velocity = (velocity * fling_multiplier) + (dir_forward * forward_push)
+		player_body.override_player_height(self)
 		emit_signal("player_climb_end")
 
 

--- a/addons/godot-xr-tools/functions/Function_Crouch_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Crouch_movement.gd
@@ -1,0 +1,81 @@
+tool
+class_name Function_CrouchMovement
+extends MovementProvider
+
+##
+## Movement Provider for Crouching
+##
+## @desc:
+##     This script works with the PlayerBody attached to the players ARVROrigin.
+##
+##     When the player presses the selected button, the height is overridden
+##     to the crouch height
+##
+
+
+# enum our buttons, should find a way to put this more central
+enum Buttons {
+	VR_BUTTON_BY = 1,
+	VR_GRIP = 2,
+	VR_BUTTON_3 = 3,
+	VR_BUTTON_4 = 4,
+	VR_BUTTON_5 = 5,
+	VR_BUTTON_6 = 6,
+	VR_BUTTON_AX = 7,
+	VR_BUTTON_8 = 8,
+	VR_BUTTON_9 = 9,
+	VR_BUTTON_10 = 10,
+	VR_BUTTON_11 = 11,
+	VR_BUTTON_12 = 12,
+	VR_BUTTON_13 = 13,
+	VR_PAD = 14,
+	VR_TRIGGER = 15
+}
+
+
+## Movement provider order
+export var order := 10
+
+## Crouch height
+export var crouch_height := 1.0
+
+## Crouch button
+export (Buttons) var crouch_button: int = Buttons.VR_PAD
+
+
+## Crouching flag
+var _crouching := false
+
+
+# Controller node
+onready var _controller : ARVRController = get_parent()
+
+
+# Perform jump movement
+func physics_movement(delta: float, player_body: PlayerBody, _disabled: bool):
+	# Skip if the controller isn't active
+	if !_controller.get_is_active():
+		return
+
+	# Check for crouching change
+	var crouching := _controller.is_button_pressed(crouch_button) != 0
+	if crouching == _crouching:
+		return
+	
+	# Update crouching state
+	_crouching = crouching
+	if crouching:
+		player_body.override_player_height(self, crouch_height)
+	else:
+		player_body.override_player_height(self)
+
+
+# This method verifies the MovementProvider has a valid configuration.
+func _get_configuration_warning():
+	# Check the controller node
+	var test_controller = get_parent()
+	if !test_controller or !test_controller is ARVRController:
+		return "Unable to find ARVR Controller node"
+
+	# Call base class
+	return ._get_configuration_warning()

--- a/addons/godot-xr-tools/functions/Function_Crouch_movement.tscn
+++ b/addons/godot-xr-tools/functions/Function_Crouch_movement.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/functions/Function_Crouch_movement.gd" type="Script" id=1]
+
+[node name="Function_Crouch_movement" type="Node" groups=["movement_providers"]]
+script = ExtResource( 1 )


### PR DESCRIPTION
This pull request implements feature requests #143 and #116 with the help of @teddybear082. The changes include:
 - Added advanced player height control
 - Modified climbing to collapse player to a sphere to allow mounting climbed objects
 - Added crouch movement provider

The PlayerBody now supports:
 - Player height offset to allow future height calibration (for seated or disabled players)
 - Minimum and maximum allowed player height (as measured by head position)
 - Overriding player height by movement providers (for crouching or climb-mounting)

The math for placing the player body under the camera had to be modified extensively - the original logic would *always* put the player body on the ARVROrigin floor, whereas the new logic puts the player body under/around the head. This change results in the head/camera always being in the correct position in relationship to the body.
