### PR TITLE
Added additional node-searching helper functions.

### DIFF
--- a/addons/godot-xr-tools/misc/arvr_helpers.gd
+++ b/addons/godot-xr-tools/misc/arvr_helpers.gd
@@ -2,15 +2,12 @@ tool
 class_name ARVRHelpers
 
 
+## XR Tools Helper Rountines
 ##
-## ARVR Helper Rountines
+## This script contains static functions to help find ARVR player nodes.
 ##
-## @desc:
-##     This script contains static functions to help find ARVR player nodes.
-##
-##     As these functions are static, the caller must pass in a node located
-##     somewhere under the players ARVROrigin.
-##
+## As these functions are static, the caller must pass in a node located
+## somewhere under the players [ARVROrigin].
 
 
 ## Find the ARVR Origin from a player node and an optional path
@@ -24,18 +21,14 @@ static func get_arvr_origin(node: Node, path: NodePath = NodePath("")) -> ARVROr
 			return origin
 
 	# Walk up the tree from the provided node looking for the origin
-	var current = node
-	while current:
-		origin = current as ARVROrigin
-		if origin:
-			return origin
-		current = current.get_parent()
+	origin = find_ancestor(node, "*", "ARVROrigin")
+	if origin:
+		return origin
 
 	# We check our children but only one level
-	for child in node.get_children():
-		origin = child as ARVROrigin
-		if origin:
-			return origin
+	origin = find_child(node, "*", "ARVROrigin", false)
+	if origin:
+		return origin
 
 	# Could not find origin
 	return null
@@ -61,10 +54,9 @@ static func get_arvr_camera(node: Node, path: NodePath = NodePath("")) -> ARVRCa
 		return camera
 
 	# Search all children of the origin for the camera
-	for child in origin.get_children():
-		camera = child as ARVRCamera
-		if camera:
-			return camera
+	camera = find_child(origin, "*", "ARVRCamera", false)
+	if camera:
+		return camera
 
 	# Could not find camera
 	return null
@@ -77,7 +69,90 @@ static func get_left_controller(node: Node, path: NodePath = NodePath("")) -> AR
 static func get_right_controller(node: Node, path: NodePath = NodePath("")) -> ARVRController:
 	return _get_controller(node, "RightHandController", 2, path)
 
-## Find a controller given some search parameters
+## Find all children of the specified node matching the given criteria
+##
+## This function returns an array containing all children of the specified
+## node matching the given criteria. This function can be slow and find_child
+## is faster if only one child is needed.
+##
+## The pattern argument specifies the match pattern to check against the
+## node name. Use "*" to match anything.
+##
+## The type argument specifies the type of node to find. Use "" to match any
+## type.
+##
+## The recursive argument specifies whether the search deeply though all child
+## nodes, or whether to only check the immediate children.
+##
+## The owned argument specifies whether the node must be owned.
+static func find_children(
+		node : Node, 
+		pattern : String, 
+		type : String = "", 
+		recursive : bool = true, 
+		owned : bool = true) -> Array:
+	# Find the children
+	var found := []
+	if node:
+		_find_children(found, node, pattern, type, recursive, owned)
+	return found
+
+## Find a child of the specified node matching the given criteria
+##
+## This function finds the first child of the specified node matching the given
+## criteria.
+##
+## The pattern argument specifies the match pattern to check against the
+## node name. Use "*" to match anything.
+##
+## The type argument specifies the type of node to find. Use "" to match any
+## type.
+##
+## The recursive argument specifies whether the search deeply though all child
+## nodes, or whether to only check the immediate children.
+##
+## The owned argument specifies whether the node must be owned.
+static func find_child(
+		node : Node, 
+		pattern : String, 
+		type : String = "", 
+		recursive : bool = true, 
+		owned : bool = true) -> Node:
+	# Find the child
+	if node:
+		return _find_child(node, pattern, type, recursive, owned)
+
+	# Invalid node
+	return null
+
+## Find an ancestor of the specified node matching the given criteria
+##
+## This function finds the first ancestor of the specified node matching the 
+## given criteria.
+##
+## The pattern argument specifies the match pattern to check against the
+## node name. Use "*" to match anything.
+##
+## The type argument specifies the type of node to find. Use "" to match any
+## type.
+static func find_ancestor(
+		node : Node, 
+		pattern : String, 
+		type : String = "") -> Node:
+	# Loop finding ancestor
+	while node:
+		# If node matches filter then break
+		if (node.name.match(pattern) and (type == "" or node.is_class(type))):
+			break
+
+		# Advance to parent
+		node = node.get_parent()
+
+	# Return found node (or null)
+	return node
+
+
+# Find a controller given some search parameters
 static func _get_controller(var node: Node, var default_name: String, var id: int, var path: NodePath) -> ARVRController:
 	var controller: ARVRController
 
@@ -104,4 +179,54 @@ static func _get_controller(var node: Node, var default_name: String, var id: in
 			return controller
 
 	# Could not find the controller
+	return null
+
+# Recursive helper function for find_children.
+static func _find_children(
+		found : Array,
+		node : Node,
+		pattern : String,
+		type : String,
+		recursive : bool,
+		owned : bool) -> void:
+	# Iterate over all children
+	for i in node.get_child_count():
+		# Get the child
+		var child := node.get_child(i)
+
+		# If child matches filter then add it to the array
+		if (child.name.match(pattern) and
+			(type == "" or child.is_class(type)) and
+			(not owned or child.owner)):
+			found.push_back(child)
+
+		# If recursive is enabled then descend into children
+		if recursive:
+			_find_children(found, child, pattern, type, recursive, owned)
+
+# Recursive helper functiomn for find_child
+static func _find_child(
+		node : Node,
+		pattern : String,
+		type : String,
+		recursive : bool,
+		owned : bool) -> Node:
+	# Iterate over all children
+	for i in node.get_child_count():
+		# Get the child
+		var child := node.get_child(i)
+
+		# If child matches filter then return it
+		if (child.name.match(pattern) and
+			(type == "" or child.is_class(type)) and
+			(not owned or child.owner)):
+			return child
+
+		# If recursive is enabled then descend into children
+		if recursive:
+			var found := _find_child(node, pattern, type, recursive, owned)
+			if found:
+				return found
+	
+	# Not found
 	return null


### PR DESCRIPTION
The additional find_children() and find_child() methods are intended to assist in finding nodes. For example some movement providers need to find function or movement nodes under the controllers. This can be achieved by:
```gdscript
# Get left controller
var left_controller : ARVRController = ARVRHelpers.get_left_controller(self)

# Get left controllers pickup
var left_pickup : XRToolsFunctionPickup = ARVRHelpers.find_child(left_controller, "*", "XRToolsFunctionPickup")

# Get left controllers direct movement
var left_direct : XRToolsMovementDirect = ARVRHelpers.find_child(left_controller, "*", "XRToolsMovementDirect")
```
