### PR TITLE
[CI] Move LICENSE, CONTRIBUTORS.md and VERSIONS.md

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -23,9 +23,9 @@ jobs:
           mkdir plugin/godot-xr-tools
           mkdir plugin/godot-xr-tools/addons
           cp -r demo/godot-xr-tools/addons/godot-xr-tools plugin/godot-xr-tools/addons
-          cp demo/godot-xr-tools/LICENSE plugin/godot-xr-tools
-          cp demo/godot-xr-tools/CONTRIBUTORS.md plugin/godot-xr-tools
-          cp demo/godot-xr-tools/VERSIONS.md plugin/godot-xr-tools
+          cp demo/godot-xr-tools/LICENSE plugin/godot-xr-tools/addons/godot-xr-tools
+          cp demo/godot-xr-tools/CONTRIBUTORS.md plugin/godot-xr-tools/addons/godot-xr-tools
+          cp demo/godot-xr-tools/VERSIONS.md plugin/godot-xr-tools/addons/godot-xr-tools
           rm -rf demo/godot-xr-tools/.git
           rm -rf demo/godot-xr-tools/.github
       - name: Add OpenXR Plugin


### PR DESCRIPTION
On building the plugin that is published on the asset library, instead of copying these files into the project root, we now copy them into the plugin root. 