### PR TITLE
Fixed immediate dropping for RemoteTransform held objects

### DIFF
--- a/addons/godot-xr-tools/objects/Object_pickable.gd
+++ b/addons/godot-xr-tools/objects/Object_pickable.gd
@@ -217,6 +217,7 @@ func let_go(p_linear_velocity: Vector3, p_angular_velocity: Vector3) -> void:
 				global_transform = original_transform
 
 			HoldMethod.REMOTE_TRANSFORM:
+				_remote_transform.remote_path = NodePath()
 				_remote_transform.queue_free()
 				_remote_transform = null
 


### PR DESCRIPTION
This pull request fixes issue #160 by clearing the RemoteTransform.remote_path in the let_go() handler, so transform-driving is immediately disabled even though the RemoteTransform may continue to exist until the end of the current frame.