### PR TITLE
Fixed snap zone demo for Godot 4

### DIFF
--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -188,5 +188,5 @@ func _pick_up_object(target: Node3D) -> void:
 # Called when the grab distance has been modified
 func _set_grab_distance(new_value: float) -> void:
 	grab_distance = new_value
-	if is_inside_tree() and $CollisionShape:
-		$CollisionShape.shape.radius = grab_distance
+	if is_inside_tree() and $CollisionShape3D:
+		$CollisionShape3D.shape.radius = grab_distance

--- a/addons/godot-xr-tools/objects/snap_zone.tscn
+++ b/addons/godot-xr-tools/objects/snap_zone.tscn
@@ -1,14 +1,15 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://ce7vysyvondf8"]
 
-[ext_resource path="res://addons/godot-xr-tools/objects/snap_zone.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://addons/godot-xr-tools/objects/snap_zone.gd" id="1"]
 
-[sub_resource type="SphereShape3D" id=1]
+[sub_resource type="SphereShape3D" id="1"]
+radius = 0.05
 
 [node name="SnapZone" type="Area3D"]
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-shape = SubResource( 1 )
+shape = SubResource("1")
 
 [connection signal="body_entered" from="." to="." method="_on_snap_zone_body_entered"]
 [connection signal="body_exited" from="." to="." method="_on_snap_zone_body_exited"]

--- a/scenes/pickable_demo/objects/snap_toy_red.tscn
+++ b/scenes/pickable_demo/objects/snap_toy_red.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=6 format=3 uid="uid://cf024hg5alcif"]
 
-[ext_resource type="PackedScene" path="res://addons/godot-xr-tools/objects/pickable.tscn" id="1"]
+[ext_resource type="PackedScene" uid="uid://c8l60rnugru40" path="res://addons/godot-xr-tools/objects/pickable.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://da2qgxxwwitl6" path="res://addons/godot-xr-tools/objects/highlight/highlight_ring.tscn" id="2"]
 
 [sub_resource type="ConvexPolygonShape3D" id="17"]
@@ -21,6 +21,7 @@ albedo_color = Color(1, 0, 0, 1)
 collision_layer = 4
 collision_mask = 65543
 reset_transform_on_pickup = false
+picked_up_layer = 65536
 ranged_grab_method = 0
 
 [node name="CollisionShape3D" parent="." index="1"]

--- a/scenes/pickable_demo/objects/snap_toy_yellow.tscn
+++ b/scenes/pickable_demo/objects/snap_toy_yellow.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=6 format=3 uid="uid://cboxrvj4xdi6f"]
 
-[ext_resource type="PackedScene" path="res://addons/godot-xr-tools/objects/pickable.tscn" id="1"]
+[ext_resource type="PackedScene" uid="uid://c8l60rnugru40" path="res://addons/godot-xr-tools/objects/pickable.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://da2qgxxwwitl6" path="res://addons/godot-xr-tools/objects/highlight/highlight_ring.tscn" id="2"]
 
 [sub_resource type="ConvexPolygonShape3D" id="20"]
@@ -21,6 +21,7 @@ albedo_color = Color(1, 1, 0, 1)
 collision_layer = 4
 collision_mask = 65543
 reset_transform_on_pickup = false
+picked_up_layer = 65536
 ranged_grab_method = 0
 
 [node name="CollisionShape3D" parent="." index="1"]

--- a/scenes/pickable_demo/objects/snap_tray.tscn
+++ b/scenes/pickable_demo/objects/snap_tray.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=11 format=3 uid="uid://c6rmke57xw5lg"]
 
-[ext_resource type="PackedScene" path="res://addons/godot-xr-tools/objects/pickable.tscn" id="1"]
+[ext_resource type="PackedScene" uid="uid://c8l60rnugru40" path="res://addons/godot-xr-tools/objects/pickable.tscn" id="1"]
 [ext_resource type="Material" path="res://assets/wahooney.itch.io/blue_grid.tres" id="2"]
 [ext_resource type="PackedScene" uid="uid://da2qgxxwwitl6" path="res://addons/godot-xr-tools/objects/highlight/highlight_ring.tscn" id="3"]
-[ext_resource type="PackedScene" path="res://addons/godot-xr-tools/objects/snap_zone.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://ce7vysyvondf8" path="res://addons/godot-xr-tools/objects/snap_zone.tscn" id="4"]
 
 [sub_resource type="BoxShape3D" id="9"]
 size = Vector3(0.3, 0.4, 0.1)


### PR DESCRIPTION
Fixed snap-zone radius setting - could be turned into a tool script.
Fixed picked-up layer for snap toys so they work with the snap-zone.