### PR TITLE
Update function_pickup.gd to not require controller as direct parent

### DIFF
--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -26,6 +26,9 @@ const MAX_GRAB_DISTANCE2: float = 1000000.0
 ## Pickup enabled property
 export var enabled : bool = true
 
+## Controller tied to this pickup function
+export (NodePath) var _controller_node_path = get_parent().get_path()
+
 ## Grip controller button
 export (XRTools.Axis) var pickup_axis_id = XRTools.Axis.VR_GRIP_AXIS
 
@@ -71,17 +74,16 @@ var _grab_area : Area
 var _grab_collision : CollisionShape
 var _ranged_area : Area
 var _ranged_collision : CollisionShape
-var _controller : ARVRController
+
 
 
 ## Grip threshold (from configuration)
 onready var grip_threshold = XRTools.get_grip_threshold()
-
+onready var _controller : ARVRController = get_node(_controller_node_path)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	_controller = get_parent()
-
+	
 	# Create the grab collision shape
 	_grab_collision = CollisionShape.new()
 	_grab_collision.set_name("GrabCollisionShape")


### PR DESCRIPTION
-make XR tools function pickup not have to be a child of controller

-Allow user to set nodepath of a controller node, by default assume the nodepath is the nodepath of the parent so that if pickup is childed to a controller, the user does not have to do anything else.

- helpful for use with avatar so that function pickup can be the child of a bone attachment or for games that may have instruments attached to hands, e.g., claw mechanism, where pickup point should be at the claw and not at the controller location.