### PR TITLE
Improved pointer demo supporting left hand with switching

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,7 @@
 # 3.1.0 (Development)
 - Improvements to our 2D in 3D viewport
 - Use value based grip input with threshold
+- Improved pointer demo supporting left hand with switching
 
 # 3.0.0
 - Included demo project with test scenes to evaluate features

--- a/scenes/pointer_demo/objects/keyboard_test_screen.gd
+++ b/scenes/pointer_demo/objects/keyboard_test_screen.gd
@@ -2,6 +2,6 @@ extends Node2D
 
 
 func _on_ClearButton_pressed():
-	$TextEdit1.text = ""
-	$TextEdit2.text = ""
-	$TextEdit3.text = ""
+	$Container/Line1/TextEdit.text = ""
+	$Container/Line2/TextEdit.text = ""
+	$Container/Line3/TextEdit.text = ""

--- a/scenes/pointer_demo/objects/keyboard_test_screen.tscn
+++ b/scenes/pointer_demo/objects/keyboard_test_screen.tscn
@@ -5,50 +5,88 @@
 [node name="KeyboardTestScreen" type="Node2D"]
 script = ExtResource( 1 )
 
-[node name="Label1" type="Label" parent="."]
+[node name="Container" type="VBoxContainer" parent="."]
 margin_left = 10.0
-margin_top = 14.0
-margin_right = 60.0
-margin_bottom = 28.0
-text = "Line 1:"
-
-[node name="TextEdit1" type="TextEdit" parent="."]
-margin_left = 70.0
 margin_top = 10.0
-margin_right = 270.0
-margin_bottom = 31.0
+margin_right = 257.0
+margin_bottom = 50.0
 
-[node name="Label2" type="Label" parent="."]
-margin_left = 10.0
-margin_top = 44.0
-margin_right = 60.0
-margin_bottom = 58.0
+[node name="Header" type="HBoxContainer" parent="Container"]
+margin_right = 250.0
+margin_bottom = 48.0
+
+[node name="Label" type="Label" parent="Container/Header"]
+margin_right = 250.0
+margin_bottom = 48.0
+rect_min_size = Vector2( 250, 0 )
+text = "Press trigger on controller to switch active pointer to that controller, or interact with the UI."
+align = 1
+autowrap = true
+
+[node name="Line1" type="HBoxContainer" parent="Container"]
+margin_top = 52.0
+margin_right = 250.0
+margin_bottom = 73.0
+
+[node name="Label" type="Label" parent="Container/Line1"]
+margin_top = 3.0
+margin_right = 43.0
+margin_bottom = 17.0
+text = "Line 1:"
+align = 2
+
+[node name="TextEdit" type="TextEdit" parent="Container/Line1"]
+margin_left = 47.0
+margin_right = 247.0
+margin_bottom = 21.0
+rect_min_size = Vector2( 200, 21 )
+
+[node name="Line2" type="HBoxContainer" parent="Container"]
+margin_top = 77.0
+margin_right = 250.0
+margin_bottom = 98.0
+
+[node name="Label" type="Label" parent="Container/Line2"]
+margin_top = 3.0
+margin_right = 43.0
+margin_bottom = 17.0
 text = "Line 2:"
+align = 2
 
-[node name="TextEdit2" type="TextEdit" parent="."]
-margin_left = 70.0
-margin_top = 40.0
-margin_right = 270.0
-margin_bottom = 61.0
+[node name="TextEdit" type="TextEdit" parent="Container/Line2"]
+margin_left = 47.0
+margin_right = 247.0
+margin_bottom = 21.0
+rect_min_size = Vector2( 200, 21 )
 
-[node name="Label3" type="Label" parent="."]
-margin_left = 10.0
-margin_top = 74.0
-margin_right = 60.0
-margin_bottom = 88.0
+[node name="Line3" type="HBoxContainer" parent="Container"]
+margin_top = 102.0
+margin_right = 250.0
+margin_bottom = 123.0
+
+[node name="Label" type="Label" parent="Container/Line3"]
+margin_top = 3.0
+margin_right = 43.0
+margin_bottom = 17.0
 text = "Line 3:"
+align = 2
 
-[node name="TextEdit3" type="TextEdit" parent="."]
-margin_left = 70.0
-margin_top = 70.0
-margin_right = 270.0
-margin_bottom = 91.0
+[node name="TextEdit" type="TextEdit" parent="Container/Line3"]
+margin_left = 47.0
+margin_right = 247.0
+margin_bottom = 21.0
+rect_min_size = Vector2( 200, 21 )
 
-[node name="ClearButton" type="Button" parent="."]
-margin_left = 226.0
-margin_top = 100.0
-margin_right = 270.0
-margin_bottom = 120.0
+[node name="Footer" type="HBoxContainer" parent="Container"]
+margin_top = 127.0
+margin_right = 250.0
+margin_bottom = 147.0
+alignment = 2
+
+[node name="ClearButton" type="Button" parent="Container/Footer"]
+margin_left = 206.0
+margin_right = 250.0
+margin_bottom = 20.0
 text = "Clear"
 
-[connection signal="pressed" from="ClearButton" to="." method="_on_ClearButton_pressed"]
+[connection signal="pressed" from="Container/Footer/ClearButton" to="." method="_on_ClearButton_pressed"]

--- a/scenes/pointer_demo/pointer_demo.gd
+++ b/scenes/pointer_demo/pointer_demo.gd
@@ -1,0 +1,33 @@
+extends SceneBase
+
+
+enum Pointer {
+	LEFT = 0,
+	RIGHT = 1
+}
+
+var pointer_left_or_right = Pointer.RIGHT
+
+
+func _set_pointer_enabled():
+	$ARVROrigin/LeftHand/FunctionPointer.enabled = pointer_left_or_right == Pointer.LEFT
+	$ARVROrigin/RightHand/FunctionPointer.enabled = pointer_left_or_right == Pointer.RIGHT
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	_set_pointer_enabled()
+
+
+func _on_LeftHand_button_pressed(button):
+	if pointer_left_or_right == Pointer.RIGHT and button == $ARVROrigin/LeftHand/FunctionPointer.active_button:
+		# switch to left
+		pointer_left_or_right = Pointer.LEFT
+		_set_pointer_enabled()
+
+
+func _on_RightHand_button_pressed(button):
+	if pointer_left_or_right == Pointer.LEFT and button == $ARVROrigin/RightHand/FunctionPointer.active_button:
+		# switch to right
+		pointer_left_or_right = Pointer.RIGHT
+		_set_pointer_enabled()

--- a/scenes/pointer_demo/pointer_demo.tscn
+++ b/scenes/pointer_demo/pointer_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://scenes/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/meshes/teleport/teleport.tscn" type="PackedScene" id=2]
@@ -12,9 +12,12 @@
 [ext_resource path="res://addons/godot-xr-tools/assets/right_hand.tscn" type="PackedScene" id=10]
 [ext_resource path="res://addons/godot-xr-tools/objects/virtual_keyboard.tscn" type="PackedScene" id=11]
 [ext_resource path="res://scenes/pointer_demo/objects/display.tscn" type="PackedScene" id=12]
+[ext_resource path="res://scenes/pointer_demo/pointer_demo.gd" type="Script" id=13]
 [ext_resource path="res://scenes/pointer_demo/objects/color_change_cube.tscn" type="PackedScene" id=15]
 
 [node name="PointerDemo" instance=ExtResource( 1 )]
+script = ExtResource( 13 )
+environment = null
 
 [node name="LeftHand" parent="ARVROrigin/LeftHand" index="0" instance=ExtResource( 6 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
@@ -24,6 +27,9 @@ enabled = true
 order = 10
 max_speed = 3.0
 strafe = true
+
+[node name="FunctionPointer" parent="ARVROrigin/LeftHand" index="2" instance=ExtResource( 5 )]
+enabled = false
 
 [node name="RightHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 10 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
@@ -49,7 +55,9 @@ scene_base = NodePath("..")
 title = ExtResource( 4 )
 
 [node name="Display" parent="." index="3" instance=ExtResource( 12 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, -3 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.3, -3 )
+screen_size = Vector2( 2.8, 1.65 )
+viewport_size = Vector2( 280, 165 )
 
 [node name="VirtualKeyboard" parent="." index="4" instance=ExtResource( 11 )]
 transform = Transform( 1, 0, 0, 0, 0.965926, 0.258819, 0, -0.258819, 0.965926, 0, 1, -2 )
@@ -65,3 +73,6 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 2.5, -3 )
 
 [node name="ColorChangeCube4" parent="." index="8" instance=ExtResource( 15 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 1.7, -3 )
+
+[connection signal="button_pressed" from="ARVROrigin/LeftHand" to="." method="_on_LeftHand_button_pressed"]
+[connection signal="button_pressed" from="ARVROrigin/RightHand" to="." method="_on_RightHand_button_pressed"]


### PR DESCRIPTION
This is a simple little improvement to the pointer demo so both hands have a laser pointer, but the user can switch between right and left hand by pressing the trigger on the desired controller.

Nice improvement for our left handed players.

I've also improved the UI a bit, added a message around how the trigger works and changed it to using VBox and HBox containers for layout.