### PR TITLE
Modified climbing demo to use the new hand

### DIFF
--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=22 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/staging/scene_base.tscn" type="PackedScene" id=1]
-[ext_resource path="res://addons/godot-xr-tools/assets/left_hand.tscn" type="PackedScene" id=2]
-[ext_resource path="res://addons/godot-xr-tools/assets/right_hand.tscn" type="PackedScene" id=3]
+[ext_resource path="res://addons/godot-xr-tools/hands/right_hand_low.tscn" type="PackedScene" id=2]
+[ext_resource path="res://addons/godot-xr-tools/hands/left_hand_low.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_turn.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_direct.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/godot-xr-tools/assets/player_body.tscn" type="PackedScene" id=6]
@@ -36,8 +36,7 @@ transform = Transform( -4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -89, 36
 [node name="ARVRCamera" parent="ARVROrigin" index="0"]
 far = 400.0
 
-[node name="LeftHand" parent="ARVROrigin/LeftHand" index="0" instance=ExtResource( 2 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
+[node name="LeftHand" parent="ARVROrigin/LeftHand" index="0" instance=ExtResource( 3 )]
 hand_material_override = ExtResource( 17 )
 
 [node name="MovementDirect" parent="ARVROrigin/LeftHand" index="1" instance=ExtResource( 5 )]
@@ -51,8 +50,7 @@ strafe = true
 [node name="MovementJump" parent="ARVROrigin/LeftHand" index="3" instance=ExtResource( 15 )]
 jump_button_id = 7
 
-[node name="RightHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 3 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
+[node name="RightHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 2 )]
 hand_material_override = ExtResource( 17 )
 
 [node name="MovementDirect" parent="ARVROrigin/RightHand" index="1" instance=ExtResource( 5 )]

--- a/scenes/climbing_gliding_demo/materials/ghost_hand.tres
+++ b/scenes/climbing_gliding_demo/materials/ghost_hand.tres
@@ -1,8 +1,11 @@
-[gd_resource type="SpatialMaterial" load_steps=2 format=2]
+[gd_resource type="SpatialMaterial" load_steps=3 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/hands/textures/glove_caucasian_green_camo.png" type="Texture" id=1]
 
 [sub_resource type="SpatialMaterial" id=1]
 flags_transparent = true
 params_depth_draw_mode = 1
+albedo_texture = ExtResource( 1 )
 
 [resource]
 render_priority = -1


### PR DESCRIPTION
This pull request changes the climbing demo to use the new hand model. This allows demonstrating the hand material override better by having the alternate material put gloves on the hand as well as providing the ghost-hand effect.

![image](https://user-images.githubusercontent.com/1863707/200712520-68ebd732-ef96-42ef-a7a1-fee38e7f7b49.png)
