### PR TITLE
Ensure max_speed limit is enforced

### DIFF
--- a/addons/godot-xr-tools/VERSIONS.md
+++ b/addons/godot-xr-tools/VERSIONS.md
@@ -1,3 +1,6 @@
+# 2.6.0
+- Fixed enforcement of direct-movement maximum speed
+
 # 2.5.0
 - Added advanced player height control
 - Modified climbing to collapse player to a sphere to allow mounting climbed objects

--- a/addons/godot-xr-tools/functions/Function_Direct_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Direct_movement.gd
@@ -47,8 +47,9 @@ func physics_movement(delta: float, player_body: PlayerBody, _disabled: bool):
 		player_body.ground_control_velocity.x += _controller.get_joystick_axis(0) * max_speed
 
 	# Clamp ground control
-	player_body.ground_control_velocity.x = clamp(player_body.ground_control_velocity.x, -max_speed, max_speed)
-	player_body.ground_control_velocity.y = clamp(player_body.ground_control_velocity.y, -max_speed, max_speed)
+	var length := player_body.ground_control_velocity.length()
+	if length > max_speed:
+		player_body.ground_control_velocity *= max_speed / length
 
 
 # This method verifies the MovementProvider has a valid configuration.


### PR DESCRIPTION
This pull request fixes issue #165 by clamping the magnitude of the ground_control_velocity vector rather than clamping each axis individually This ensures the vector magnitude never exceeds the max_speed limit.