### PR TITLE
Implement grip threshold

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,6 @@
 # 3.1.0 (Development)
 - Improvements to our 2D in 3D viewport
+- Use value based grip input with threshold
 
 # 3.0.0
 - Included demo project with test scenes to evaluate features

--- a/addons/godot-xr-tools/functions/function_pointer.gd
+++ b/addons/godot-xr-tools/functions/function_pointer.gd
@@ -20,27 +20,6 @@ extends Spatial
 ##
 
 
-# enum our buttons, should find a way to put this more central
-enum Buttons {
-	VR_BUTTON_BY = 1,
-	VR_GRIP = 2,
-	VR_BUTTON_3 = 3,
-	VR_BUTTON_4 = 4,
-	VR_BUTTON_5 = 5,
-	VR_BUTTON_6 = 6,
-	VR_BUTTON_AX = 7,
-	VR_BUTTON_8 = 8,
-	VR_BUTTON_9 = 9,
-	VR_BUTTON_10 = 10,
-	VR_BUTTON_11 = 11,
-	VR_BUTTON_12 = 12,
-	VR_BUTTON_13 = 13,
-	VR_PAD = 14,
-	VR_TRIGGER = 15,
-	VR_ACTION = 255
-}
-
-
 ## Pointer enabled property
 export var enabled : bool = true setget set_enabled
 
@@ -66,7 +45,7 @@ export var collide_with_bodies : bool = true setget set_collide_with_bodies
 export var collide_with_areas : bool = false setget set_collide_with_areas
 
 ## Active button
-export (Buttons) var active_button : int = Buttons.VR_TRIGGER
+export (XRTools.Buttons) var active_button : int = XRTools.Buttons.VR_TRIGGER
 
 ## Action to monitor (if button set to VR_ACTION)
 export var action = ""
@@ -95,7 +74,7 @@ func _ready():
 	ws = ARVRServer.world_scale
 
 	# If pointer-trigger is a button then subscribe to button signals
-	if active_button != Buttons.VR_ACTION:
+	if active_button != XRTools.Buttons.VR_ACTION:
 		# Get button press feedback from our parent (should be an ARVRController)
 		get_parent().connect("button_pressed", self, "_on_button_pressed")
 		get_parent().connect("button_release", self, "_on_button_release")
@@ -117,7 +96,7 @@ func _process(_delta):
 		return
 
 	# If pointer-trigger is an action then check for action
-	if active_button == Buttons.VR_ACTION and action != "":
+	if active_button == XRTools.Buttons.VR_ACTION and action != "":
 		if Input.is_action_just_pressed(action):
 			_button_pressed()
 		elif !Input.is_action_pressed(action) and target:

--- a/addons/godot-xr-tools/functions/function_teleport.gd
+++ b/addons/godot-xr-tools/functions/function_teleport.gd
@@ -15,26 +15,6 @@ extends KinematicBody
 ##
 
 
-# enum our buttons, should find a way to put this more central
-enum Buttons {
-	VR_BUTTON_BY = 1,
-	VR_GRIP = 2,
-	VR_BUTTON_3 = 3,
-	VR_BUTTON_4 = 4,
-	VR_BUTTON_5 = 5,
-	VR_BUTTON_6 = 6,
-	VR_BUTTON_AX = 7,
-	VR_BUTTON_8 = 8,
-	VR_BUTTON_9 = 9,
-	VR_BUTTON_10 = 10,
-	VR_BUTTON_11 = 11,
-	VR_BUTTON_12 = 12,
-	VR_BUTTON_13 = 13,
-	VR_PAD = 14,
-	VR_TRIGGER = 15
-}
-
-
 ## Teleport enabled property
 export var enabled : bool = true setget set_enabled
 
@@ -69,7 +49,7 @@ export (int, LAYERS_3D_PHYSICS) var valid_teleport_mask : int = ~0
 export var camera : NodePath
 
 ## Teleport button
-export (Buttons) var teleport_button : int = Buttons.VR_TRIGGER
+export (XRTools.Buttons) var teleport_button : int = XRTools.Buttons.VR_TRIGGER
 
 
 var origin_node : ARVROrigin
@@ -280,7 +260,7 @@ func _physics_process(delta):
 				color = cant_teleport_color
 
 			# check our axis to see if we need to rotate
-			teleport_rotation += (delta * controller.get_joystick_axis(0) * -4.0)
+			teleport_rotation += (delta * controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_X_AXIS) * -4.0)
 
 			# update target and colour
 			var target_basis = Basis()

--- a/addons/godot-xr-tools/functions/movement_crouch.gd
+++ b/addons/godot-xr-tools/functions/movement_crouch.gd
@@ -14,26 +14,6 @@ extends XRToolsMovementProvider
 ##
 
 
-# enum our buttons, should find a way to put this more central
-enum Buttons {
-	VR_BUTTON_BY = 1,
-	VR_GRIP = 2,
-	VR_BUTTON_3 = 3,
-	VR_BUTTON_4 = 4,
-	VR_BUTTON_5 = 5,
-	VR_BUTTON_6 = 6,
-	VR_BUTTON_AX = 7,
-	VR_BUTTON_8 = 8,
-	VR_BUTTON_9 = 9,
-	VR_BUTTON_10 = 10,
-	VR_BUTTON_11 = 11,
-	VR_BUTTON_12 = 12,
-	VR_BUTTON_13 = 13,
-	VR_PAD = 14,
-	VR_TRIGGER = 15
-}
-
-
 ## Movement provider order
 export var order : int = 10
 
@@ -41,7 +21,7 @@ export var order : int = 10
 export var crouch_height : float = 1.0
 
 ## Crouch button
-export (Buttons) var crouch_button : int = Buttons.VR_PAD
+export (XRTools.Buttons) var crouch_button : int = XRTools.Buttons.VR_PAD
 
 
 ## Crouching flag

--- a/addons/godot-xr-tools/functions/movement_direct.gd
+++ b/addons/godot-xr-tools/functions/movement_direct.gd
@@ -40,11 +40,11 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 		return
 
 	# Apply forwards/backwards ground control
-	player_body.ground_control_velocity.y += _controller.get_joystick_axis(1) * max_speed
+	player_body.ground_control_velocity.y += _controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_Y_AXIS) * max_speed
 
 	# Apply left/right ground control
 	if strafe:
-		player_body.ground_control_velocity.x += _controller.get_joystick_axis(0) * max_speed
+		player_body.ground_control_velocity.x += _controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_X_AXIS) * max_speed
 
 	# Clamp ground control
 	var length := player_body.ground_control_velocity.length()

--- a/addons/godot-xr-tools/functions/movement_flight.gd
+++ b/addons/godot-xr-tools/functions/movement_flight.gd
@@ -39,25 +39,6 @@ signal flight_started()
 signal flight_finished()
 
 
-# enum our buttons, should find a way to put this more central
-enum Buttons {
-	VR_BUTTON_BY = 1,
-	VR_GRIP = 2,
-	VR_BUTTON_3 = 3,
-	VR_BUTTON_4 = 4,
-	VR_BUTTON_5 = 5,
-	VR_BUTTON_6 = 6,
-	VR_BUTTON_AX = 7,
-	VR_BUTTON_8 = 8,
-	VR_BUTTON_9 = 9,
-	VR_BUTTON_10 = 10,
-	VR_BUTTON_11 = 11,
-	VR_BUTTON_12 = 12,
-	VR_BUTTON_13 = 13,
-	VR_PAD = 14,
-	VR_TRIGGER = 15
-}
-
 # Enumeration of controller to use for flight
 enum FlightController {
 	LEFT,		# Use left controller
@@ -92,7 +73,7 @@ export var order : int = 30
 export (FlightController) var controller : int = FlightController.LEFT
 
 ## Flight toggle button
-export (Buttons) var flight_button : int = Buttons.VR_BUTTON_BY
+export (XRTools.Buttons) var flight_button : int = XRTools.Buttons.VR_BUTTON_BY
 
 ## Flight pitch control
 export (FlightPitch) var pitch : int = FlightPitch.CONTROLLER
@@ -186,8 +167,8 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	var side := forwards.cross(Vector3.UP)
 
 	# Construct the target velocity
-	var joy_forwards := _controller.get_joystick_axis(1)
-	var joy_side := _controller.get_joystick_axis(0)
+	var joy_forwards := _controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_Y_AXIS)
+	var joy_side := _controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_X_AXIS)
 	var heading := forwards * joy_forwards + side * joy_side
 
 	# Calculate the flight velocity

--- a/addons/godot-xr-tools/functions/movement_grapple.gd
+++ b/addons/godot-xr-tools/functions/movement_grapple.gd
@@ -26,25 +26,6 @@ signal grapple_started()
 signal grapple_finished()
 
 
-# enum our buttons, should find a way to put this more central
-enum Buttons {
-	VR_BUTTON_BY = 1,
-	VR_GRIP = 2,
-	VR_BUTTON_3 = 3,
-	VR_BUTTON_4 = 4,
-	VR_BUTTON_5 = 5,
-	VR_BUTTON_6 = 6,
-	VR_BUTTON_AX = 7,
-	VR_BUTTON_8 = 8,
-	VR_BUTTON_9 = 9,
-	VR_BUTTON_10 = 10,
-	VR_BUTTON_11 = 11,
-	VR_BUTTON_12 = 12,
-	VR_BUTTON_13 = 13,
-	VR_PAD = 14,
-	VR_TRIGGER = 15
-}
-
 # Grapple state
 enum GrappleState {
 	IDLE,			# Idle
@@ -76,7 +57,7 @@ export var rope_width : float = 0.02
 export var friction : float = 0.1
 
 ## Grapple button (triggers grappling movement).  Be sure this button does not conflict with other functions.
-export (Buttons) var grapple_button_id : int = Buttons.VR_TRIGGER
+export (XRTools.Buttons) var grapple_button_id : int = XRTools.Buttons.VR_TRIGGER
 
 # Hook related variables
 var hook_object : Spatial = null

--- a/addons/godot-xr-tools/functions/movement_jump.gd
+++ b/addons/godot-xr-tools/functions/movement_jump.gd
@@ -15,30 +15,12 @@ extends XRToolsMovementProvider
 ##     and jump velocity.
 ##
 
-# enum our buttons, should find a way to put this more central
-enum Buttons {
-	VR_BUTTON_BY = 1,
-	VR_GRIP = 2,
-	VR_BUTTON_3 = 3,
-	VR_BUTTON_4 = 4,
-	VR_BUTTON_5 = 5,
-	VR_BUTTON_6 = 6,
-	VR_BUTTON_AX = 7,
-	VR_BUTTON_8 = 8,
-	VR_BUTTON_9 = 9,
-	VR_BUTTON_10 = 10,
-	VR_BUTTON_11 = 11,
-	VR_BUTTON_12 = 12,
-	VR_BUTTON_13 = 13,
-	VR_PAD = 14,
-	VR_TRIGGER = 15
-}
 
 ## Movement provider order
 export var order : int = 20
 
 ## Button to trigger jump
-export (Buttons) var jump_button_id : int = Buttons.VR_TRIGGER
+export (XRTools.Buttons) var jump_button_id : int = XRTools.Buttons.VR_TRIGGER
 
 # Node references
 onready var _controller: ARVRController = get_parent()

--- a/addons/godot-xr-tools/functions/movement_turn.gd
+++ b/addons/godot-xr-tools/functions/movement_turn.gd
@@ -46,7 +46,7 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: b
 		return
 
 	# Read the left/right joystick axis
-	var left_right := _controller.get_joystick_axis(0)
+	var left_right := _controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_X_AXIS)
 	if abs(left_right) <= 0.1:
 		# Not turning
 		_turn_step = 0.0

--- a/addons/godot-xr-tools/misc/hold_button.gd
+++ b/addons/godot-xr-tools/misc/hold_button.gd
@@ -6,30 +6,10 @@ extends Spatial
 signal pressed
 
 
-# Button
-enum Buttons {
-	VR_BUTTON_BY = 1,
-	VR_GRIP = 2,
-	VR_BUTTON_3 = 3,
-	VR_BUTTON_4 = 4,
-	VR_BUTTON_5 = 5,
-	VR_BUTTON_6 = 6,
-	VR_BUTTON_AX = 7,
-	VR_BUTTON_8 = 8,
-	VR_BUTTON_9 = 9,
-	VR_BUTTON_10 = 10,
-	VR_BUTTON_11 = 11,
-	VR_BUTTON_12 = 12,
-	VR_BUTTON_13 = 13,
-	VR_PAD = 14,
-	VR_TRIGGER = 15
-}
-
-
 # Enable our button
 export var enabled : bool = false setget set_enabled
 
-export (Buttons) var activate_button : int = Buttons.VR_TRIGGER
+export (XRTools.Buttons) var activate_button : int = XRTools.Buttons.VR_TRIGGER
 
 # Countdown
 export var hold_time : float = 2.0

--- a/addons/godot-xr-tools/plugin.gd
+++ b/addons/godot-xr-tools/plugin.gd
@@ -1,4 +1,83 @@
 tool
 extends EditorPlugin
+class_name XRTools
 
-# We don't have any tool elements here yet
+
+# enum our axis
+enum Axis {
+	VR_PRIMARY_X_AXIS = 0,
+	VR_PRIMARY_Y_AXIS = 1,
+	VR_SECONDARY_X_AXIS = 6,
+	VR_SECONDARY_Y_AXIS = 7,
+	VR_TRIGGER_AXIS = 2,
+	VR_GRIP_AXIS = 4
+}
+
+
+# enum our buttons
+enum Buttons {
+	VR_BUTTON_BY = 1,
+	VR_GRIP = 2,
+	VR_BUTTON_3 = 3,
+	VR_BUTTON_4 = 4,
+	VR_BUTTON_5 = 5,
+	VR_BUTTON_6 = 6,
+	VR_BUTTON_AX = 7,
+	VR_BUTTON_8 = 8,
+	VR_BUTTON_9 = 9,
+	VR_BUTTON_10 = 10,
+	VR_BUTTON_11 = 11,
+	VR_BUTTON_12 = 12,
+	VR_BUTTON_13 = 13,
+	VR_PAD = 14,
+	VR_TRIGGER = 15
+}
+
+
+static func get_grip_threshold() -> float:
+	# can return null which is not a float, so don't type this!
+	var threshold = ProjectSettings.get_setting("godot_xr_tools/input/grip_threshold")
+
+	if threshold == null:
+		# plugin disabled or setting not saved, return our default.
+		threshold = 0.7
+	if !(threshold >= 0.2 and threshold <= 0.8):
+		# out of bounds? reset to default
+		threshold = 0.7
+	
+	return threshold
+
+static func set_grip_threshold(p_threshold : float) -> void:
+	if !(p_threshold >= 0.2 and p_threshold <= 0.8):
+		print("Threshold out of bounds")
+		return
+
+	ProjectSettings.set_setting("godot_xr_tools/input/grip_threshold", p_threshold)
+
+func _define_project_setting(p_name : String, p_type : int, p_hint : int = PROPERTY_HINT_NONE , p_hint_string : String = "", p_default_val = "") -> void:
+	# p_default_val can be any type!!
+
+	if !ProjectSettings.has_setting(p_name):
+		ProjectSettings.set_setting(p_name, p_default_val)
+
+	var property_info : Dictionary = {
+		"name" : p_name,
+		"type" : p_type,
+		"hint" : p_hint,
+		"hint_string" : p_hint_string
+	}
+
+	ProjectSettings.add_property_info(property_info)
+	ProjectSettings.set_initial_value(p_name, p_default_val)
+
+
+func _enter_tree():
+	# our plugin is loaded
+
+	# provide meta data for our project settings
+	_define_project_setting("godot_xr_tools/input/grip_threshold", TYPE_REAL, PROPERTY_HINT_RANGE, "0.2,0.8,0.05", 0.7)
+
+
+func _exit_tree():
+	# our plugin is turned off
+	pass

--- a/addons/godot-xr-tools/plugin.gd
+++ b/addons/godot-xr-tools/plugin.gd
@@ -30,7 +30,8 @@ enum Buttons {
 	VR_BUTTON_12 = 12,
 	VR_BUTTON_13 = 13,
 	VR_PAD = 14,
-	VR_TRIGGER = 15
+	VR_TRIGGER = 15,
+	VR_ACTION = 255 ## Only supported in function pointer, should solve that differently!!
 }
 
 

--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://assets/meshes/teleport/teleport.gd"
 }, {
+"base": "EditorPlugin",
+"class": "XRTools",
+"language": "GDScript",
+"path": "res://addons/godot-xr-tools/plugin.gd"
+}, {
 "base": "Spatial",
 "class": "XRToolsClimbable",
 "language": "GDScript",
@@ -233,6 +238,7 @@ _global_script_class_icons={
 "ARVRHelpers": "",
 "SceneBase": "",
 "Teleport": "",
+"XRTools": "",
 "XRToolsClimbable": "res://addons/godot-xr-tools/editor/icons/hand.svg",
 "XRToolsFallDamage": "",
 "XRToolsFunctionPickup": "res://addons/godot-xr-tools/editor/icons/function.svg",


### PR DESCRIPTION
This PR introduces a grip threshold on our pickup function.

On controllers such as the Oculus touch our grip button is an actual button which results in our logic working pretty sweet.
On controllers such as the Index it's actually a pressure sensor. The problem is that the build in threshold makes it really hard to let go of things.
So here we are implementing our own so we have control over this threshold and use the grip axis as our input.

For controllers such as Oculus Touch controllers OpenXR already provides support so unpressed is `0.0` and pressed is `1.0` and switching from the grip button to the grip axis should be transparent.

Instead of having this as a property I'm introducing this as a project setting so we can share the same value on other scripts as well.
![image](https://user-images.githubusercontent.com/1945449/197751460-4a34c18f-c6d5-40a2-8719-ca11fa604ea1.png)
It's worth contemplating doing this for other shared settings as well.

I have also moved our `Buttons` enum to our plugin script, only the pickup function uses this but we can do further cleanup of other scripts so we don't re-define this everywhere