### PR TITLE
Added more laser options to XRToolsFunctionPointer

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,7 @@
 - Improvements to our 2D in 3D viewport
 - Use value based grip input with threshold
 - Improved pointer demo supporting left hand with switching
+- Enhanced pointer laser visibility options for colliding with targets.
 
 # 3.0.0
 - Included demo project with test scenes to evaluate features

--- a/scenes/pointer_demo/pointer_demo.tscn
+++ b/scenes/pointer_demo/pointer_demo.tscn
@@ -30,6 +30,9 @@ strafe = true
 
 [node name="FunctionPointer" parent="ARVROrigin/LeftHand" index="2" instance=ExtResource( 5 )]
 enabled = false
+show_laser = 2
+laser_length = 1
+show_target = true
 
 [node name="RightHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 10 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
@@ -44,6 +47,7 @@ strafe = false
 smooth_rotation = true
 
 [node name="FunctionPointer" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 5 )]
+laser_length = 1
 
 [node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 8 )]
 


### PR DESCRIPTION
This pull request implements feature #217 with the following changes:
 - Added option to only show laser pointer on collision
 - Added option to truncate laser length to collision point

The configuration options are:
![image](https://user-images.githubusercontent.com/1863707/197672381-0c3781a7-fdd0-4254-bf29-af62f4a104bd.png)
 - Show Laser can be one of [Hide / Show / Collide]
 - Laser Length can be one of [Full / Collide]

Truncation to the collision looks as follows:
![image](https://user-images.githubusercontent.com/1863707/197672869-bd220dd4-0d23-414a-bcba-95e3a60fc840.png)
![image](https://user-images.githubusercontent.com/1863707/197673041-1f47d8aa-9e68-4c22-bba6-09f7f3276fc4.png)

