### PR TITLE
Changed XRToolsMovementTurn to XRToolsFunctionTurn

### DIFF
--- a/addons/godot-xr-tools/functions/function_turn.gd
+++ b/addons/godot-xr-tools/functions/function_turn.gd
@@ -1,22 +1,18 @@
 tool
-class_name XRToolsMovementTurn
-extends XRToolsMovementProvider
+class_name XRToolsFunctionTurn, "res://addons/godot-xr-tools/editor/icons/function.svg"
+extends Node
 
 ##
 ## Movement Provider for Turning
 ##
 ## @desc:
-##     This script provides turning support for the player. This script works
-##     with the PlayerBody attached to the players ARVROrigin.
+##     This script provides turning support for the player.
 ##
 ##     The following types of turning are supported:
 ##      - Snap turning
 ##      - Smooth turning
 ##
 
-
-## Movement provider order
-export var order : int = 5
 
 ## Use smooth rotation (may cause motion sickness)
 export var smooth_rotation : bool = false
@@ -38,11 +34,17 @@ var _turn_step : float = 0.0
 # Controller node
 onready var _controller : ARVRController = get_parent()
 
+# Origin node
+onready var _origin : ARVROrigin = ARVRHelpers.get_arvr_origin(self)
+
+# Camea node
+onready var _camera : ARVRCamera = ARVRHelpers.get_arvr_camera(self)
+
 
 # Perform jump movement
-func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
-	# Skip if the controller isn't active
-	if !_controller.get_is_active():
+func _process(delta: float):
+	# Skip processing in editor or if the controller isn't active
+	if Engine.editor_hint or !_controller.get_is_active():
 		return
 
 	# Read the left/right joystick axis
@@ -54,7 +56,7 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: b
 
 	# Handle smooth rotation
 	if smooth_rotation:
-		_rotate_player(player_body, smooth_turn_speed * delta * left_right)
+		_rotate_player(smooth_turn_speed * delta * left_right)
 		return
 
 	# Update the next turn-step delay
@@ -64,27 +66,37 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: b
 
 	# Turn one step in the requested direction
 	_turn_step = step_turn_delay
-	_rotate_player(player_body, deg2rad(step_turn_angle) * sign(left_right))
+	_rotate_player(deg2rad(step_turn_angle) * sign(left_right))
 
 
 # Rotate the origin node around the camera
-func _rotate_player(player_body: XRToolsPlayerBody, angle: float):
+func _rotate_player(angle: float):
 	var t1 := Transform()
 	var t2 := Transform()
 	var rot := Transform()
 
-	t1.origin = -player_body.camera_node.transform.origin
-	t2.origin = player_body.camera_node.transform.origin
+	t1.origin = -_camera.transform.origin
+	t2.origin = _camera.transform.origin
 	rot = rot.rotated(Vector3(0.0, -1.0, 0.0), angle)
-	player_body.origin_node.transform = (player_body.origin_node.transform * t2 * rot * t1).orthonormalized()
+	_origin.transform = (_origin.transform * t2 * rot * t1).orthonormalized()
 
 
 # This method verifies the movement provider has a valid configuration.
-func _get_configuration_warning():
+func _get_configuration_warnings():
 	# Check the controller node
 	var test_controller = get_parent()
 	if !test_controller or !test_controller is ARVRController:
 		return "Unable to find ARVR Controller node"
 
+	# Check the origin node
+	var test_origin = ARVRHelpers.get_arvr_origin(self)
+	if !test_origin:
+		return "Unable to find ARVR Origin node"
+
+	# Check the camera node
+	var test_camera = ARVRHelpers.get_arvr_camera(self)
+	if !test_camera:
+		return "Unable to find ARVR Camera node"
+
 	# Call base class
-	return ._get_configuration_warning()
+	return ._get_configuration_warnings()

--- a/addons/godot-xr-tools/functions/function_turn.tscn
+++ b/addons/godot-xr-tools/functions/function_turn.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/functions/function_turn.gd" type="Script" id=1]
+
+[node name="FunctionTurn" type="Node"]
+script = ExtResource( 1 )

--- a/addons/godot-xr-tools/functions/movement_turn.tscn
+++ b/addons/godot-xr-tools/functions/movement_turn.tscn
@@ -1,6 +1,0 @@
-[gd_scene load_steps=2 format=2]
-
-[ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.gd" type="Script" id=1]
-
-[node name="MovementTurn" type="Node" groups=["movement_providers"]]
-script = ExtResource( 1 )

--- a/project.godot
+++ b/project.godot
@@ -50,6 +50,11 @@ _global_script_classes=[ {
 "path": "res://addons/godot-xr-tools/functions/function_teleport.gd"
 }, {
 "base": "Node",
+"class": "XRToolsFunctionTurn",
+"language": "GDScript",
+"path": "res://addons/godot-xr-tools/functions/function_turn.gd"
+}, {
+"base": "Node",
 "class": "XRToolsGroundPhysics",
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/overrides/ground_physics.gd"
@@ -180,11 +185,6 @@ _global_script_classes=[ {
 "path": "res://addons/godot-xr-tools/functions/movement_provider.gd"
 }, {
 "base": "XRToolsMovementProvider",
-"class": "XRToolsMovementTurn",
-"language": "GDScript",
-"path": "res://addons/godot-xr-tools/functions/movement_turn.gd"
-}, {
-"base": "XRToolsMovementProvider",
 "class": "XRToolsMovementWind",
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/functions/movement_wind.gd"
@@ -238,6 +238,7 @@ _global_script_class_icons={
 "XRToolsFunctionPickup": "res://addons/godot-xr-tools/editor/icons/function.svg",
 "XRToolsFunctionPointer": "res://addons/godot-xr-tools/editor/icons/function.svg",
 "XRToolsFunctionTeleport": "res://addons/godot-xr-tools/editor/icons/function.svg",
+"XRToolsFunctionTurn": "res://addons/godot-xr-tools/editor/icons/function.svg",
 "XRToolsGroundPhysics": "",
 "XRToolsGroundPhysicsSettings": "",
 "XRToolsHand": "res://addons/godot-xr-tools/editor/icons/hand.svg",
@@ -264,7 +265,6 @@ _global_script_class_icons={
 "XRToolsMovementJump": "",
 "XRToolsMovementPhysicalJump": "",
 "XRToolsMovementProvider": "res://addons/godot-xr-tools/editor/icons/movement_provider.svg",
-"XRToolsMovementTurn": "",
 "XRToolsMovementWind": "",
 "XRToolsPhysicsHand": "",
 "XRToolsPickable": "",

--- a/scenes/basic_movement_demo/basic_movement_demo.tscn
+++ b/scenes/basic_movement_demo/basic_movement_demo.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://scenes/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/assets/right_hand.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/assets/left_hand.tscn" type="PackedScene" id=3]
-[ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.tscn" type="PackedScene" id=4]
+[ext_resource path="res://addons/godot-xr-tools/functions/function_turn.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_direct.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/godot-xr-tools/assets/player_body.tscn" type="PackedScene" id=6]
 [ext_resource path="res://assets/maps/basic_map.tscn" type="PackedScene" id=7]
@@ -39,7 +39,7 @@ order = 10
 max_speed = 3.0
 strafe = false
 
-[node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 4 )]
+[node name="FunctionTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 4 )]
 smooth_rotation = true
 
 [node name="MovementJump" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 10 )]

--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://scenes/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/assets/left_hand.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/assets/right_hand.tscn" type="PackedScene" id=3]
-[ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.tscn" type="PackedScene" id=4]
+[ext_resource path="res://addons/godot-xr-tools/functions/function_turn.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_direct.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/godot-xr-tools/assets/player_body.tscn" type="PackedScene" id=6]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_glide.tscn" type="PackedScene" id=7]
@@ -58,7 +58,7 @@ order = 10
 max_speed = 3.0
 strafe = false
 
-[node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 4 )]
+[node name="FunctionTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 4 )]
 smooth_rotation = true
 
 [node name="FunctionPickup" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 9 )]

--- a/scenes/grappling_demo/grappling_demo.tscn
+++ b/scenes/grappling_demo/grappling_demo.tscn
@@ -6,7 +6,7 @@
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_climb.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_jump.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/godot-xr-tools/assets/left_hand.tscn" type="PackedScene" id=6]
-[ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.tscn" type="PackedScene" id=7]
+[ext_resource path="res://addons/godot-xr-tools/functions/function_turn.tscn" type="PackedScene" id=7]
 [ext_resource path="res://addons/godot-xr-tools/functions/function_pickup.tscn" type="PackedScene" id=8]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_glide.tscn" type="PackedScene" id=9]
 [ext_resource path="res://addons/godot-xr-tools/assets/right_hand.tscn" type="PackedScene" id=10]
@@ -50,7 +50,7 @@ order = 10
 max_speed = 3.0
 strafe = false
 
-[node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 7 )]
+[node name="FunctionTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 7 )]
 smooth_rotation = true
 
 [node name="MovementJump" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 5 )]

--- a/scenes/interactables_demo/interactables_demo.tscn
+++ b/scenes/interactables_demo/interactables_demo.tscn
@@ -9,7 +9,7 @@
 [ext_resource path="res://addons/godot-xr-tools/functions/function_pickup.tscn" type="PackedScene" id=7]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_direct.tscn" type="PackedScene" id=8]
 [ext_resource path="res://addons/godot-xr-tools/assets/player_body.tscn" type="PackedScene" id=9]
-[ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.tscn" type="PackedScene" id=10]
+[ext_resource path="res://addons/godot-xr-tools/functions/function_turn.tscn" type="PackedScene" id=10]
 [ext_resource path="res://addons/godot-xr-tools/assets/left_physics_hand.tscn" type="PackedScene" id=11]
 [ext_resource path="res://assets/meshes/interactables/slider_smooth.tscn" type="PackedScene" id=12]
 [ext_resource path="res://assets/meshes/interactables/slider_zero.tscn" type="PackedScene" id=13]
@@ -28,6 +28,8 @@
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
 
 [node name="MovementDirect" parent="ARVROrigin/LeftHand" index="1" instance=ExtResource( 8 )]
+enabled = true
+order = 10
 max_speed = 3.0
 strafe = true
 
@@ -40,9 +42,12 @@ ranged_collision_mask = 0
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
 
 [node name="MovementDirect" parent="ARVROrigin/RightHand" index="1" instance=ExtResource( 8 )]
+enabled = true
+order = 10
 max_speed = 3.0
+strafe = false
 
-[node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 10 )]
+[node name="FunctionTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 10 )]
 smooth_rotation = true
 
 [node name="FunctionPickup" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 7 )]

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://addons/godot-xr-tools/assets/right_hand.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/assets/left_hand.tscn" type="PackedScene" id=3]
 [ext_resource path="res://assets/maps/basic_map.tscn" type="PackedScene" id=4]
-[ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/functions/function_turn.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_direct.tscn" type="PackedScene" id=6]
 [ext_resource path="res://scenes/basic_movement_demo/basic_movement_demo.tscn" type="PackedScene" id=7]
 [ext_resource path="res://addons/godot-xr-tools/assets/player_body.tscn" type="PackedScene" id=8]
@@ -29,6 +29,8 @@
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
 
 [node name="MovementDirect" parent="ARVROrigin/LeftHand" index="1" instance=ExtResource( 6 )]
+enabled = true
+order = 10
 max_speed = 3.0
 strafe = true
 
@@ -36,9 +38,12 @@ strafe = true
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
 
 [node name="MovementDirect" parent="ARVROrigin/RightHand" index="1" instance=ExtResource( 6 )]
+enabled = true
+order = 10
 max_speed = 3.0
+strafe = false
 
-[node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 5 )]
+[node name="FunctionTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 5 )]
 smooth_rotation = true
 
 [node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 8 )]

--- a/scenes/pickable_demo/pickable_demo.tscn
+++ b/scenes/pickable_demo/pickable_demo.tscn
@@ -9,7 +9,7 @@
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_direct.tscn" type="PackedScene" id=7]
 [ext_resource path="res://addons/godot-xr-tools/functions/function_pickup.tscn" type="PackedScene" id=8]
 [ext_resource path="res://addons/godot-xr-tools/assets/player_body.tscn" type="PackedScene" id=9]
-[ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.tscn" type="PackedScene" id=10]
+[ext_resource path="res://addons/godot-xr-tools/functions/function_turn.tscn" type="PackedScene" id=10]
 [ext_resource path="res://scenes/pickable_demo/objects/snap_toy_red.tscn" type="PackedScene" id=11]
 [ext_resource path="res://scenes/pickable_demo/objects/snap_toy_yellow.tscn" type="PackedScene" id=12]
 [ext_resource path="res://scenes/pickable_demo/objects/grab_ball.tscn" type="PackedScene" id=13]
@@ -44,7 +44,7 @@ order = 10
 max_speed = 3.0
 strafe = false
 
-[node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 10 )]
+[node name="FunctionTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 10 )]
 smooth_rotation = true
 
 [node name="FunctionPickup" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 8 )]

--- a/scenes/pointer_demo/pointer_demo.tscn
+++ b/scenes/pointer_demo/pointer_demo.tscn
@@ -8,7 +8,7 @@
 [ext_resource path="res://addons/godot-xr-tools/assets/left_hand.tscn" type="PackedScene" id=6]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_direct.tscn" type="PackedScene" id=7]
 [ext_resource path="res://addons/godot-xr-tools/assets/player_body.tscn" type="PackedScene" id=8]
-[ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.tscn" type="PackedScene" id=9]
+[ext_resource path="res://addons/godot-xr-tools/functions/function_turn.tscn" type="PackedScene" id=9]
 [ext_resource path="res://addons/godot-xr-tools/assets/right_hand.tscn" type="PackedScene" id=10]
 [ext_resource path="res://addons/godot-xr-tools/objects/virtual_keyboard.tscn" type="PackedScene" id=11]
 [ext_resource path="res://scenes/pointer_demo/objects/display.tscn" type="PackedScene" id=12]
@@ -34,7 +34,7 @@ order = 10
 max_speed = 3.0
 strafe = false
 
-[node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 9 )]
+[node name="FunctionTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 9 )]
 smooth_rotation = true
 
 [node name="FunctionPointer" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 5 )]

--- a/scenes/teleport_demo/teleport_demo.tscn
+++ b/scenes/teleport_demo/teleport_demo.tscn
@@ -3,26 +3,31 @@
 [ext_resource path="res://scenes/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/functions/function_teleport.tscn" type="PackedScene" id=2]
 [ext_resource path="res://scenes/main_menu/return to main menu.png" type="Texture" id=3]
-[ext_resource path="res://addons/godot-xr-tools/assets/player_body.tscn" type="PackedScene" id=4]
-[ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/functions/function_turn.tscn" type="PackedScene" id=5]
 [ext_resource path="res://assets/meshes/teleport/teleport.tscn" type="PackedScene" id=6]
 [ext_resource path="res://assets/maps/basic_map.tscn" type="PackedScene" id=7]
 [ext_resource path="res://assets/meshes/ramps/ramps.tscn" type="PackedScene" id=8]
 [ext_resource path="res://assets/meshes/mound/mound.tscn" type="PackedScene" id=9]
+
+[sub_resource type="SphereShape" id=4]
+radius = 0.2
 
 [sub_resource type="ViewportTexture" id=3]
 viewport_path = NodePath("Instructions/Viewport")
 
 [node name="TeleportDemo" instance=ExtResource( 1 )]
 
+[node name="PlayerBodyTrigger" type="StaticBody" parent="ARVROrigin/ARVRCamera" index="0" groups=["player_body"]]
+collision_layer = 524288
+collision_mask = 0
+
+[node name="CollisionShape" type="CollisionShape" parent="ARVROrigin/ARVRCamera/PlayerBodyTrigger" index="0"]
+shape = SubResource( 4 )
+
 [node name="FunctionTeleport" parent="ARVROrigin/LeftHand" index="0" instance=ExtResource( 2 )]
 camera = NodePath("../../ARVRCamera")
 
-[node name="MovementTurn" parent="ARVROrigin/LeftHand" index="1" instance=ExtResource( 5 )]
-
-[node name="MovementTurn" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 5 )]
-
-[node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 4 )]
+[node name="FunctionTurn" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 5 )]
 
 [node name="BasicMap" parent="." index="1" instance=ExtResource( 7 )]
 


### PR DESCRIPTION
This pull request implements #212 by changing the XRToolsMovementTurn to XRToolsFunctionTurn.

The Teleport demo removes the XRToolsPlayerBody from the player rig, so the player no-longer slides down slopes causing minor VR motion sickness.