### PR TITLE
Added moving platform support to the player body

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -3,6 +3,7 @@
 - Modified climbing to collapse player to a sphere to allow mounting climbed objects
 - Added crouch movement provider
 - Added example fall damage detection
+- Added moving platform support to player body
 
 # 2.4.1
 - Fixed grab distance


### PR DESCRIPTION
This implements feature request #149 by adding moving-platform support to the player body.

The approach is as follows:
 1. The _update_ground_information function calculates the ground-velocity (how fast the ground is moving) by analyzing how the contact-point under the players feet moves between frames - specifically how the point is transformed locally by the ground spatial node.
 2. The _apply_velocity_and_control function works in a ground-relative frame of reference by subtracting the ground-velocity at the start of the function, then adding it back in at the end.

There is one "hack" caused by the fact that the KinematicBody move_and_slide is an "instantaneous" function in that when it performs the move-and-slide, the universe is frozen. As such if the ground is moving down and the player is standing on it moving down at the same speed, the move-and-slide sees the ground as stationary at that instant and instead outputs a player vertical velocity of 0. The code detects a vertical velocity of 0 and instead treats it as the player moving at exactly the ground vertical velocity.

Even with this hack there is still some stuttering if the platform moves vertically. Further research may be warranted to try and stick the players feet to the ground, although crude attempts at doing this broke jumping.