### PR TITLE
properly handle 2d scenes that are instanced in the tree

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -253,6 +253,10 @@ func _update_scene() -> void:
 		scene_node = scene.instance()
 		$Viewport.add_child(scene_node)
 
+	# (or use the scene if there is one already under the Viewport)
+	elif $Viewport.get_child_count() == 1:
+		scene_node = $Viewport.get_child(0)
+	
 	# make sure we update atleast once
 	$Viewport.render_target_update_mode = Viewport.UPDATE_ONCE
 


### PR DESCRIPTION
This is a very small change so that the viewport_2d_in_3d feature can handle the case where you set the node to `editable children` and instance the 2D scene under the Viewport node while leaving the `export var scene : PackedScene` value blank. 

The reason for this feature is it lets you set a your own values into the exported variables in the 2D scene so you don't have to only take the default options (for example, using the same label scene for a number of different labels), and for being able to wire in signals directly through the godot Node interface. 

A more user friendly version of this feature would be for the viewport_2d_in_3d node to look for any children that are 2D controls and reparent them under its Viewport node on startup.  This would mean you be able to do this without turning on `editable children`.


