### PR TITLE
Modified hand script to apply world_scale

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -9,6 +9,7 @@
 - Fixed jump detection to work in player-units
 - Added valid-layer checking to teleport movement
 - Modified hand meshes (blend and glb) to be scaled, so the hand scenes can be 1:1 scaled
+- Modified hands to scale with world_scale (required for godot-openxr 1.3.0 and later)
 
 # 2.4.1
 - Fixed grab distance

--- a/addons/godot-xr-tools/assets/Hand.gd
+++ b/addons/godot-xr-tools/assets/Hand.gd
@@ -1,7 +1,43 @@
+class_name XRToolsHand
 extends Spatial
 
+
+##
+## XR Hand Script
+##
+## @desc:
+##     This script manages a godot-xr-tools hand. It animates the hand blending
+##     grip and trigger animations based on controller input.
+##
+##     Additionally the hand script detects world-scale changes in the ARVRServer
+##     and re-scales the hand appropriately so the hand stays scaled to the
+##     physical hand of the user.
+##
+
+
+# Signal emitted when the hand scale changes
+signal hand_scale_changed(scale)
+
+
+# Last world scale (for scaling hands)
+var _last_world_scale := 1.0
+
+
+# Capture the initial transform
+onready var _transform := transform
+
+
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(delta: float) -> void:
+	# Scale the hand mesh with the world scale. This is required for OpenXR plugin
+	# 1.3.0 and later where the plugin no-longer scales the controllers with
+	# world_scale
+	if ARVRServer.world_scale != _last_world_scale:
+		_last_world_scale = ARVRServer.world_scale
+		transform = _transform.scaled(Vector3.ONE * _last_world_scale)
+		emit_signal("hand_scale_changed", _last_world_scale)
+
+	# Animate the hand mesh with the controller inputs
 	var controller : ARVRController = get_parent()
 	if controller:
 		var grip = controller.get_joystick_axis(JOY_VR_ANALOG_GRIP)


### PR DESCRIPTION
This change is to make the hands work with godot-openxr 1.3.0 and later where the ARVRController node scaling has been removed.