### PR TITLE
Minimal changes to make code functional with Godot 4.0 beta 1

### DIFF
--- a/addons/godot-xr-tools/assets/HandBlendTree.tres
+++ b/addons/godot-xr-tools/assets/HandBlendTree.tres
@@ -19,15 +19,15 @@ filters = ["Armature_Left/Skeleton3D:Index.Distal", "Armature_Left/Skeleton3D:In
 
 [resource]
 graph_offset = Vector2(232.37, 34.5087)
-nodes/Default/node = SubResource( "3" )
+nodes/Default/node = SubResource("3")
 nodes/Default/position = Vector2(220, 60)
-nodes/Fist/node = SubResource( "1" )
+nodes/Fist/node = SubResource("1")
 nodes/Fist/position = Vector2(240, 200)
-nodes/Fist2/node = SubResource( "4" )
+nodes/Fist2/node = SubResource("4")
 nodes/Fist2/position = Vector2(460, 320)
-nodes/Grip/node = SubResource( "5" )
+nodes/Grip/node = SubResource("5")
 nodes/Grip/position = Vector2(780, 180)
-nodes/Trigger/node = SubResource( "2" )
+nodes/Trigger/node = SubResource("2")
 nodes/Trigger/position = Vector2(560, 80)
 nodes/output/position = Vector2(1020, 80)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"Fist2", &"Trigger", 0, &"Default", &"Trigger", 1, &"Fist"]

--- a/addons/godot-xr-tools/assets/LeftHand.glb.import
+++ b/addons/godot-xr-tools/assets/LeftHand.glb.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/LeftHand.glb-7a289350d7a0389e0068af98c6813b91
 
 nodes/root_type="Node3D"
 nodes/root_name="Scene Root"
+nodes/apply_root_scale=true
 nodes/root_scale=1.0
 meshes/ensure_tangents=true
 meshes/generate_lods=true

--- a/addons/godot-xr-tools/assets/PlayerBody.gd
+++ b/addons/godot-xr-tools/assets/PlayerBody.gd
@@ -289,7 +289,7 @@ func _update_ground_information():
 	else:
 		on_ground = true
 		ground_vector = ground_collision.get_normal()
-		ground_angle = rad2deg(ground_collision.get_angle())
+		ground_angle = rad_to_deg(ground_collision.get_angle())
 		ground_node = ground_collision.get_collider()
 
 		# Select the ground physics

--- a/addons/godot-xr-tools/effects/vignette.gd
+++ b/addons/godot-xr-tools/effects/vignette.gd
@@ -1,4 +1,4 @@
-@tool
+#@tool
 extends Node3D
 
 @export var radius = 1.0:
@@ -31,7 +31,7 @@ extends Node3D
 @export var auto_rotation_limit = 20.0:
 	set(new_value):
 		auto_rotation_limit = new_value
-		auto_rotation_limit_rad = deg2rad(auto_rotation_limit)
+		auto_rotation_limit_rad = deg_to_rad(auto_rotation_limit)
 
 @export var auto_velocity_limit = 10.0
 
@@ -42,19 +42,19 @@ var fade_delay = 0.0
 var origin_node = null
 var last_origin_basis : Basis
 var last_location : Vector3
-@onready var auto_rotation_limit_rad = deg2rad(auto_rotation_limit)
+@onready var auto_rotation_limit_rad = deg_to_rad(auto_rotation_limit)
 
 func _update_radius():
 	if radius < 1.0:
 		if material:
-			material.set_shader_param("radius", radius * sqrt(2))
+			material.set_shader_parameter("radius", radius * sqrt(2))
 		$Mesh.visible = true
 	else:
 		$Mesh.visible = false
 
 func _update_fade():
 	if material:
-		material.set_shader_param("fade", fade)
+		material.set_shader_parameter("fade", fade)
 
 func _update_mesh():
 	var vertices : PackedVector3Array
@@ -63,7 +63,7 @@ func _update_mesh():
 	vertices.resize(2 * steps)
 	indices.resize(6 * steps)
 	for i in steps:
-		var v : Vector3 = Vector3.RIGHT.rotated(Vector3.FORWARD, deg2rad((360.0 * i) / steps))
+		var v : Vector3 = Vector3.RIGHT.rotated(Vector3.FORWARD, deg_to_rad((360.0 * i) / steps))
 		vertices[i] = v
 		vertices[steps+i] = v * 2.0
 

--- a/addons/godot-xr-tools/effects/vignette.gdshader
+++ b/addons/godot-xr-tools/effects/vignette.gdshader
@@ -1,7 +1,7 @@
 shader_type spatial;
 render_mode depth_test_disabled, skip_vertex_transform, unshaded;
 
-uniform vec4 color : hint_color = vec4(0.0, 0.0, 0.0, 1.0);
+uniform vec4 color : source_color = vec4(0.0, 0.0, 0.0, 1.0);
 uniform float radius = 1.0;
 uniform float fade = 0.05;
 

--- a/addons/godot-xr-tools/functions/Function_Direct_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Direct_movement.gd
@@ -105,7 +105,7 @@ func _perform_player_rotation(delta: float, player_body: PlayerBody):
 
 	# Turn one step in the requested direction
 	_turn_step = step_turn_delay
-	_rotate_player(player_body, deg2rad(step_turn_angle) * sign(left_right))
+	_rotate_player(player_body, deg_to_rad(step_turn_angle) * sign(left_right))
 
 
 # Rotate the origin node around the camera

--- a/addons/godot-xr-tools/functions/Function_Flight_movement.gd
+++ b/addons/godot-xr-tools/functions/Function_Flight_movement.gd
@@ -122,6 +122,10 @@ func _ready():
 
 
 func _process(_delta: float):
+	# Do not run physics if in the editor
+	if Engine.is_editor_hint():
+		return
+
 	# Skip if disabled or the controller isn't active
 	if !enabled or !_controller.get_is_active():
 		set_flying(false)

--- a/addons/godot-xr-tools/functions/Function_Teleport.gd
+++ b/addons/godot-xr-tools/functions/Function_Teleport.gd
@@ -178,7 +178,7 @@ func _physics_process(delta):
 		var cast_length = 0.0
 		var fine_tune = 1.0
 		var hit_something = false
-		var max_slope_cos = cos(deg2rad(max_slope))
+		var max_slope_cos = cos(deg_to_rad(max_slope))
 		for i in range(1,26):
 			var new_cast_length = cast_length + (step_size / fine_tune)
 			var global_target = Vector3(0.0, 0.0, -new_cast_length)
@@ -244,9 +244,9 @@ func _physics_process(delta):
 				break
 		
 		# and just update our shader
-		$Teleport.get_surface_override_material(0).set_shader_param("scale_t", 1.0 / strength)
-		$Teleport.get_surface_override_material(0).set_shader_param("ws", ws)
-		$Teleport.get_surface_override_material(0).set_shader_param("length", cast_length)
+		$Teleport.get_surface_override_material(0).set_shader_parameter("scale_t", 1.0 / strength)
+		$Teleport.get_surface_override_material(0).set_shader_parameter("ws", ws)
+		$Teleport.get_surface_override_material(0).set_shader_parameter("length", cast_length)
 		if hit_something:
 			var color = can_teleport_color
 			var normal = Vector3.UP
@@ -273,13 +273,13 @@ func _physics_process(delta):
 			last_target_transform.origin = target_global_origin + Vector3(0.0, 0.001, 0.0)
 			$Target.global_transform = last_target_transform
 			
-			$Teleport.get_surface_override_material(0).set_shader_param("mix_color", color)
+			$Teleport.get_surface_override_material(0).set_shader_parameter("mix_color", color)
 			$Target.get_surface_override_material(0).albedo_color = color
 			$Target.visible = can_teleport
 		else:
 			can_teleport = false
 			$Target.visible = false
-			$Teleport.get_surface_override_material(0).set_shader_param("mix_color", no_collision_color)
+			$Teleport.get_surface_override_material(0).set_shader_parameter("mix_color", no_collision_color)
 	elif is_teleporting:
 		if can_teleport:
 			

--- a/addons/godot-xr-tools/functions/Function_pointer.gd
+++ b/addons/godot-xr-tools/functions/Function_pointer.gd
@@ -43,7 +43,7 @@ func _update_y_offset():
 func _update_distance():
 	$Laser.mesh.size.z = distance
 	$Laser.position.z = distance * -0.5
-	$RayCast.cast_to.z = -distance
+	$RayCast.target_position.z = -distance
 
 @export_flags_3d_physics  var collision_mask = 15:
 	set(new_value):

--- a/addons/godot-xr-tools/functions/Function_pointer.tscn
+++ b/addons/godot-xr-tools/functions/Function_pointer.tscn
@@ -15,7 +15,7 @@ radial_segments = 16
 rings = 8
 
 [node name="Function_pointer" type="Node3D"]
-script = ExtResource( "2" )
+script = ExtResource("2")
 collision_mask = 524287
 
 [node name="RayCast" type="RayCast3D" parent="."]
@@ -25,10 +25,10 @@ collision_mask = 524287
 [node name="Laser" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, -5)
 cast_shadow = 0
-mesh = SubResource( "1" )
-surface_material_override/0 = ExtResource( "1" )
+mesh = SubResource("1")
+surface_material_override/0 = ExtResource("1")
 
 [node name="Target" type="MeshInstance3D" parent="."]
 visible = false
-mesh = SubResource( "2" )
-surface_material_override/0 = ExtResource( "1" )
+mesh = SubResource("2")
+surface_material_override/0 = ExtResource("1")

--- a/addons/godot-xr-tools/images/icon.png.import
+++ b/addons/godot-xr-tools/images/icon.png.import
@@ -1,9 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture2D"
+type="CompressedTexture2D"
 uid="uid://bcll0cv3rie0i"
-path="res://.godot/imported/icon.png-1d8efcc4c33e64800e22ea3150ef148d.stex"
+path="res://.godot/imported/icon.png-1d8efcc4c33e64800e22ea3150ef148d.ctex"
 metadata={
 "vram_texture": false
 }
@@ -11,7 +11,7 @@ metadata={
 [deps]
 
 source_file="res://addons/godot-xr-tools/images/icon.png"
-dest_files=["res://.godot/imported/icon.png-1d8efcc4c33e64800e22ea3150ef148d.stex"]
+dest_files=["res://.godot/imported/icon.png-1d8efcc4c33e64800e22ea3150ef148d.ctex"]
 
 [params]
 
@@ -21,7 +21,6 @@ compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
-compress/streamed=false
 mipmaps/generate=false
 mipmaps/limit=-1
 roughness/mode=0
@@ -30,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/addons/godot-xr-tools/images/teleport_arrow.png.import
+++ b/addons/godot-xr-tools/images/teleport_arrow.png.import
@@ -1,10 +1,10 @@
 [remap]
 
 importer="texture"
-type="StreamTexture2D"
+type="CompressedTexture2D"
 uid="uid://ddoj6c345cb0c"
-path.s3tc="res://.godot/imported/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.s3tc.stex"
-path.etc2="res://.godot/imported/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc2.stex"
+path.s3tc="res://.godot/imported/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.s3tc.ctex"
+path.etc2="res://.godot/imported/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc2.ctex"
 metadata={
 "imported_formats": ["s3tc", "etc2"],
 "vram_texture": true
@@ -13,7 +13,7 @@ metadata={
 [deps]
 
 source_file="res://addons/godot-xr-tools/images/teleport_arrow.png"
-dest_files=["res://.godot/imported/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.s3tc.stex", "res://.godot/imported/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc2.stex"]
+dest_files=["res://.godot/imported/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.s3tc.ctex", "res://.godot/imported/teleport_arrow.png-f1bd44b6f478277692b3fa29171b62d3.etc2.ctex"]
 
 [params]
 
@@ -23,7 +23,6 @@ compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
-compress/streamed=false
 mipmaps/generate=true
 mipmaps/limit=-1
 roughness/mode=0
@@ -32,5 +31,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=0

--- a/addons/godot-xr-tools/images/teleport_target.png.import
+++ b/addons/godot-xr-tools/images/teleport_target.png.import
@@ -1,10 +1,10 @@
 [remap]
 
 importer="texture"
-type="StreamTexture2D"
+type="CompressedTexture2D"
 uid="uid://cu4j1s8qr1rjq"
-path.s3tc="res://.godot/imported/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.s3tc.stex"
-path.etc2="res://.godot/imported/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc2.stex"
+path.s3tc="res://.godot/imported/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.s3tc.ctex"
+path.etc2="res://.godot/imported/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc2.ctex"
 metadata={
 "imported_formats": ["s3tc", "etc2"],
 "vram_texture": true
@@ -13,7 +13,7 @@ metadata={
 [deps]
 
 source_file="res://addons/godot-xr-tools/images/teleport_target.png"
-dest_files=["res://.godot/imported/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.s3tc.stex", "res://.godot/imported/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc2.stex"]
+dest_files=["res://.godot/imported/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.s3tc.ctex", "res://.godot/imported/teleport_target.png-cd812f7d5692711ac91f6c8a4753ad73.etc2.ctex"]
 
 [params]
 
@@ -23,7 +23,6 @@ compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
-compress/streamed=false
 mipmaps/generate=true
 mipmaps/limit=-1
 roughness/mode=0
@@ -32,5 +31,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=0

--- a/addons/godot-xr-tools/materials/highlight.tres
+++ b/addons/godot-xr-tools/materials/highlight.tres
@@ -1,30 +1,29 @@
 [gd_resource type="ShaderMaterial" load_steps=7 format=3 uid="uid://dyuaw57o8y3i"]
 
-[sub_resource type="VisualShaderNodeColorUniform" id="1"]
-uniform_name = "Color"
+[sub_resource type="VisualShaderNodeColorParameter" id="VisualShaderNodeColorParameter_nl6jr"]
+parameter_name = "Color"
 
-[sub_resource type="VisualShaderNodeVectorOp" id="2"]
+[sub_resource type="VisualShaderNodeVectorOp" id="VisualShaderNodeVectorOp_8dcmn"]
 default_input_values = [0, Vector3(0, 0, 0), 1, Vector3(0.5, 0.5, 0.5)]
 operator = 2
 
-[sub_resource type="VisualShaderNodeFloatConstant" id="3"]
+[sub_resource type="VisualShaderNodeFloatConstant" id="VisualShaderNodeFloatConstant_2331j"]
 constant = 0.1
 
-[sub_resource type="VisualShaderNodeFresnel" id="4"]
+[sub_resource type="VisualShaderNodeFresnel" id="VisualShaderNodeFresnel_tghd5"]
 
-[sub_resource type="VisualShaderNodeVectorOp" id="5"]
+[sub_resource type="VisualShaderNodeVectorOp" id="VisualShaderNodeVectorOp_wy3ip"]
 operator = 2
 
-[sub_resource type="VisualShader" id="6"]
+[sub_resource type="VisualShader" id="VisualShader_wb0u4"]
 code = "shader_type spatial;
-uniform vec4 Color : hint_color;
+uniform vec4 Color : source_color;
 
 
 
 void fragment() {
-// ColorUniform:2
-	vec3 n_out2p0 = Color.rgb;
-	float n_out2p1 = Color.a;
+// ColorParameter:2
+	vec4 n_out2p0 = Color;
 
 
 // FloatConstant:4
@@ -32,7 +31,7 @@ void fragment() {
 
 
 // VectorOp:3
-	vec3 n_out3p0 = n_out2p0 * vec3(n_out4p0);
+	vec3 n_out3p0 = vec3(n_out2p0.xyz) * vec3(n_out4p0);
 
 
 // Fresnel:5
@@ -41,7 +40,7 @@ void fragment() {
 
 
 // VectorOp:6
-	vec3 n_out6p0 = n_out2p0 * vec3(n_out5p0);
+	vec3 n_out6p0 = vec3(n_out2p0.xyz) * vec3(n_out5p0);
 
 
 // Output:0
@@ -52,19 +51,19 @@ void fragment() {
 }
 "
 nodes/fragment/0/position = Vector2(660, 60)
-nodes/fragment/2/node = SubResource( "1" )
+nodes/fragment/2/node = SubResource("VisualShaderNodeColorParameter_nl6jr")
 nodes/fragment/2/position = Vector2(40, 40)
-nodes/fragment/3/node = SubResource( "2" )
+nodes/fragment/3/node = SubResource("VisualShaderNodeVectorOp_8dcmn")
 nodes/fragment/3/position = Vector2(360, 60)
-nodes/fragment/4/node = SubResource( "3" )
+nodes/fragment/4/node = SubResource("VisualShaderNodeFloatConstant_2331j")
 nodes/fragment/4/position = Vector2(20, 180)
-nodes/fragment/5/node = SubResource( "4" )
+nodes/fragment/5/node = SubResource("VisualShaderNodeFresnel_tghd5")
 nodes/fragment/5/position = Vector2(40, 340)
-nodes/fragment/6/node = SubResource( "5" )
+nodes/fragment/6/node = SubResource("VisualShaderNodeVectorOp_wy3ip")
 nodes/fragment/6/position = Vector2(360, 220)
 nodes/fragment/connections = PackedInt32Array(2, 0, 3, 0, 3, 0, 0, 0, 4, 0, 3, 1, 2, 0, 6, 0, 5, 0, 6, 1, 6, 0, 0, 5)
 
 [resource]
 render_priority = 0
-shader = SubResource( "6" )
-shader_param/Color = Color(0.301961, 0.392157, 0.988235, 1)
+shader = SubResource("VisualShader_wb0u4")
+shader_parameter/Color = Color(0.301961, 0.392157, 0.988235, 1)

--- a/addons/godot-xr-tools/materials/teleport.gdshader
+++ b/addons/godot-xr-tools/materials/teleport.gdshader
@@ -4,8 +4,8 @@ render_mode unshaded, cull_disabled, skip_vertex_transform;
 uniform float scale_t = 0.2;
 uniform float length = 20.0;
 uniform float ws = 1.0;
-uniform vec4 mix_color : hint_color;
-uniform sampler2D arrow_texture : hint_albedo;
+uniform vec4 mix_color : source_color;
+uniform sampler2D arrow_texture : source_color;
 
 void vertex() {
 	vec3 down = vec3(0.0, -1.0 / ws, 0.0);

--- a/addons/godot-xr-tools/misc/XR_Helpers.gd
+++ b/addons/godot-xr-tools/misc/XR_Helpers.gd
@@ -65,14 +65,14 @@ static func get_xr_camera(node: Node, path: NodePath = NodePath()) -> XRCamera3D
 
 ## Find the Left Hand Controller from a player node and an optional path
 static func get_left_controller(node: Node, path: NodePath = NodePath()) -> XRController3D:
-	return _get_controller(node, "LeftHandController", 1, path)
+	return _get_controller(node, "LeftHandController", "left_hand", path)
 
 ## Find the Right Hand Controller from a player node and an optional path
 static func get_right_controller(node: Node, path: NodePath = NodePath()) -> XRController3D:
-	return _get_controller(node, "RightHandController", 2, path)
+	return _get_controller(node, "RightHandController", "right_hand", path)
 
 ## Find a controller given some search parameters
-static func _get_controller(node: Node, default_name: String, id: int, path: NodePath) -> XRController3D:
+static func _get_controller(node: Node, default_name: String, tracker: String, path: NodePath) -> XRController3D:
 	var controller: XRController3D
 	
 	# Try using the node path first
@@ -94,7 +94,7 @@ static func _get_controller(node: Node, default_name: String, id: int, path: Nod
 	# Search all children of the origin for the controller
 	for child in origin.get_children():
 		controller = child as XRController3D
-		if controller and controller.controller_id == id:
+		if controller and controller.tracker == tracker:
 			return controller
 
 	# Could not find the controller

--- a/addons/godot-xr-tools/objects/Object_pickable.gd
+++ b/addons/godot-xr-tools/objects/Object_pickable.gd
@@ -1,5 +1,5 @@
 @tool
-extends RigidDynamicBody3D
+extends RigidBody3D
 class_name XRToolsPickable
 
 # Set hold mode


### PR DESCRIPTION
This pull request makes the older godot-xr-tools (based on 2.x) work with Godot 4.0 beta 1. The following has been tested:
 * Hands
 * Player body
 * Direct movement
 * Teleport movement
 * Flying
 * Gliding
 * Jumping
 * Pickup
 * Pickable Objects
 * Climbing
 * Climbable Objects

The Vignette has had to have its tool-script disabled to prevent locking up Godot 4 on startup.