### PR TITLE
Added snap_zone enable/disable property

### DIFF
--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -15,6 +15,9 @@ signal highlight_updated(pickable, enable)
 signal close_highlight_updated(pickable, enable)
 
 
+## Enable or disable snap-zone
+export var enabled : bool = true
+
 ## Grab distance
 export var grab_distance : float = 0.3 setget _set_grab_distance
 
@@ -51,9 +54,15 @@ func _ready():
 
 # Called on each frame to update the pickup
 func _process(_delta):
+	# Skip if not enabled
+	if not enabled:
+		return
+
+	# Skip if already holding a valid object
 	if is_instance_valid(picked_up_object):
 		return
 
+	# Check for an object to grab
 	for o in _object_in_grab_area:
 		# skip objects that can not be picked up
 		if not o.can_pick_up(self):
@@ -66,6 +75,10 @@ func _process(_delta):
 
 # Pickable Method: snap-zone can be grabbed if holding object
 func can_pick_up(by: Spatial) -> bool:
+	# Refuse if not enabled
+	if not enabled:
+		return false
+
 	# Refuse if no object is held
 	if not is_instance_valid(picked_up_object):
 		return false

--- a/project.godot
+++ b/project.godot
@@ -312,6 +312,7 @@ common/drop_mouse_on_gui_input_disabled=true
 3d_physics/layer_17="held_object"
 3d_physics/layer_18="player_hand"
 3d_physics/layer_20="player_body"
+3d_physics/layer_21="pointable"
 
 [physics]
 

--- a/scenes/pickable_demo/objects/snap_tray.gd
+++ b/scenes/pickable_demo/objects/snap_tray.gd
@@ -1,0 +1,46 @@
+extends XRToolsPickable
+
+
+signal pointer_pressed(at)
+
+
+## Snap-tray active state
+export var tray_active : bool = true setget _set_tray_active
+
+## Active material
+export (Material) var active_material : Material
+
+## Inactive material
+export (Material) var inactive_material : Material
+
+
+## Called when the node enters the scene tree for the first time.
+func _ready():
+	# Connect to the pointer pressed signal
+	connect("pointer_pressed", self, "_on_pointer_pressed")
+
+	# Update the tray_active state
+	_update_tray_active()
+
+
+## Handler for snap tray being pressed by pointer
+func _on_pointer_pressed(_at : Vector3) -> void:
+	# Toggle tray_active
+	_set_tray_active(not tray_active)
+
+
+## Handler for tray_active property change
+func _set_tray_active(new_value : bool) -> void:
+	tray_active = new_value
+	if is_inside_tree():
+		_update_tray_active()
+
+
+## Update state based on tray_active property
+func _update_tray_active() -> void:
+	$Body.material_override = active_material if tray_active else inactive_material
+	$SnapArea1/SnapZone1.enabled = tray_active
+	$SnapArea2/SnapZone2.enabled = tray_active
+	$SnapArea3/SnapZone3.enabled = tray_active
+	$SnapArea4/SnapZone4.enabled = tray_active
+	

--- a/scenes/pickable_demo/objects/snap_tray.tscn
+++ b/scenes/pickable_demo/objects/snap_tray.tscn
@@ -1,9 +1,16 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/objects/pickable.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=2]
 [ext_resource path="res://addons/godot-xr-tools/objects/highlight/highlight_ring.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/godot-xr-tools/objects/snap_zone.tscn" type="PackedScene" id=4]
+[ext_resource path="res://scenes/pickable_demo/objects/snap_tray.gd" type="Script" id=5]
+[ext_resource path="res://assets/wahooney.itch.io/white_grid.png" type="Texture" id=6]
+
+[sub_resource type="SpatialMaterial" id=15]
+albedo_color = Color( 0.247059, 0.247059, 0.247059, 1 )
+albedo_texture = ExtResource( 6 )
+uv1_triplanar = true
 
 [sub_resource type="BoxShape" id=9]
 extents = Vector3( 0.15, 0.2, 0.05 )
@@ -27,11 +34,14 @@ albedo_color = Color( 0.498039, 0.498039, 0.498039, 1 )
 albedo_color = Color( 0.498039, 0.498039, 0.498039, 1 )
 
 [node name="SnapTray" instance=ExtResource( 1 )]
-collision_layer = 4
+collision_layer = 1048580
 collision_mask = 65543
+script = ExtResource( 5 )
 reset_transform_on_pickup = false
-picked_up_layer = 65536
 ranged_grab_method = 0
+tray_active = false
+active_material = ExtResource( 2 )
+inactive_material = SubResource( 15 )
 
 [node name="CollisionShape" parent="." index="1"]
 shape = SubResource( 9 )

--- a/scenes/pickable_demo/objects/snap_tray_inactive_material.tres
+++ b/scenes/pickable_demo/objects/snap_tray_inactive_material.tres
@@ -1,0 +1,8 @@
+[gd_resource type="SpatialMaterial" load_steps=2 format=2]
+
+[ext_resource path="res://assets/wahooney.itch.io/white_grid.png" type="Texture" id=1]
+
+[resource]
+albedo_color = Color( 0.247059, 0.247059, 0.247059, 1 )
+albedo_texture = ExtResource( 1 )
+uv1_triplanar = true

--- a/scenes/pickable_demo/pickable_demo.tscn
+++ b/scenes/pickable_demo/pickable_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://scenes/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/maps/basic_map.tscn" type="PackedScene" id=2]
@@ -17,6 +17,7 @@
 [ext_resource path="res://assets/meshes/table/table.tscn" type="PackedScene" id=15]
 [ext_resource path="res://scenes/pickable_demo/objects/snap_tray.tscn" type="PackedScene" id=16]
 [ext_resource path="res://scenes/pickable_demo/objects/hammer.tscn" type="PackedScene" id=17]
+[ext_resource path="res://addons/godot-xr-tools/functions/function_pointer.tscn" type="PackedScene" id=18]
 
 [node name="PickableDemo" instance=ExtResource( 1 )]
 
@@ -52,6 +53,11 @@ grab_distance = 0.1
 grab_collision_mask = 4
 ranged_angle = 10.0
 ranged_collision_mask = 4
+
+[node name="FunctionPointer" parent="ARVROrigin/RightHand" index="4" instance=ExtResource( 18 )]
+show_laser = 2
+laser_length = 1
+collision_mask = 1048576
 
 [node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 9 )]
 
@@ -106,11 +112,15 @@ transform = Transform( 0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, 0.707107, -
 
 [node name="SnapToys" type="Spatial" parent="." index="8"]
 
-[node name="SnapTray" parent="SnapToys" index="0" instance=ExtResource( 16 )]
+[node name="SnapTray1" parent="SnapToys" index="0" instance=ExtResource( 16 )]
 transform = Transform( 0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, 0.707107, 1.5, 1, -2.9 )
+tray_active = true
 
-[node name="SnapToyRed" parent="SnapToys" index="1" instance=ExtResource( 11 )]
+[node name="SnapTray2" parent="SnapToys" index="1" instance=ExtResource( 16 )]
+transform = Transform( 0.996195, 0, -0.0871558, 0, 1, 0, 0.0871558, 0, 0.996195, 1.1, 1, -3 )
+
+[node name="SnapToyRed" parent="SnapToys" index="2" instance=ExtResource( 11 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.6, 0.9, -3 )
 
-[node name="SnapToyYellow" parent="SnapToys" index="2" instance=ExtResource( 12 )]
+[node name="SnapToyYellow" parent="SnapToys" index="3" instance=ExtResource( 12 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.8, 0.9, -3 )


### PR DESCRIPTION
This pull request implements feature #183 by:
 - Added enable to snap_zone and prevent adding/removing item when disabled.
 - Added pointable layer to demo project.
 - Modified pickable demo so snap trays can be enabled/disabled by pointer.


The pickable demo has two trays - one active and one inactive:
![image](https://user-images.githubusercontent.com/1863707/197921194-51d65a3a-203c-4b7d-98b6-6318c6726ba9.png)

The user can use the pointer to toggle activity and play with having items locked in the snap-zone:
![image](https://user-images.githubusercontent.com/1863707/197921342-6a512611-50bf-422f-97ba-81b657790cfd.png)
