### PR TITLE
Add sprinting node

### DIFF
--- a/addons/godot-xr-tools/functions/movement_sprint.gd
+++ b/addons/godot-xr-tools/functions/movement_sprint.gd
@@ -59,9 +59,6 @@ var _left_controller_original_max_speed : float = 0.0
 ## Variable to hold right controller direct movement node original max speed
 var _right_controller_original_max_speed : float = 0.0
 
-## Variable to hold overall max speed between direct movement nodes if multiple
-var _overall_max_speed : float = 0.0
-
 ## Variable used to cache left controller direct movement function, if any 
 var _left_controller_direct_move : XRToolsMovementDirect = null 
 
@@ -129,6 +126,7 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, disabled: b
 		else:
 			set_sprinting(false)
 			
+			
 # Public function used to set sprinting active or not active
 func set_sprinting(active: bool) -> void:
 	# Skip if no change
@@ -149,15 +147,12 @@ func set_sprinting(active: bool) -> void:
 			_left_controller_original_max_speed = _left_controller_direct_move.max_speed
 		if _right_controller_direct_move:
 			_right_controller_original_max_speed = _right_controller_direct_move.max_speed
-	
-		# Set overall max speed based on current status during runtime
-		_overall_max_speed = max(_left_controller_original_max_speed, _right_controller_original_max_speed)
 		
 		# Set both controllers' direct movement functions, if appliable, to the sprinting speed
 		if _left_controller_direct_move:
-			_left_controller_direct_move.max_speed = _overall_max_speed*sprint_speed_multiplier
+			_left_controller_direct_move.max_speed = _left_controller_original_max_speed * sprint_speed_multiplier
 		if _right_controller_direct_move:
-			_right_controller_direct_move.max_speed = _overall_max_speed*sprint_speed_multiplier
+			_right_controller_direct_move.max_speed = _right_controller_original_max_speed * sprint_speed_multiplier
 	
 	else:
 		# We are not sprinting

--- a/addons/godot-xr-tools/functions/movement_sprint.gd
+++ b/addons/godot-xr-tools/functions/movement_sprint.gd
@@ -1,0 +1,168 @@
+tool
+class_name XRToolsMovementSprint
+extends XRToolsMovementProvider
+
+
+## XR Tools Movement Provider for Sprinting
+##
+## This script provides sprinting movement for the player. It assumes there is a direct movement
+## node in the scene otherwise it will not be functional. There will not be an error, there just
+## will not be any reason for it to have any impact on the player.  This node should be a direct
+## child of the FPController node rather than to a specific ARVRController.
+
+
+## Signal emitted when sprinting starts
+signal sprinting_started()
+
+## Signal emitted when sprinting finishes
+signal sprinting_finished()
+
+
+## Enumeration of controller to use for triggering sprinting.  This allows the developer to assign the sprint button to either controller
+enum SprintController {
+	LEFT,		# Use left controller
+	RIGHT,		# Use right controler
+}
+
+## Enumeration of sprinting modes - toggle or hold button
+enum SprintType {
+	HOLD_TO_SPRINT,	## Hold button to sprint
+	TOGGLE_SPRINT,	## Toggle sprinting on button press
+}
+
+## Type of sprinting
+export (SprintType) var sprint_type : int = SprintType.HOLD_TO_SPRINT
+
+## Sprint speed multiplier (multiplier from speed set by direct movement node(s))
+export (float, 1.0, 4.0) var sprint_speed_multiplier : float = 2.0
+
+## Movement provider order
+export var order : int = 11
+
+## Sprint controller
+export (SprintController) var controller : int = SprintController.LEFT
+
+## Sprint button
+export (XRTools.Buttons) var sprint_button : int = XRTools.Buttons.VR_PAD
+
+# Sprint controller
+var _controller : ARVRController
+
+## Sprinting flag
+var _sprinting : bool = false
+
+## Sprint button down state
+var _sprint_button_down : bool = false
+
+## Variable to hold left controller direct movement node original max speed
+var _left_controller_original_max_speed : float = 0.0
+
+## Variable to hold right controller direct movement node original max speed
+var _right_controller_original_max_speed : float = 0.0
+
+## Variable to hold overall max speed between direct movement nodes if multiple
+var _overall_max_speed : float = 0.0
+
+## Fetch left controller
+onready var _left_controller : ARVRController = ARVRHelpers.get_left_controller(self)
+
+## Fetch right controller
+onready var _right_controller : ARVRController = ARVRHelpers.get_right_controller(self)
+
+## Fetch left controller direct movement function if any using XRTools' ARVRHelpers function
+onready var _left_controller_direct_move : XRToolsMovementDirect = _left_controller.get_node_or_null("MovementDirect") #ARVRHelpers.find_child(_left_controller, "*", "XRToolsMovementDirect")
+
+## Fetch right controller direct movement function if any using XRTools' ARVRHelpers function
+onready var _right_controller_direct_move : XRToolsMovementDirect = _right_controller.get_node_or_null("MovementDirect") #ARVRHelpers.find_child(_right_controller, "*", "XRToolsMovementDirect")
+
+func _ready():
+	# Get the sprinting controller
+	if controller == SprintController.LEFT:
+		_controller = _left_controller
+	else:
+		_controller = _right_controller
+
+# Perform sprinting
+func physics_movement(_delta: float, player_body: XRToolsPlayerBody, disabled: bool):
+	# Skip if the controller isn't active or is not enabled 
+	if !_controller.get_is_active() or disabled == true or !enabled:
+		set_sprinting(false)
+		return
+		
+	# Detect sprint button down and pressed states
+	var sprint_button_down := _controller.is_button_pressed(sprint_button) != 0
+	var sprint_button_pressed := sprint_button_down and !_sprint_button_down
+	_sprint_button_down = sprint_button_down
+
+	# Calculate new sprinting state
+	var sprinting := _sprinting
+	match sprint_type:
+		SprintType.HOLD_TO_SPRINT:
+			# Sprint when button down
+			sprinting = sprint_button_down
+
+		SprintType.TOGGLE_SPRINT:
+			# Toggle when button pressed
+			if sprint_button_pressed:
+				sprinting = !sprinting
+
+	# Update sprinting state
+	if sprinting != _sprinting:
+		_sprinting = sprinting
+		if sprinting:
+			set_sprinting(true)
+		else:
+			set_sprinting(false)
+			
+
+func set_sprinting(active: bool) -> void:
+	# Skip if no change
+	if active == is_active:
+		return
+
+	# Update state
+	is_active = active
+
+	# Handle state change
+	if is_active:
+		emit_signal("sprinting_started")
+		_sprinting = true
+		
+		# Since max speeds could be changed while game is running, check now for original max speeds of left and right nodes	
+		if _left_controller_direct_move:
+			_left_controller_original_max_speed = _left_controller_direct_move.max_speed
+		if _right_controller_direct_move:
+			_right_controller_original_max_speed = _right_controller_direct_move.max_speed
+	
+		# Set overall max speed based on current status during runtime
+		_overall_max_speed = max(_left_controller_original_max_speed, _right_controller_original_max_speed)
+		
+		# Set both controllers' direct movement functions, if appliable, to the sprinting speed
+		if _left_controller_direct_move:
+			_left_controller_direct_move.max_speed = _overall_max_speed*sprint_speed_multiplier
+		if _right_controller_direct_move:
+			_right_controller_direct_move.max_speed = _overall_max_speed*sprint_speed_multiplier
+	
+	else:
+		emit_signal("sprinting_finished")
+		_sprinting = false
+		
+		# Set both controllers' direct movement functions, if applicable, to their original speeds
+		if _left_controller_direct_move:
+			_left_controller_direct_move.max_speed = _left_controller_original_max_speed
+		if _right_controller_direct_move:
+			_right_controller_direct_move.max_speed = _right_controller_original_max_speed
+
+
+
+# This method verifies the movement provider has a valid configuration.
+func _get_configuration_warning():
+	
+#	# Make sure player has a direct movement node
+#	var _left_direct = ARVRHelpers.find_child(ARVRHelpers.get_left_controller(self), "*", "XRToolsMovementDirect")
+#	var _right_direct = ARVRHelpers.find_child(ARVRHelpers.get_right_controller(self), "*", "XRToolsMovementDirect")
+#	if _left_direct == null and _right_direct == null:
+#		return "Unable to find XRToolsMovementDirect instance for player to support sprinting"
+#
+	# Call base class
+	return ._get_configuration_warning()

--- a/addons/godot-xr-tools/functions/movement_sprint.tscn
+++ b/addons/godot-xr-tools/functions/movement_sprint.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/functions/movement_sprint.gd" type="Script" id=1]
+
+[node name="MovementSprint" type="Node" groups=["movement_providers"]]
+script = ExtResource( 1 )

--- a/project.godot
+++ b/project.godot
@@ -180,6 +180,11 @@ _global_script_classes=[ {
 "path": "res://addons/godot-xr-tools/functions/movement_provider.gd"
 }, {
 "base": "XRToolsMovementProvider",
+"class": "XRToolsMovementSprint",
+"language": "GDScript",
+"path": "res://addons/godot-xr-tools/functions/movement_sprint.gd"
+}, {
+"base": "XRToolsMovementProvider",
 "class": "XRToolsMovementTurn",
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/functions/movement_turn.gd"
@@ -279,6 +284,7 @@ _global_script_class_icons={
 "XRToolsMovementJump": "",
 "XRToolsMovementPhysicalJump": "",
 "XRToolsMovementProvider": "res://addons/godot-xr-tools/editor/icons/movement_provider.svg",
+"XRToolsMovementSprint": "",
 "XRToolsMovementTurn": "",
 "XRToolsMovementWind": "",
 "XRToolsPhysicsHand": "",
@@ -336,4 +342,3 @@ quality/driver/driver_name="GLES2"
 vram_compression/import_etc=true
 vram_compression/import_etc2=false
 limits/time/time_rollover_secs=30.0
-environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
-Create XRToolsMovementSprint class

-Node should be child of FP Controller rather than any particular controller

-Allows user to select which controller to use to enable sprinting

-Allows user to select between toggle and hold modes for sprinting

-When enabled, sprinting will set both controllers' direct movement nodes' max speed variables to the sprint multiplier, which is a float clamped between 1-4x, and set by default at 2.0

-When sprinting is deactivated, the direct movement max speeds variables are returned to their original states (this means a player cannot be "sprinting" with one hand and "walking" with the other, without needing the information stored in the player_body node)

-Emits signals for when the player starts or stops sprinting so that, for instance, sound effects could be varied based on whether user is sprinting