### PR TITLE
Added hand_material_override export property to XRToolsHand script.

### DIFF
--- a/addons/godot-xr-tools/assets/hand.gd
+++ b/addons/godot-xr-tools/assets/hand.gd
@@ -2,32 +2,46 @@ class_name XRToolsHand, "res://addons/godot-xr-tools/editor/icons/hand.svg"
 extends Spatial
 
 
+## XR Tools Hand Script
 ##
-## XR Hand Script
-##
-## @desc:
-##     This script manages a godot-xr-tools hand. It animates the hand blending
-##     grip and trigger animations based on controller input.
-##
-##     Additionally the hand script detects world-scale changes in the ARVRServer
-##     and re-scales the hand appropriately so the hand stays scaled to the
-##     physical hand of the user.
-##
+## This script manages a godot-xr-tools hand. It animates the hand blending
+## grip and trigger animations based on controller input. Additionally the 
+## hand script detects world-scale changes in the XRServer and re-scales the
+## hand appropriately so the hand stays scaled to the physical hand of the
+## user.
 
 
-# Signal emitted when the hand scale changes
+## Signal emitted when the hand scale changes
 signal hand_scale_changed(scale)
+
+
+## Override the hand material
+export (Material) var hand_material_override setget set_hand_material_override
 
 
 # Last world scale (for scaling hands)
 var _last_world_scale : float = 1.0
 
+## Initial hand transform (from controller) - used for scaling hands
+var _transform : Transform
 
-# Capture the initial transform
-onready var _transform : Transform = transform
+## Hand mesh
+var _hand_mesh : MeshInstance
 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
+## Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	# Save the initial hand transform
+	_transform = transform
+
+	# Find the hand mesh and update the hand material
+	_hand_mesh = _find_mesh_instance(self)
+	_update_hand_material_override()
+
+
+## This method is called on every frame. It checks for world-scale changes and
+## scales itself causing the hand mesh and skeleton to scale appropriately.
+## It then reads the grip and trigger action values to animate the hand.
 func _process(_delta: float) -> void:
 	# Scale the hand mesh with the world scale. This is required for OpenXR plugin
 	# 1.3.0 and later where the plugin no-longer scales the controllers with
@@ -53,3 +67,31 @@ func _process(_delta: float) -> void:
 
 		# var grip_state = controller.is_button_pressed(JOY_VR_GRIP)
 		# print("Pressed: " + str(grip_state))
+
+
+## Set the hand material override
+func set_hand_material_override(material : Material) -> void:
+	hand_material_override = material
+	if is_inside_tree():
+		_update_hand_material_override()
+
+
+func _update_hand_material_override() -> void:
+	if _hand_mesh:
+		_hand_mesh.material_override = hand_material_override
+
+
+func _find_mesh_instance(node : Node) -> MeshInstance:
+	# Test if the node is a mesh
+	var mesh := node as MeshInstance
+	if mesh:
+		return mesh
+
+	# Check all children
+	for i in node.get_child_count():
+		mesh = _find_mesh_instance(node.get_child(i))
+		if mesh:
+			return mesh
+
+	# Could not find mesh
+	return null

--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=22 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/staging/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/assets/left_hand.tscn" type="PackedScene" id=2]
@@ -16,6 +16,7 @@
 [ext_resource path="res://assets/meshes/teleport/teleport.tscn" type="PackedScene" id=14]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_jump.tscn" type="PackedScene" id=15]
 [ext_resource path="res://scenes/climbing_gliding_demo/objects/hill.tscn" type="PackedScene" id=16]
+[ext_resource path="res://scenes/climbing_gliding_demo/materials/ghost_hand.tres" type="Material" id=17]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_wind.tscn" type="PackedScene" id=22]
 
 [sub_resource type="CubeMesh" id=1]
@@ -37,6 +38,7 @@ far = 400.0
 
 [node name="LeftHand" parent="ARVROrigin/LeftHand" index="0" instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
+hand_material_override = ExtResource( 17 )
 
 [node name="MovementDirect" parent="ARVROrigin/LeftHand" index="1" instance=ExtResource( 5 )]
 enabled = true
@@ -51,6 +53,7 @@ jump_button_id = 7
 
 [node name="RightHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 3 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
+hand_material_override = ExtResource( 17 )
 
 [node name="MovementDirect" parent="ARVROrigin/RightHand" index="1" instance=ExtResource( 5 )]
 enabled = true
@@ -59,7 +62,6 @@ max_speed = 3.0
 strafe = false
 
 [node name="MovementTurn" parent="ARVROrigin/RightHand" index="2" instance=ExtResource( 4 )]
-smooth_rotation = true
 
 [node name="FunctionPickup" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 9 )]
 

--- a/scenes/climbing_gliding_demo/materials/ghost_hand.tres
+++ b/scenes/climbing_gliding_demo/materials/ghost_hand.tres
@@ -1,0 +1,13 @@
+[gd_resource type="SpatialMaterial" load_steps=2 format=2]
+
+[sub_resource type="SpatialMaterial" id=1]
+flags_transparent = true
+params_depth_draw_mode = 1
+
+[resource]
+render_priority = -1
+next_pass = SubResource( 1 )
+flags_transparent = true
+flags_unshaded = true
+flags_no_depth_test = true
+albedo_color = Color( 0, 1, 1, 0.25098 )


### PR DESCRIPTION
This pull request implements #247 by:
- Adding a "Hand Material Override" property to XRToolsHand
- Demonstrating with a ghost-hand material added to the climbing/gliding demo scene

![image](https://user-images.githubusercontent.com/1863707/200189600-199d7ad3-2c6d-4471-9831-81078dcf89f4.png)
![image](https://user-images.githubusercontent.com/1863707/200189558-bd473b17-e32f-493e-a4d1-d4563971dace.png)
