### PR TITLE
Fix quantization of teleport title image

### DIFF
--- a/assets/meshes/teleport/teleport_title_material.tres
+++ b/assets/meshes/teleport/teleport_title_material.tres
@@ -1,4 +1,4 @@
-[gd_resource type="ShaderMaterial" load_steps=8 format=2]
+[gd_resource type="ShaderMaterial" load_steps=9 format=2]
 
 [sub_resource type="VisualShaderNodeTextureUniform" id=5]
 uniform_name = "Title"
@@ -21,6 +21,10 @@ output_port_for_preview = 0
 default_input_values = [ 0, Vector3( 0, 0, 0 ), 1, Vector3( 2, 1, 0 ) ]
 operator = 2
 
+[sub_resource type="VisualShaderNodeScalarOp" id=12]
+default_input_values = [ 0, 0.0, 1, 5.0 ]
+operator = 4
+
 [sub_resource type="VisualShader" id=6]
 code = "shader_type spatial;
 render_mode specular_schlick_ggx, unshaded;
@@ -38,9 +42,13 @@ void fragment() {
 // Input:4
 	float n_out4p0 = TIME;
 
+// ScalarOp:8
+	float n_in8p1 = 5.00000;
+	float n_out8p0 = mod(n_out4p0, n_in8p1);
+
 // VectorOp:5
 	vec3 n_in5p1 = vec3(0.20000, 0.00000, 0.00000);
-	vec3 n_out5p0 = vec3(n_out4p0) * n_in5p1;
+	vec3 n_out5p0 = vec3(n_out8p0) * n_in5p1;
 
 // Input:3
 	vec3 n_out3p0 = vec3(UV, 0.0);
@@ -71,7 +79,7 @@ void light() {
 
 }
 "
-graph_offset = Vector2( 75.5651, 149 )
+graph_offset = Vector2( -921.082, 269.413 )
 flags/unshaded = true
 nodes/fragment/0/position = Vector2( 798, 252 )
 nodes/fragment/2/node = SubResource( 5 )
@@ -79,14 +87,16 @@ nodes/fragment/2/position = Vector2( 378, 315 )
 nodes/fragment/3/node = SubResource( 7 )
 nodes/fragment/3/position = Vector2( -378, 567 )
 nodes/fragment/4/node = SubResource( 8 )
-nodes/fragment/4/position = Vector2( -378, 315 )
+nodes/fragment/4/position = Vector2( -640, 320 )
 nodes/fragment/5/node = SubResource( 9 )
 nodes/fragment/5/position = Vector2( -189, 294 )
 nodes/fragment/6/node = SubResource( 10 )
 nodes/fragment/6/position = Vector2( 84, 378 )
 nodes/fragment/7/node = SubResource( 11 )
 nodes/fragment/7/position = Vector2( -189, 546 )
-nodes/fragment/connections = PoolIntArray( 4, 0, 5, 0, 5, 0, 6, 0, 6, 0, 2, 0, 3, 0, 7, 0, 7, 0, 6, 1, 2, 0, 0, 0 )
+nodes/fragment/8/node = SubResource( 12 )
+nodes/fragment/8/position = Vector2( -400, 300 )
+nodes/fragment/connections = PoolIntArray( 5, 0, 6, 0, 6, 0, 2, 0, 3, 0, 7, 0, 7, 0, 6, 1, 2, 0, 0, 0, 8, 0, 5, 0, 4, 0, 8, 0 )
 
 [resource]
 resource_local_to_scene = true


### PR DESCRIPTION
This pull request fixes issue #208 which appears to occur due to the TIME in the shader getting numerically large (up to 3600.0) resulting in loss of precision in the texture UV coordinates.

This change introduces the Remainder (modulo) operation immediately after the TIME input block so the time remains in the interval [0..5)
![image](https://user-images.githubusercontent.com/1863707/195927996-97e85ba8-9d49-49bc-acaf-6b77d04b0a6d.png)
