### PR TITLE
Incorporate mouse pressure change from 3.0.0

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
@@ -31,6 +31,7 @@ func _on_pointer_moved(from, to):
 	event.set_global_position(local_to)
 	event.set_relative(local_to - local_from) # should this be scaled/warped?
 	event.set_button_mask(mouse_mask)
+	event.set_pressure(mouse_mask)
 	
 	if vp:
 		vp.push_input(event)


### PR DESCRIPTION
This pull request applies the InputEventMouseMotion.pressure change from the 3.x branch onto the 4.x branch