### PR TITLE
Improve snap turning logic

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,6 +5,7 @@
 - Improved pointer demo supporting left hand with switching
 - Enhanced pointer laser visibility options for colliding with targets.
 - Implement poke feature (finger interaction)
+- Improvements to snap turning
 
 # 3.0.0
 - Included demo project with test scenes to evaluate features

--- a/addons/godot-xr-tools/assets/player_body.gd
+++ b/addons/godot-xr-tools/assets/player_body.gd
@@ -296,7 +296,7 @@ func override_player_height(key, value: float = -1.0):
 func _update_body_under_camera():
 	# Calculate the player height based on the camera position in the origin and the calibration
 	var player_height: float = clamp(
-		camera_node.transform.origin.y + player_head_height + player_height_offset,
+		camera_node.transform.origin.y + player_head_height + player_height_offset + XRToolsUserSettings.player_height_adjust,
 		player_height_min * ARVRServer.world_scale,
 		player_height_max * ARVRServer.world_scale)
 

--- a/addons/godot-xr-tools/plugin.gd
+++ b/addons/godot-xr-tools/plugin.gd
@@ -37,15 +37,15 @@ enum Buttons {
 
 static func get_grip_threshold() -> float:
 	# can return null which is not a float, so don't type this!
-	var threshold = ProjectSettings.get_setting("godot_xr_tools/input/grip_threshold")
+	var threshold = 0.7
 
-	if threshold == null:
-		# plugin disabled or setting not saved, return our default.
-		threshold = 0.7
+	if ProjectSettings.has_setting("godot_xr_tools/input/grip_threshold"):
+		threshold = ProjectSettings.get_setting("godot_xr_tools/input/grip_threshold")
+
 	if !(threshold >= 0.2 and threshold <= 0.8):
 		# out of bounds? reset to default
 		threshold = 0.7
-	
+
 	return threshold
 
 static func set_grip_threshold(p_threshold : float) -> void:
@@ -54,6 +54,61 @@ static func set_grip_threshold(p_threshold : float) -> void:
 		return
 
 	ProjectSettings.set_setting("godot_xr_tools/input/grip_threshold", p_threshold)
+
+
+static func get_snap_turning_deadzone() -> float:
+	# can return null which is not a float, so don't type this!
+	var deadzone = 0.25
+	
+	if ProjectSettings.has_setting("godot_xr_tools/input/snap_turning_deadzone"):
+		deadzone = ProjectSettings.get_setting("godot_xr_tools/input/snap_turning_deadzone")
+
+	if !(deadzone >= 0.0 and deadzone <= 0.5):
+		# out of bounds? reset to default
+		deadzone = 0.25
+
+	return deadzone
+
+static func set_snap_turning_deadzone(p_deadzone : float) -> void:
+	if !(p_deadzone >= 0.0 and p_deadzone <= 0.5):
+		print("Deadzone out of bounds")
+		return
+
+	ProjectSettings.set_setting("godot_xr_tools/input/snap_turning_deadzone", p_deadzone)
+
+
+static func get_default_snap_turning() -> bool:
+	var default = true
+	
+	if ProjectSettings.has_setting("godot_xr_tools/input/default_snap_turning"):
+		default = ProjectSettings.get_setting("godot_xr_tools/input/default_snap_turning")
+
+	# default may not be bool, so JIC
+	return default == true
+
+static func set_default_snap_turning(p_default : bool) -> void:
+	ProjectSettings.set_setting("godot_xr_tools/input/default_snap_turning", p_default)
+
+
+static func get_player_standard_height() -> float:
+	var standard_height = 1.85
+	
+	if ProjectSettings.has_setting("godot_xr_tools/player/standard_height"):
+		standard_height = ProjectSettings.get_setting("godot_xr_tools/player/standard_height")
+
+	if !(standard_height >= 1.0 and standard_height <= 2.5):
+		# out of bounds? reset to default
+		standard_height = 1.85
+
+	return standard_height
+
+static func set_player_standard_height(p_height : float) -> void:
+	if !(p_height >= 1.0 and p_height <= 2.5):
+		print("Standard height out of bounds")
+		return
+
+	ProjectSettings.set_setting("godot_xr_tools/player/standard_height", p_height)
+
 
 func _define_project_setting(p_name : String, p_type : int, p_hint : int = PROPERTY_HINT_NONE , p_hint_string : String = "", p_default_val = "") -> void:
 	# p_default_val can be any type!!
@@ -77,7 +132,13 @@ func _enter_tree():
 
 	# provide meta data for our project settings
 	_define_project_setting("godot_xr_tools/input/grip_threshold", TYPE_REAL, PROPERTY_HINT_RANGE, "0.2,0.8,0.05", 0.7)
+	_define_project_setting("godot_xr_tools/input/snap_turning_deadzone", TYPE_REAL, PROPERTY_HINT_RANGE, "0.0,0.5,0.05", 0.25)
+	_define_project_setting("godot_xr_tools/input/default_snap_turning", TYPE_BOOL, PROPERTY_HINT_NONE, "", true)
 
+	_define_project_setting("godot_xr_tools/player/standard_height", TYPE_REAL, PROPERTY_HINT_RANGE, "1.0,2.5,0.1", 1.85)
+
+	# register our autoload user settings object
+	add_autoload_singleton("XRToolsUserSettings", "res://addons/godot-xr-tools/user_settings/user_settings.gd")
 
 func _exit_tree():
 	# our plugin is turned off

--- a/addons/godot-xr-tools/user_settings/user_settings.gd
+++ b/addons/godot-xr-tools/user_settings/user_settings.gd
@@ -1,0 +1,63 @@
+extends Node
+
+# our settings
+export var snap_turning : bool = true
+export var player_height_adjust : float = 0.0 setget set_player_height_adjust
+
+var settings_file_name = "user://xtools_user_settings.json"
+
+func set_player_height_adjust(new_value : float) -> void:
+	player_height_adjust = clamp(new_value, -1.0, 1.0)
+
+
+func reset_to_defaults():
+	# Reset to defaults
+	snap_turning = XRTools.get_default_snap_turning()
+	player_height_adjust = 0.0
+
+
+func _load():
+	# First reset our values
+	reset_to_defaults()
+
+	# Now attempt to load our settings file
+	var file = File.new()
+	if !file.file_exists(settings_file_name):
+		return
+
+	if file.open(settings_file_name, File.READ):
+		var text = file.get_as_text()
+		file.close()
+
+		var data : Dictionary = parse_json(text)
+
+		# Parse our input settings
+		if data.has("input"):
+			var input : Dictionary = data["input"]
+			if input.has("default_snap_turning"):
+				snap_turning = input["default_snap_turning"]
+
+		# Parse our player settings
+		if data.has("player"):
+			var player : Dictionary = data["player"]
+			if player.has("height_adjust"):
+				player_height_adjust = player["height_adjust"]
+
+func save():
+	var data = {
+		"input" : {
+			"default_snap_turning" : snap_turning
+		},
+		"player" : {
+			"height_adjust" : player_height_adjust
+		}
+	}
+
+	var file = File.new()
+	if file.open(settings_file_name, File.WRITE):
+		file.store_line(to_json(data))
+		file.close()
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	_load()

--- a/addons/godot-xr-tools/user_settings/user_settings_ui.gd
+++ b/addons/godot-xr-tools/user_settings/user_settings_ui.gd
@@ -1,0 +1,54 @@
+extends TabContainer
+
+export (NodePath) var camera
+export var player_head_height : float = 0.1
+
+func _update():
+	# Input
+	$Input/SnapTurning/SnapTurningCB.pressed = XRToolsUserSettings.snap_turning
+
+	# Player
+	$Player/PlayerHeight/PlayerHeightSlider.value = XRToolsUserSettings.player_height_adjust
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	if XRToolsUserSettings:
+		_update()
+	else:
+		$Save/Button.disabled = true
+
+
+func _on_Save_pressed():
+	if XRToolsUserSettings:
+		# Save
+		XRToolsUserSettings.save()
+
+
+func _on_Reset_pressed():
+	if XRToolsUserSettings:
+		XRToolsUserSettings.reset_to_defaults()
+		_update()
+
+# Input settings changed
+func _on_SnapTurningCB_pressed():
+	XRToolsUserSettings.snap_turning = $Input/SnapTurning/SnapTurningCB.pressed
+
+# Player settings changed
+func _on_PlayerHeightSlider_drag_ended(value_changed):
+	XRToolsUserSettings.player_height_adjust = $Player/PlayerHeight/PlayerHeightSlider.value
+
+
+func _on_PlayerHeightStandard_pressed():
+	if !camera:
+		return
+	
+	var camera_node = get_node_or_null(camera)
+	if !camera_node:
+		return
+	
+	var base_height = camera_node.transform.origin.y + player_head_height
+	var height_adjust = XRTools.get_player_standard_height() - base_height
+	XRToolsUserSettings.player_height_adjust = height_adjust
+	$Player/PlayerHeight/PlayerHeightSlider.value = XRToolsUserSettings.player_height_adjust
+
+

--- a/addons/godot-xr-tools/user_settings/user_settings_ui.tscn
+++ b/addons/godot-xr-tools/user_settings/user_settings_ui.tscn
@@ -1,0 +1,142 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/user_settings/user_settings_ui.gd" type="Script" id=1]
+
+[node name="UserSettingsUI" type="TabContainer"]
+rect_min_size = Vector2( 250, 200 )
+tab_align = 0
+script = ExtResource( 1 )
+
+[node name="Input" type="VBoxContainer" parent="."]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
+
+[node name="SnapTurning" type="HBoxContainer" parent="Input"]
+margin_right = 242.0
+margin_bottom = 24.0
+
+[node name="Label" type="Label" parent="Input/SnapTurning"]
+margin_top = 1.0
+margin_right = 100.0
+margin_bottom = 22.0
+rect_min_size = Vector2( 100, 21 )
+text = "Snap turning:"
+align = 2
+valign = 1
+
+[node name="SnapTurningCB" type="CheckBox" parent="Input/SnapTurning"]
+margin_left = 104.0
+margin_right = 128.0
+margin_bottom = 24.0
+
+[node name="HSeparator" type="HSeparator" parent="Input"]
+margin_top = 28.0
+margin_right = 242.0
+margin_bottom = 32.0
+
+[node name="Buttons" type="HBoxContainer" parent="Input"]
+margin_top = 36.0
+margin_right = 242.0
+margin_bottom = 61.0
+custom_constants/separation = 10
+alignment = 1
+
+[node name="Save" type="Button" parent="Input/Buttons"]
+margin_left = 41.0
+margin_right = 116.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 75, 25 )
+text = "Apply"
+
+[node name="Reset" type="Button" parent="Input/Buttons"]
+margin_left = 126.0
+margin_right = 201.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 75, 25 )
+text = "Reset"
+
+[node name="Player" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
+
+[node name="PlayerHeight" type="HBoxContainer" parent="Player"]
+margin_right = 242.0
+margin_bottom = 21.0
+
+[node name="Label" type="Label" parent="Player/PlayerHeight"]
+margin_right = 100.0
+margin_bottom = 21.0
+rect_min_size = Vector2( 100, 21 )
+text = "Height adjust:"
+align = 2
+valign = 1
+
+[node name="PlayerHeightSlider" type="HSlider" parent="Player/PlayerHeight"]
+margin_left = 104.0
+margin_right = 229.0
+margin_bottom = 16.0
+rect_min_size = Vector2( 125, 0 )
+min_value = -1.0
+max_value = 1.0
+step = 0.1
+
+[node name="PlayerHeightCalc" type="HBoxContainer" parent="Player"]
+margin_top = 25.0
+margin_right = 242.0
+margin_bottom = 50.0
+
+[node name="Label" type="Label" parent="Player/PlayerHeightCalc"]
+margin_top = 5.0
+margin_right = 100.0
+margin_bottom = 19.0
+rect_min_size = Vector2( 100, 0 )
+
+[node name="PlayerHeightStandard" type="Button" parent="Player/PlayerHeightCalc"]
+margin_left = 104.0
+margin_right = 229.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 125, 25 )
+text = "Set to standard"
+
+[node name="HSeparator" type="HSeparator" parent="Player"]
+margin_top = 54.0
+margin_right = 242.0
+margin_bottom = 58.0
+
+[node name="Buttons" type="HBoxContainer" parent="Player"]
+margin_top = 62.0
+margin_right = 242.0
+margin_bottom = 87.0
+custom_constants/separation = 10
+alignment = 1
+
+[node name="Save" type="Button" parent="Player/Buttons"]
+margin_left = 41.0
+margin_right = 116.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 75, 25 )
+text = "Apply"
+
+[node name="Reset" type="Button" parent="Player/Buttons"]
+margin_left = 126.0
+margin_right = 201.0
+margin_bottom = 25.0
+rect_min_size = Vector2( 75, 25 )
+text = "Reset"
+
+[connection signal="pressed" from="Input/SnapTurning/SnapTurningCB" to="." method="_on_SnapTurningCB_pressed"]
+[connection signal="pressed" from="Input/Buttons/Save" to="." method="_on_Save_pressed"]
+[connection signal="pressed" from="Input/Buttons/Reset" to="." method="_on_Reset_pressed"]
+[connection signal="drag_ended" from="Player/PlayerHeight/PlayerHeightSlider" to="." method="_on_PlayerHeightSlider_drag_ended"]
+[connection signal="pressed" from="Player/PlayerHeightCalc/PlayerHeightStandard" to="." method="_on_PlayerHeightStandard_pressed"]
+[connection signal="pressed" from="Player/Buttons/Save" to="." method="_on_Save_pressed"]
+[connection signal="pressed" from="Player/Buttons/Reset" to="." method="_on_Reset_pressed"]

--- a/project.godot
+++ b/project.godot
@@ -297,6 +297,7 @@ config/icon="res://icon.png"
 [autoload]
 
 ResourceQueue="*res://assets/resource_queue/resource_queue.gd"
+XRToolsUserSettings="*res://addons/godot-xr-tools/user_settings/user_settings.gd"
 
 [editor_plugins]
 

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=26 format=2]
+[gd_scene load_steps=28 format=2]
 
 [ext_resource path="res://scenes/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/assets/right_hand.tscn" type="PackedScene" id=2]
@@ -25,6 +25,8 @@
 [ext_resource path="res://scenes/main_menu/main_menu_level.gd" type="Script" id=23]
 [ext_resource path="res://scenes/poke_demo/poke_demo.tscn" type="PackedScene" id=24]
 [ext_resource path="res://scenes/poke_demo/poke_demo.png" type="Texture" id=25]
+[ext_resource path="res://scenes/main_menu/objects/settings_ui.tscn" type="PackedScene" id=26]
+[ext_resource path="res://addons/godot-xr-tools/assets/poke.tscn" type="PackedScene" id=27]
 
 [node name="MainMenuLevel" instance=ExtResource( 1 )]
 script = ExtResource( 23 )
@@ -32,6 +34,16 @@ environment = null
 
 [node name="LeftHand" parent="ARVROrigin/LeftHand" index="0" instance=ExtResource( 3 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
+
+[node name="Skeleton" parent="ARVROrigin/LeftHand/LeftHand/LeftHand/Armature_Left" index="0"]
+bones/7/bound_children = [ NodePath("BoneAttachment") ]
+
+[node name="BoneAttachment" type="BoneAttachment" parent="ARVROrigin/LeftHand/LeftHand/LeftHand/Armature_Left/Skeleton" index="1"]
+transform = Transform( 0.927501, -0.373365, 0.0184361, -0.00490146, -0.0614605, -0.998098, 0.373788, 0.925646, -0.0588348, -0.000317366, 0.0346926, 0.155956 )
+bone_name = "index_distal"
+
+[node name="Poke" parent="ARVROrigin/LeftHand/LeftHand/LeftHand/Armature_Left/Skeleton/BoneAttachment" index="0" instance=ExtResource( 27 )]
+transform = Transform( 1, -1.49012e-07, 9.31323e-09, 1.49012e-07, 1, -7.45058e-09, 5.58794e-09, 1.86265e-08, 1, 0.001, 0.02, -0.001 )
 
 [node name="MovementDirect" parent="ARVROrigin/LeftHand" index="1" instance=ExtResource( 6 )]
 enabled = true
@@ -42,6 +54,16 @@ strafe = true
 [node name="RightHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
 
+[node name="Skeleton" parent="ARVROrigin/RightHand/RightHand/RightHand/Armature_Left" index="0"]
+bones/7/bound_children = [ NodePath("BoneAttachment") ]
+
+[node name="BoneAttachment" type="BoneAttachment" parent="ARVROrigin/RightHand/RightHand/RightHand/Armature_Left/Skeleton" index="1"]
+transform = Transform( 0.927501, -0.373365, 0.0184361, -0.00490146, -0.0614605, -0.998098, 0.373788, 0.925646, -0.0588348, -0.000317366, 0.0346926, 0.155956 )
+bone_name = "index_distal"
+
+[node name="Poke" parent="ARVROrigin/RightHand/RightHand/RightHand/Armature_Left/Skeleton/BoneAttachment" index="0" instance=ExtResource( 27 )]
+transform = Transform( 1, -1.49012e-07, 9.31323e-09, 1.49012e-07, 1, -7.45058e-09, 5.58794e-09, 1.86265e-08, 1, -0.001, 0.023, 0 )
+
 [node name="MovementDirect" parent="ARVROrigin/RightHand" index="1" instance=ExtResource( 6 )]
 enabled = true
 order = 10
@@ -49,7 +71,6 @@ max_speed = 3.0
 strafe = false
 
 [node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 5 )]
-smooth_rotation = true
 
 [node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 8 )]
 
@@ -105,5 +126,14 @@ scene_base = NodePath("../..")
 scene = ExtResource( 24 )
 title = ExtResource( 25 )
 
+[node name="SettingsUI" parent="." index="3" instance=ExtResource( 26 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.5 )
+camera = NodePath("../ARVROrigin/ARVRCamera")
+
 [connection signal="child_entered_tree" from="Demos" to="." method="_on_Demos_child_entered_tree"]
 [connection signal="child_exiting_tree" from="Demos" to="." method="_on_Demos_child_exiting_tree"]
+
+[editable path="ARVROrigin/LeftHand/LeftHand"]
+[editable path="ARVROrigin/LeftHand/LeftHand/LeftHand"]
+[editable path="ARVROrigin/RightHand/RightHand"]
+[editable path="ARVROrigin/RightHand/RightHand/RightHand"]

--- a/scenes/main_menu/objects/settings_ui.gd
+++ b/scenes/main_menu/objects/settings_ui.gd
@@ -1,0 +1,13 @@
+extends Spatial
+
+export (NodePath) var camera
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	var camera_node = get_node_or_null(camera)
+	if camera_node:
+		var scene = $Screen/Viewport2Din3D.get_scene_instance()
+		if scene:
+			var settings_ui = scene.get_node_or_null("UserSettingsUI")
+			if settings_ui:
+				settings_ui.camera = camera_node.get_path()

--- a/scenes/main_menu/objects/settings_ui.tscn
+++ b/scenes/main_menu/objects/settings_ui.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/objects/viewport_2d_in_3d.tscn" type="PackedScene" id=1]
+[ext_resource path="res://scenes/main_menu/objects/settings_ui_content.tscn" type="PackedScene" id=2]
+[ext_resource path="res://scenes/main_menu/objects/settings_ui.gd" type="Script" id=3]
+
+[sub_resource type="CubeMesh" id=1]
+size = Vector3( 0.65, 0.525, 0.02 )
+
+[sub_resource type="SpatialMaterial" id=2]
+albedo_color = Color( 0.203922, 0.203922, 0.203922, 1 )
+metallic = 0.35
+roughness = 0.52
+
+[node name="SettingsUI" type="Spatial"]
+script = ExtResource( 3 )
+
+[node name="Screen" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 1.3, 0 )
+mesh = SubResource( 1 )
+material/0 = SubResource( 2 )
+
+[node name="Viewport2Din3D" parent="Screen" instance=ExtResource( 1 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.015 )
+screen_size = Vector2( 0.625, 0.5 )
+viewport_size = Vector2( 250, 200 )
+scene = ExtResource( 2 )
+
+[node name="CSGCylinder" type="CSGCylinder" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.9, 0 )
+radius = 0.05
+height = 1.8
+material = SubResource( 2 )
+
+[node name="CSGBox" type="CSGBox" parent="CSGCylinder"]
+transform = Transform( 1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0.761732, 0 )
+operation = 2
+width = 0.5
+height = 1.0
+depth = 0.5

--- a/scenes/main_menu/objects/settings_ui_content.tscn
+++ b/scenes/main_menu/objects/settings_ui_content.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/user_settings/user_settings_ui.tscn" type="PackedScene" id=1]
+
+[node name="SettingsUIContent" type="VBoxContainer"]
+
+[node name="Header" type="HBoxContainer" parent="."]
+margin_right = 250.0
+margin_bottom = 48.0
+
+[node name="Label" type="Label" parent="Header"]
+margin_right = 250.0
+margin_bottom = 48.0
+rect_min_size = Vector2( 250, 0 )
+text = "Welcome to Godot XR Tools. Use the joysticks on your controllers to move around."
+autowrap = true
+
+[node name="UserSettingsUI" parent="." instance=ExtResource( 1 )]
+margin_top = 52.0
+margin_right = 250.0
+margin_bottom = 252.0

--- a/scenes/poke_demo/poke_demo.tscn
+++ b/scenes/poke_demo/poke_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://scenes/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/assets/right_hand.tscn" type="PackedScene" id=2]
@@ -13,11 +13,15 @@
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_direct.tscn" type="PackedScene" id=11]
 [ext_resource path="res://assets/meshes/table/table.tscn" type="PackedScene" id=12]
 [ext_resource path="res://scenes/pickable_demo/objects/grab_cube.tscn" type="PackedScene" id=13]
+[ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.tscn" type="PackedScene" id=14]
 
 [node name="PokeDemo" instance=ExtResource( 1 )]
 
 [node name="LeftHand" parent="ARVROrigin/LeftHand" index="0" instance=ExtResource( 3 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
+
+[node name="Skeleton" parent="ARVROrigin/LeftHand/LeftHand/LeftHand/Armature_Left" index="0"]
+bones/7/bound_children = [ NodePath("BoneAttachment") ]
 
 [node name="BoneAttachment" type="BoneAttachment" parent="ARVROrigin/LeftHand/LeftHand/LeftHand/Armature_Left/Skeleton" index="1"]
 transform = Transform( 0.927501, -0.373365, 0.0184361, -0.00490146, -0.0614605, -0.998098, 0.373788, 0.925646, -0.0588348, -0.000317366, 0.0346926, 0.155956 )
@@ -28,6 +32,9 @@ transform = Transform( 1, -1.49012e-07, 9.31323e-09, 1.49012e-07, 1, -7.45058e-0
 
 [node name="RightHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
+
+[node name="Skeleton" parent="ARVROrigin/RightHand/RightHand/RightHand/Armature_Left" index="0"]
+bones/7/bound_children = [ NodePath("BoneAttachment") ]
 
 [node name="BoneAttachment" type="BoneAttachment" parent="ARVROrigin/RightHand/RightHand/RightHand/Armature_Left/Skeleton" index="1"]
 transform = Transform( 0.927501, -0.373365, 0.0184361, -0.00490146, -0.0614605, -0.998098, 0.373788, 0.925646, -0.0588348, -0.000317366, 0.0346926, 0.155956 )
@@ -40,7 +47,9 @@ transform = Transform( 1, -2.08616e-07, 1.11759e-08, 1.78814e-07, 1, -1.11759e-0
 enabled = true
 order = 10
 max_speed = 5.0
-strafe = true
+strafe = false
+
+[node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 14 )]
 
 [node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 10 )]
 

--- a/scenes/teleport_demo/teleport_demo.tscn
+++ b/scenes/teleport_demo/teleport_demo.tscn
@@ -18,8 +18,6 @@ viewport_path = NodePath("Instructions/Viewport")
 [node name="FunctionTeleport" parent="ARVROrigin/LeftHand" index="0" instance=ExtResource( 2 )]
 camera = NodePath("../../ARVRCamera")
 
-[node name="MovementTurn" parent="ARVROrigin/LeftHand" index="1" instance=ExtResource( 5 )]
-
 [node name="MovementTurn" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 5 )]
 
 [node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 4 )]


### PR DESCRIPTION
## Add defaults in Project Settings
Added a snap deadzone and default snap turning settings to our project settings:

![image](https://user-images.githubusercontent.com/1945449/197924631-5b97fba9-cbb6-457a-ad31-742dbbe83c34.png)

## Add user settings system to save user preference

Added a user settings class that saves user settings to `user://xtools_user_settings.json`

There is also a default UI class that allows developers to just embed the scene into something of their choosing:
![image](https://user-images.githubusercontent.com/1945449/197924992-3ff4cf17-51d2-4b34-808c-e0a72b5a7a94.png)

In our demo application we nicely integrate this UI on a pedestal:
![image](https://user-images.githubusercontent.com/1945449/197925089-cc8d182d-f4a4-4642-a2f0-d80a533c8fef.png)

But similarly we could embed access to this UI in game. We may add a demo for this where the UI can be access on the players wrist or something like that. That's for another day though.

## By default have turn movement adhere to user/system settings

Our `MovementTurn` class now has a new turn mode setting that replaces the smooth tickbox:
![image](https://user-images.githubusercontent.com/1945449/197925169-60e78576-e6e0-4b66-8fa6-cf8cf9d457a7.png)

This can be:
- Default, we will check the user settings for this (which defaults to our project settings)
- Snap, which sets this to snap turning regardless of our user setting
- Smooth, which sets this to smooth turning regardless of our user setting

## Add user setting for player height adjustment

I also added a height adjust user setting:

![image](https://user-images.githubusercontent.com/1945449/197925318-6f78648a-856d-4ba4-ad8d-a10d9fdaf033.png)

This simply increases/decreases the player height calculated in the `PlayerBody` node. This allows you to play games designed for standing up while being seated, or if you're a small/tall person adjust your in game size to make the experience more comfortable. 

*edit* I also added a project setting "player standard height". This setting allows the developer to set the height of the player they are designing the game for.
There is now a button on the user settings UI that takes the current height of the player based on the camera position, compares it to the "standard height" and calculates an adjustment value that makes the player the "standard" height.