### PR TITLE
Moved XRToolsPickable remote-pickup processing to separate node

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -11,6 +11,7 @@
 - Modified hand meshes (blend and glb) to be scaled, so the hand scenes can be 1:1 scaled
 - Modified hands to scale with world_scale (required for godot-openxr 1.3.0 and later)
 - Added physics hands with PhysicsBody bones
+- Fixed disabling of _process in XRToolsPickable script
 
 # 2.4.1
 - Fixed grab distance

--- a/addons/godot-xr-tools/misc/Move_To.gd
+++ b/addons/godot-xr-tools/misc/Move_To.gd
@@ -1,0 +1,90 @@
+class_name XRToolsMoveTo
+extends Node
+
+
+##
+## Move To node
+##
+## @desc:
+##     This node moves a control Spatial to the specified target Spatial
+##     at a requested speed.
+## 
+
+
+## Signal invoked when the move finishes
+signal move_complete
+
+
+# Spatial to control
+var _control: Spatial
+
+# Spatial representing the target
+var _target: Spatial
+
+# Starting transform
+var _start: Transform
+
+# Target offset
+var _offset: Transform
+
+# Move duration
+var _duration: float
+
+# Move time
+var _time: float = 0.0
+
+
+## Initialize the XRToolsMoveTo
+func _init():
+	# Disable processing until needed
+	set_process(false)
+
+
+## Process the movement
+func _process(delta: float) -> void:
+	# Calculate the destination
+	var destination := _target.global_transform * _offset
+	
+	# Update the move time
+	_time += delta
+	
+	# Detect end of move
+	if _time > _duration:
+		# Disable processing
+		set_process(false)
+
+		# Move to the target
+		_control.global_transform = destination
+
+		# Report the move as complete
+		emit_signal("move_complete")
+		return
+
+	# Interpolate to the target
+	_control.global_transform = _start.interpolate_with(
+		destination, 
+		_time / _duration)
+
+
+## Start the move
+func start(var control: Spatial, var target: Spatial, var offset: Transform, var speed: float) -> void:
+	# Save the control and target
+	_control = control
+	_target = target
+	_offset = offset
+	
+	# Save the starting transform
+	_start = control.global_transform
+	
+	# Calculate the duration
+	var destination := _target.global_transform * _offset
+	var distance := (destination.origin - _start.origin).length()
+	_duration = distance / speed
+
+	# Start processing
+	set_process(true)
+
+
+## Stop the move
+func stop() -> void:
+	set_process(false)


### PR DESCRIPTION
This pull request fixes bug #163 by moving the remote-pickup logic to a separate helper node. This has two side-effects:
 1. The XRToolsPickable no-longer uses or enables/disables _process
 2. The new XRToolsMoveTo script is a little smarter about moving, and rotates the object into the hand at the same time
