### PR TITLE
Added support for crouch-toggle to XRToolsMovementCrouch.

### DIFF
--- a/addons/godot-xr-tools/functions/movement_crouch.gd
+++ b/addons/godot-xr-tools/functions/movement_crouch.gd
@@ -2,16 +2,20 @@ tool
 class_name XRToolsMovementCrouch
 extends XRToolsMovementProvider
 
+## XR Tools Movement Provider for Crouching
 ##
-## Movement Provider for Crouching
+## This script works with the [XRToolsPlayerBody] attached to the players 
+## [ARVROrigin].
 ##
-## @desc:
-##     This script works with the PlayerBody attached to the players ARVROrigin.
-##
+## While the player presses the crounch button, the height is overridden to
+## the specified crouch height.
 
-##     When the player presses the selected button, the height is overridden
-##     to the crouch height
-##
+
+## Enumeration of crouching modes
+enum CrouchType {
+	HOLD_TO_CROUCH,	## Hold button to crouch
+	TOGGLE_CROUCH,	## Toggle crouching on button press
+}
 
 
 ## Movement provider order
@@ -23,9 +27,15 @@ export var crouch_height : float = 1.0
 ## Crouch button
 export (XRTools.Buttons) var crouch_button : int = XRTools.Buttons.VR_PAD
 
+## Type of crouching
+export (CrouchType) var crouch_type : int = CrouchType.HOLD_TO_CROUCH
+
 
 ## Crouching flag
 var _crouching : bool = false
+
+## Crouch button down state
+var _crouch_button_down : bool = false
 
 
 # Controller node
@@ -38,17 +48,30 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 	if !_controller.get_is_active():
 		return
 
-	# Check for crouching change
-	var crouching := _controller.is_button_pressed(crouch_button) != 0
-	if crouching == _crouching:
-		return
+	# Detect crouch button down and pressed states
+	var crouch_button_down := _controller.is_button_pressed(crouch_button) != 0
+	var crouch_button_pressed := crouch_button_down and !_crouch_button_down
+	_crouch_button_down = crouch_button_down
+
+	# Calculate new crouching state
+	var crouching := _crouching
+	match crouch_type:
+		CrouchType.HOLD_TO_CROUCH:
+			# Crouch when button down
+			crouching = crouch_button_down
+
+		CrouchType.TOGGLE_CROUCH:
+			# Toggle when button pressed
+			if crouch_button_pressed:
+				crouching = !crouching
 
 	# Update crouching state
-	_crouching = crouching
-	if crouching:
-		player_body.override_player_height(self, crouch_height)
-	else:
-		player_body.override_player_height(self)
+	if crouching != _crouching:
+		_crouching = crouching
+		if crouching:
+			player_body.override_player_height(self, crouch_height)
+		else:
+			player_body.override_player_height(self)
 
 
 # This method verifies the movement provider has a valid configuration.

--- a/scenes/basic_movement_demo/basic_movement_demo.tscn
+++ b/scenes/basic_movement_demo/basic_movement_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/staging/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/assets/right_hand.tscn" type="PackedScene" id=2]
@@ -12,8 +12,10 @@
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_jump.tscn" type="PackedScene" id=10]
 [ext_resource path="res://assets/meshes/teleport/teleport.tscn" type="PackedScene" id=11]
 [ext_resource path="res://scenes/main_menu/return to main menu.png" type="Texture" id=12]
+[ext_resource path="res://addons/godot-xr-tools/functions/movement_crouch.tscn" type="PackedScene" id=13]
 
 [sub_resource type="ViewportTexture" id=3]
+flags = 4
 viewport_path = NodePath("Instructions/Viewport")
 
 [node name="BasicMovementDemo" instance=ExtResource( 1 )]
@@ -30,6 +32,10 @@ strafe = true
 [node name="MovementJump" parent="ARVROrigin/LeftHand" index="2" instance=ExtResource( 10 )]
 jump_button_id = 7
 
+[node name="MovementCrouch" parent="ARVROrigin/LeftHand" index="3" instance=ExtResource( 13 )]
+crouch_height = 1.3
+crouch_button = 1
+
 [node name="RightHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
 
@@ -40,10 +46,14 @@ max_speed = 3.0
 strafe = false
 
 [node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 4 )]
-smooth_rotation = true
 
 [node name="MovementJump" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 10 )]
 jump_button_id = 7
+
+[node name="MovementCrouch" parent="ARVROrigin/RightHand" index="4" instance=ExtResource( 13 )]
+crouch_height = 1.3
+crouch_button = 1
+crouch_type = 1
 
 [node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 6 )]
 
@@ -78,31 +88,18 @@ margin_left = 10.0
 margin_top = 10.0
 margin_right = 360.0
 margin_bottom = 260.0
-bbcode_enabled = true
-bbcode_text = "[u]Basic Movement Demo[/u]
-
-This scene demonstrates basic movement including:
- * Left Controller:
-   - Joystick U/D/L/R: Smooth Movement with strafing
-   - A/X Button: Jump
- * Right Controller:
-   - Joystick U/D: Smooth Movement
-   - Joystick L/R: Smooth Turning
-   - A/X Button: Jump
-
-Test objects have been placed in the scene to allow testing of the different movement mechanics. The ramps and slopes are useful for evaluating how movement settings affect how easily the player can navigate on different terrain."
 text = "Basic Movement Demo
 
 This scene demonstrates basic movement including:
  * Left Controller:
-   - Joystick U/D/L/R: Smooth Movement with strafing
+   - Joystick U/D/L/R: Movement
    - A/X Button: Jump
+   - B/Y Button: Crouch (Hold)
  * Right Controller:
-   - Joystick U/D: Smooth Movement
-   - Joystick L/R: Smooth Turning
+   - Joystick U/D: Movement
+   - Joystick L/R: Turning
    - A/X Button: Jump
-
-Test objects have been placed in the scene to allow testing of the different movement mechanics. The ramps and slopes are useful for evaluating how movement settings affect how easily the player can navigate on different terrain."
+   - B/Y Button: Couch (Toggle)"
 
 [node name="Sprite3D" type="Sprite3D" parent="Instructions" index="1"]
 flip_v = true


### PR DESCRIPTION
This pull request implements feature #203 by adding a "Crouch Type" option to specify whether to crouch by holding or by toggling the button.

Additionally the basic movement demo was updated to include a crouch on each hand (left-hold and right-toggle) and the instructions updated.