### PR TITLE
World-scale fixes for movement providers

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -4,6 +4,9 @@
 - Added crouch movement provider
 - Added example fall damage detection
 - Added moving platform support to player body
+- Fixed player height-clamping to work in player-units
+- Fixed glide T-pose detection to work in player-units
+- Fixed jump detection to work in player-units
 
 # 2.4.1
 - Fixed grab distance

--- a/addons/godot-xr-tools/assets/PlayerBody.gd
+++ b/addons/godot-xr-tools/assets/PlayerBody.gd
@@ -293,8 +293,8 @@ func _update_body_under_camera():
 	# Calculate the player height based on the camera position in the origin and the calibration
 	var player_height := clamp(
 		camera_node.transform.origin.y + player_head_height + player_height_offset,
-		player_height_min,
-		player_height_max)
+		player_height_min * ARVRServer.world_scale,
+		player_height_max * ARVRServer.world_scale)
 
 	# Allow forced overriding of height
 	if _player_height_override >= 0.0:

--- a/addons/godot-xr-tools/functions/Function_Glide_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Glide_movement.gd
@@ -76,7 +76,8 @@ func physics_movement(delta: float, player_body: PlayerBody, disabled: bool):
 	var left_to_right := (right_position - left_position) * HORIZONTAL
 
 	# Set gliding based on hand separation
-	_set_gliding(left_to_right.length() >= glide_detect_distance)
+	var separation := left_to_right.length() / ARVRServer.world_scale
+	_set_gliding(separation >= glide_detect_distance)
 
 	# Skip if not gliding
 	if !is_active:

--- a/addons/godot-xr-tools/functions/Function_JumpDetect_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_JumpDetect_movement.gd
@@ -115,6 +115,9 @@ func _detect_body_jump(delta: float, player_body: PlayerBody) -> void:
 	if abs(camera_vel) < 0.001:
 		return;
 
+	# Correct for ARVR world-scale (convert to player units)
+	camera_vel /= ARVRServer.world_scale
+
 	# Clamp the camera instantaneous velocity to +/- 2x the jump threshold
 	camera_vel = clamp(camera_vel, -2.0 * body_jump_threshold, 2.0 * body_jump_threshold)
 
@@ -144,6 +147,10 @@ func _detect_arms_jump(delta: float, player_body: PlayerBody) -> void:
 	if abs(controller_left_vel) <= 0.001 and abs(controller_right_vel) <= 0.001:
 		return
 
+	# Correct for ARVR world-scale (convert to player units)
+	controller_left_vel /= ARVRServer.world_scale
+	controller_right_vel /= ARVRServer.world_scale
+	
 	# Clamp the controller instantaneous velocity to +/- 2x the jump threshold
 	controller_left_vel = clamp(controller_left_vel, -2.0 * arms_jump_threshold, 2.0 * arms_jump_threshold)
 	controller_right_vel = clamp(controller_right_vel, -2.0 * arms_jump_threshold, 2.0 * arms_jump_threshold)


### PR DESCRIPTION
This pull request fixes the world-scale / player-scale issues in #154. Specifically:
 - Player-height clamping is now done in player-units rather than world-units
 - Glide t-pose detection is now done in player-units rather than world-units
 - Jump-detection is now done in player-units rather than world-units