### PR TITLE
Added filter and update mode to Viewport 2D in 3D

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,6 @@
+# 3.1.0 (Development)
+- Improvements to our 2D in 3D viewport
+
 # 3.0.0
 - Included demo project with test scenes to evaluate features
 - Standardized class naming convention for all scripts to "XRTools<PascalCaseName>"

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -31,13 +31,27 @@ export var transparent : bool = true setget set_transparent
 ## Scene property
 export var scene : PackedScene setget set_scene
 
+## Display properties
+export var filter : bool = true setget set_filter
+
+enum UpdateMode {
+	UPDATE_ONCE, ## Note, even if already set to ONCE, if you assign the property again, it will trigger a single redraw
+	UPDATE_ALWAYS,
+	UPDATE_THROTTLED
+}
+
+export (UpdateMode) var update_mode = UpdateMode.UPDATE_ALWAYS setget set_update_mode
+export var throttle_fps : float = 30.0
+var time_since_last_update : float = 0.0
+
 ## Collision layer
 export (int, LAYERS_3D_PHYSICS) var collision_layer : int = 15 setget set_collision_layer
 
 
 var is_ready : bool = false
 var scene_node : Node
-
+var viewport_texture : ViewportTexture
+var material : SpatialMaterial
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -45,13 +59,22 @@ func _ready():
 	if Engine.editor_hint:
 		return
 
-	# apply properties
 	is_ready = true
+
+	# Setup our viewport texture and material
+	material = SpatialMaterial.new()
+	material.flags_unshaded = true
+	material.params_cull_mode = SpatialMaterial.CULL_DISABLED
+	$Screen.set_surface_material(0, material)
+
+	# apply properties
 	_update_enabled()
 	_update_screen_size()
 	_update_viewport_size()
 	_update_collision_layer()
 	_update_scene()
+	# _update_filter() ## already called from _update_viewport_size
+	_update_update_mode()
 	_update_collision_layer()
 	_update_transparent()
 
@@ -81,6 +104,18 @@ func _on_pointer_exited():
 func _input(event):
 	$Viewport.input(event)
 
+# Process event
+func _process(delta):
+	if update_mode == UpdateMode.UPDATE_THROTTLED:
+		var frame_time = 1.0 / throttle_fps
+		time_since_last_update += delta
+		if time_since_last_update > frame_time:
+			# Trigger update
+			$Viewport.render_target_update_mode = Viewport.UPDATE_ONCE
+			time_since_last_update = 0.0
+	else:
+		# This is no longer needed
+		set_process(false)
 
 # Set enabled property
 func set_enabled(is_enabled: bool) -> void:
@@ -116,6 +151,16 @@ func set_scene(new_scene: PackedScene) -> void:
 	if is_ready:
 		_update_scene()
 
+# set filter property
+func set_filter(new_filter: bool) -> void:
+	filter = new_filter
+	if is_ready:
+		_update_filter()
+
+func set_update_mode(new_update_mode: int) -> void:
+	update_mode = new_update_mode
+	if is_ready:
+		_update_update_mode()
 
 # Set collision layer property
 func set_collision_layer(new_layer: int) -> void:
@@ -140,14 +185,18 @@ func _update_screen_size() -> void:
 func _update_viewport_size() -> void:
 	$Viewport.size = viewport_size
 	$StaticBody.viewport_size = viewport_size
-	var material : SpatialMaterial = $Screen.get_surface_material(0)
-	material.albedo_texture = $Viewport.get_texture()
+
+	# Update our viewport texture, it will have changed
+	viewport_texture = $Viewport.get_texture()
+	if material:
+		material.albedo_texture = viewport_texture
+	_update_filter()
 
 
 # Transparent update handler
 func _update_transparent() -> void:
-	var material : SpatialMaterial = $Screen.get_surface_material(0)
-	material.flags_transparent = transparent
+	if material:
+		material.flags_transparent = transparent
 	$Viewport.transparent_bg = transparent
 
 
@@ -163,6 +212,25 @@ func _update_scene() -> void:
 		scene_node = scene.instance()
 		$Viewport.add_child(scene_node)
 
+# Filter update handler
+func _update_filter() -> void:
+	if viewport_texture:
+		viewport_texture.flags = Texture.FLAG_FILTER if filter else 0
+
+# Update mode handler
+func _update_update_mode() -> void:
+	if update_mode == UpdateMode.UPDATE_ONCE:
+		# this will trigger redrawing our screen
+		$Viewport.render_target_update_mode = Viewport.UPDATE_ONCE
+		set_process(false)
+	elif update_mode == UpdateMode.UPDATE_ALWAYS:
+		# redraw screen every frame
+		$Viewport.render_target_update_mode = Viewport.UPDATE_ALWAYS
+		set_process(false)
+	elif update_mode == UpdateMode.UPDATE_THROTTLED:
+		# we will attempt to update the screen at the given framerate
+		$Viewport.render_target_update_mode = Viewport.UPDATE_ONCE
+		set_process(true)
 
 # Collision layer update handler
 func _update_collision_layer() -> void:

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.tscn
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.tscn
@@ -27,6 +27,7 @@ collision_layer = 1023
 [node name="Viewport" type="Viewport" parent="."]
 size = Vector2( 300, 200 )
 transparent_bg = true
+disable_3d = true
 usage = 0
 render_target_v_flip = true
 render_target_update_mode = 3

--- a/addons/godot-xr-tools/objects/virtual_keyboard.tscn
+++ b/addons/godot-xr-tools/objects/virtual_keyboard.tscn
@@ -9,3 +9,5 @@
 screen_size = Vector2( 1.5, 0.558 )
 viewport_size = Vector2( 390, 145 )
 scene = ExtResource( 2 )
+update_mode = 2
+throttle_fps = 15.0

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -29,6 +29,8 @@
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
 
 [node name="MovementDirect" parent="ARVROrigin/LeftHand" index="1" instance=ExtResource( 6 )]
+enabled = true
+order = 10
 max_speed = 3.0
 strafe = true
 
@@ -36,7 +38,10 @@ strafe = true
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
 
 [node name="MovementDirect" parent="ARVROrigin/RightHand" index="1" instance=ExtResource( 6 )]
+enabled = true
+order = 10
 max_speed = 3.0
+strafe = false
 
 [node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 5 )]
 smooth_rotation = true

--- a/scenes/pointer_demo/objects/display.tscn
+++ b/scenes/pointer_demo/objects/display.tscn
@@ -24,6 +24,8 @@ extents = Vector3( 1.4, 0.65, 0.01 )
 screen_size = Vector2( 2.8, 1.3 )
 viewport_size = Vector2( 280, 130 )
 scene = ExtResource( 2 )
+update_mode = 2
+throttle_fps = 15.0
 
 [node name="Viewport" parent="." index="0"]
 size = Vector2( 280, 130 )


### PR DESCRIPTION
This PR adds three new settings to `Viewport2Din3D`
- `Filter` when enabled will set texture filtering on the viewport texture resulting in a less pixelated look
- `Update Mode` allows you to set different update modes (see below)
- `Throttle FPS` is the target FPS for updating the UI, this is only active if the `Update Mode` is set to `Update Throttled`

The available `Update Mode`s are:
- `Update Once`, this will redraw the screen one time. You can repeatedly assign this to trigger another update.
- `Update Always`, will update the screen every frame that is rendered to the HMD
- `Update Throttled`, will lower the update rate to the target FPS

Note that the throttled mode implements a target FPS, the actual FPS can be lower depending on the FPS of the main output.

Implements #204