### PR TITLE
Improve transparency settings and add unshaded settings

### DIFF
--- a/scenes/pointer_demo/pointer_demo.tscn
+++ b/scenes/pointer_demo/pointer_demo.tscn
@@ -44,7 +44,6 @@ max_speed = 3.0
 strafe = false
 
 [node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 9 )]
-smooth_rotation = true
 
 [node name="FunctionPointer" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 5 )]
 laser_length = 1


### PR DESCRIPTION
Added an alpha scissor setting to transparency (should convert existing boolean values correctly) and added a tickbox to ensure the content of our viewport is shown as is without lighting (unshaded).