### PR TITLE
Added hand-pose area support

### DIFF
--- a/addons/godot-xr-tools/hands/hand.gd
+++ b/addons/godot-xr-tools/hands/hand.gd
@@ -1,92 +1,31 @@
 tool
 class_name XRToolsHand, "res://addons/godot-xr-tools/editor/icons/hand.svg"
-extends Spatial
+extends Area
 
 
+## XR Tools Hand Script
 ##
-## XR Hand Script
+## This script manages a godot-xr-tools hand. It animates the hand blending
+## grip and trigger animations based on controller input.
 ##
-## @desc:
-##     This script manages a godot-xr-tools hand. It animates the hand blending
-##     grip and trigger animations based on controller input.
-##
-##     Additionally the hand script detects world-scale changes in the ARVRServer
-##     and re-scales the hand appropriately so the hand stays scaled to the
-##     physical hand of the user.
-##
+## Additionally the hand script detects world-scale changes in the ARVRServer
+## and re-scales the hand appropriately so the hand stays scaled to the
+## physical hand of the user.
+
 
 ## Signal emitted when the hand scale changes
 signal hand_scale_changed(scale)
 
+
 ## Override the hand material
-export (Material) var hand_material_override setget set_hand_material_override
+export var hand_material_override : Material setget set_hand_material_override
 
-## Hand extends
+## Default open-hand animation pose
+export var open_hand : Animation setget set_open_hand
 
-export (Animation) var open_hand setget set_open_hand
-export (Animation) var closed_hand setget set_closed_hand
+## Default close-hand animation pose
+export var closed_hand : Animation setget set_closed_hand
 
-func set_open_hand(p_new_hand : Animation):
-	open_hand = p_new_hand
-	if is_inside_tree():
-		_update_hands()
-
-func set_closed_hand(p_new_hand : Animation):
-	closed_hand = p_new_hand
-	if is_inside_tree():
-		_update_hands()
-
-func _update_hands():
-	# our first child node should be our hand
-	var hand_node : Spatial = get_child(0)
-	if !hand_node:
-		print("Couldn't find hand node")
-		return
-
-	var animation_player : AnimationPlayer = hand_node.get_node_or_null("AnimationPlayer")
-	if !animation_player:
-		print("Couldn't find animation player")
-		return
-
-	var animation_tree : AnimationTree = get_node_or_null("AnimationTree")
-	if !animation_tree:
-		print("Couldn't find animation tree")
-		return
-
-	var tree_root : AnimationNodeBlendTree = animation_tree.tree_root
-	if !tree_root:
-		print("Couldn't find tree root")
-		return
-
-	if open_hand:
-		var open_name = animation_player.find_animation(open_hand)
-		if open_name == "":
-			open_name = "open_hand"
-			if animation_player.has_animation(open_name):
-				animation_player.remove_animation(open_name)
-
-			animation_player.add_animation(open_name, open_hand)
-
-		var open_hand_obj : AnimationNodeAnimation = tree_root.get_node("OpenHand")
-		if open_hand_obj:
-			open_hand_obj.animation = open_name
-
-	if closed_hand:
-		var closed_name = animation_player.find_animation(closed_hand)
-		if closed_name == "":
-			closed_name = "closed_hand"
-			if animation_player.has_animation(closed_name):
-				animation_player.remove_animation(closed_name)
-
-			animation_player.add_animation(closed_name, closed_hand)
-
-		var closed_hand_obj : AnimationNodeAnimation = tree_root.get_node("ClosedHand1")
-		if closed_hand_obj:
-			closed_hand_obj.animation = closed_name
-
-		closed_hand_obj = tree_root.get_node("ClosedHand2")
-		if closed_hand_obj:
-			closed_hand_obj.animation = closed_name
 
 ## Last world scale (for scaling hands)
 var _last_world_scale : float = 1.0
@@ -97,22 +36,49 @@ var _transform : Transform
 ## Hand mesh
 var _hand_mesh : MeshInstance
 
+## Hand animation player
+var _animation_player : AnimationPlayer
+
+## Hand animation tree
+var _animation_tree : AnimationTree
+
+## Animation blend tree
+var _tree_root : AnimationNodeBlendTree
+
+## Open-hand pose stack - keys (Node requesting override)
+var _open_hand_stack_key := []
+
+## Open-hand pose stack - poses (Animation to use)
+var _open_hand_stack_pose := []
+
+## Closed-hand pose stack - keys (Node requesting override)
+var _closed_hand_stack_key := []
+
+## Closed-hand pose stack - poses (Animation to use)
+var _closed_hand_stack_pose := []
+
+
 ## Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	# Save the initial hand transform
 	_transform = transform
-	
-	# Find the hand mesh and update the hand material
-	_hand_mesh = _find_mesh_instance(self)
-	_update_hand_material_override()
+
+	# Find the relevant hand nodes
+	_hand_mesh = _find_child(self, "MeshInstance")
+	_animation_player = _find_child(self, "AnimationPlayer")
+	_animation_tree = _find_child(self, "AnimationTree")
 
 	# As we're going to make modifications to our animation tree, we need to do
 	# a deep copy, simply setting resource local to scene does not seem to be enough
-	var tree_root = $AnimationTree.tree_root.duplicate(true)
-	$AnimationTree.tree_root = tree_root
-	
-	# Make sure we're using the correct poses
-	_update_hands()
+	if _animation_tree:
+		_tree_root = _animation_tree.tree_root.duplicate(true)
+		_animation_tree.tree_root = _tree_root
+
+	# Apply all updates
+	_update_hand_material_override()
+	_update_open_hand()
+	_update_closed_hand()
+
 
 ## This method is called on every frame. It checks for world-scale changes and
 ## scales itself causing the hand mesh and skeleton to scale appropriately.
@@ -136,8 +102,9 @@ func _process(_delta: float) -> void:
 		var grip = controller.get_joystick_axis(JOY_VR_ANALOG_GRIP)
 		var trigger = controller.get_joystick_axis(JOY_VR_ANALOG_TRIGGER)
 
-		# Uncomment for workaround for bug in OpenXR plugin 1.1.1 and earlier giving values from -1.0 to 1.0
-		# note that when controller are not being tracking yet this will result in a value of 0.5
+		# Uncomment for workaround for bug in OpenXR plugin 1.1.1 and earlier
+		# giving values from -1.0 to 1.0. Note that when controllers are not
+		# being tracking yet this will result in a value of 0.5
 		# grip = (grip + 1.0) * 0.5
 		# trigger = (trigger + 1.0) * 0.5
 
@@ -147,6 +114,30 @@ func _process(_delta: float) -> void:
 		# var grip_state = controller.is_button_pressed(JOY_VR_GRIP)
 		# print("Pressed: " + str(grip_state))
 
+
+# This method verifies the hand has a valid configuration.
+func _get_configuration_warning():
+	# Check hand for mesh instance
+	if not _find_child(self, "MeshInstance"):
+		return "Hand does not have a MeshInstance"
+
+	# Check hand for animation player
+	if not _find_child(self, "AnimationPlayer"):
+		return "Hand does not have a AnimationPlayer"
+
+	# Check hand for animation tree
+	var tree : AnimationTree = _find_child(self, "AnimationTree")
+	if not tree:
+		return "Hand does not have a AnimationTree"
+
+	# Check hand animation tree has a root
+	if not tree.tree_root:
+		return "Hand AnimationTree has no root"
+
+	# Passed basic validation
+	return ""
+
+
 ## Set the hand material override
 func set_hand_material_override(material : Material) -> void:
 	hand_material_override = material
@@ -154,22 +145,138 @@ func set_hand_material_override(material : Material) -> void:
 		_update_hand_material_override()
 
 
+## Set the default open-hand pose
+func set_open_hand(p_new_hand : Animation) -> void:
+	open_hand = p_new_hand
+	if is_inside_tree():
+		_update_open_hand()
+
+
+## Set the default close-hand pose
+func set_closed_hand(p_new_hand : Animation):
+	closed_hand = p_new_hand
+	if is_inside_tree():
+		_update_closed_hand()
+
+
+## Add a hand animation pose override
+func add_hand_override(who : Node, open_pose : Animation, closed_pose : Animation) -> void:
+	# Skip if invalid
+	if !who:
+		return
+
+	# Add the open-pose to the open-hand stack and update the hands
+	if open_pose:
+		_open_hand_stack_key.push_back(who)
+		_open_hand_stack_pose.push_back(open_pose)
+		_update_open_hand()
+
+	# Add the closed-pose to the closed-hand stack and update the hands
+	if closed_pose:
+		_closed_hand_stack_key.push_back(who)
+		_closed_hand_stack_pose.push_back(closed_pose)
+		_update_closed_hand()
+
+
+## Remove a hand animation pose override
+func remove_hand_override(who : Node) -> void:
+	# Remove from the open-hand pose stack
+	if _remove_hand_pose(who, _open_hand_stack_key, _open_hand_stack_pose):
+		_update_open_hand()
+
+	# Remove from the closed-hand pose stack
+	if _remove_hand_pose(who, _closed_hand_stack_key, _closed_hand_stack_pose):
+		_update_closed_hand()
+
+
 func _update_hand_material_override() -> void:
 	if _hand_mesh:
 		_hand_mesh.material_override = hand_material_override
 
 
-func _find_mesh_instance(node : Node) -> MeshInstance:
-	# Test if the node is a mesh
-	var mesh := node as MeshInstance
-	if mesh:
-		return mesh
+func _update_open_hand() -> void:
+	# Skip if no blend tree
+	if !_tree_root:
+		return
 
-	# Check all children
-	for i in node.get_child_count():
-		mesh = _find_mesh_instance(node.get_child(i))
-		if mesh:
-			return mesh
+	# Find the open pose to use
+	var open_pose := open_hand
+	if _open_hand_stack_pose.size():
+		open_pose = _open_hand_stack_pose.back()
 
-	# Could not find mesh
+	# Apply the closed hand pose in the player and blend tree
+	if open_pose:
+		var open_name = _animation_player.find_animation(open_pose)
+		if open_name == "":
+			open_name = "open_hand"
+			if _animation_player.has_animation(open_name):
+				_animation_player.remove_animation(open_name)
+
+			_animation_player.add_animation(open_name, open_pose)
+
+		var open_hand_obj : AnimationNodeAnimation = _tree_root.get_node("OpenHand")
+		if open_hand_obj:
+			open_hand_obj.animation = open_name
+
+
+func _update_closed_hand() -> void:
+	# Skip if no blend tree
+	if !_tree_root:
+		return
+
+	# Find the close pose to use
+	var closed_pose := closed_hand
+	if _closed_hand_stack_pose.size():
+		closed_pose = _closed_hand_stack_pose.back()
+
+	# Apply the closed hand pose in the player and blend tree
+	if closed_hand:
+		var closed_name = _animation_player.find_animation(closed_pose)
+		if closed_name == "":
+			closed_name = "closed_hand"
+			if _animation_player.has_animation(closed_name):
+				_animation_player.remove_animation(closed_name)
+
+			_animation_player.add_animation(closed_name, closed_pose)
+
+		var closed_hand_obj : AnimationNodeAnimation = _tree_root.get_node("ClosedHand1")
+		if closed_hand_obj:
+			closed_hand_obj.animation = closed_name
+
+		closed_hand_obj = _tree_root.get_node("ClosedHand2")
+		if closed_hand_obj:
+			closed_hand_obj.animation = closed_name
+
+
+static func _find_child(node : Node, type : String) -> Node:
+	# Iterate through all children
+	for child in node.get_children():
+		# If the child is a match then return it
+		if child.is_class(type):
+			return child
+
+		# Recurse into child
+		var found := _find_child(child, type)
+		if found:
+			return found
+
+	# No child found matching type
 	return null
+
+
+static func _remove_hand_pose(who : Node, keys : Array, poses : Array) -> bool:
+	# Look for keys to remove
+	var modified := false
+	while true:
+		# Break if no key found
+		var pos := keys.find_last(who)
+		if pos < 0:
+			break
+
+		# Remove pose override from the stack
+		keys.remove(pos)
+		poses.remove(pos)
+		modified = true
+
+	# Return modified flag
+	return modified

--- a/addons/godot-xr-tools/hands/hand_physics_bone.gd
+++ b/addons/godot-xr-tools/hands/hand_physics_bone.gd
@@ -32,7 +32,7 @@ export var length : float = 0.03
 export var width_ratio : float = 0.3
 
 ## Additional collision layer for this one bone
-export (int, LAYERS_3D_PHYSICS) var collision_layer : int = 0
+export (int, LAYERS_3D_PHYSICS) var bone_collision_layer : int = 0
 
 ## Additional bone group for this one bone
 export var bone_group : String = ""
@@ -57,7 +57,7 @@ func _ready():
 
 	# Construct the bone shape
 	_bone_shape = CapsuleShape.new()
-	_bone_shape.margin = physics_hand.margin
+	_bone_shape.margin = physics_hand.bone_margin
 	_on_hand_scale_changed(ARVRServer.world_scale)
 
 	# Construct the bone collision shape
@@ -70,7 +70,7 @@ func _ready():
 	_physics_bone = KinematicBody.new()
 	_physics_bone.set_name("BoneBody")
 	_physics_bone.set_as_toplevel(true)
-	_physics_bone.collision_layer = physics_hand.collision_layer | collision_layer
+	_physics_bone.collision_layer = physics_hand.bone_collision_layer | bone_collision_layer
 	_physics_bone.collision_mask = 0
 	_physics_bone.add_child(bone_collision)
 

--- a/addons/godot-xr-tools/hands/physics_hand.gd
+++ b/addons/godot-xr-tools/hands/physics_hand.gd
@@ -13,10 +13,10 @@ extends XRToolsHand
 
 
 ## Collision layer for all bones in the hand
-export (int, LAYERS_3D_PHYSICS) var collision_layer : int = 1 << 17
+export (int, LAYERS_3D_PHYSICS) var bone_collision_layer : int = 1 << 17
 
 ## Bone collision margin
-export var margin : float = 0.004
+export var bone_margin : float = 0.004
 
 ## Bone group for all bones in the hand
 export var bone_group : String = ""

--- a/addons/godot-xr-tools/hands/scenes/highpoly/left_fullglove_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/left_fullglove_hand.tscn
@@ -1,20 +1,23 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/AnimationPlayer.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_L.gltf" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/hands/hand.gd" type="Script" id=3]
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/cleaning_glove.material" type="Material" id=4]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip.anim" type="Animation" id=5]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 5.anim" type="Animation" id=6]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=7]
 
-[node name="LeftHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="LeftHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
 }
-open_hand = ExtResource( 6 )
-closed_hand = ExtResource( 5 )
 
 [node name="Hand_L" parent="." instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
@@ -33,5 +36,9 @@ anim_player = NodePath("../Hand_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_L"]

--- a/addons/godot-xr-tools/hands/scenes/highpoly/left_fullglove_physics_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/left_fullglove_physics_hand.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_L.gltf" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/AnimationPlayer.tscn" type="PackedScene" id=2]
@@ -11,7 +11,14 @@
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 5.anim" type="Animation" id=9]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=10]
 
-[node name="LeftPhysicsHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="LeftPhysicsHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
@@ -183,5 +190,9 @@ anim_player = NodePath("../Hand_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_L"]

--- a/addons/godot-xr-tools/hands/scenes/highpoly/left_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/left_hand.tscn
@@ -1,20 +1,53 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_Nails_L.gltf" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/AnimationPlayer.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/hands/hand.gd" type="Script" id=3]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 5.anim" type="Animation" id=4]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip.anim" type="Animation" id=5]
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/caucasian_hand.material" type="Material" id=6]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=7]
 
-[node name="LeftHand" type="Spatial"]
+[sub_resource type="AnimationNodeAnimation" id=2]
+animation = "Grip"
+
+[sub_resource type="AnimationNodeAnimation" id=3]
+animation = "Grip"
+
+[sub_resource type="AnimationNodeBlend2" id=4]
+filter_enabled = true
+filters = [ "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L" ]
+
+[sub_resource type="AnimationNodeAnimation" id=5]
+animation = "Grip 5"
+
+[sub_resource type="AnimationNodeBlend2" id=6]
+filter_enabled = true
+filters = [ "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L" ]
+
+[sub_resource type="AnimationNodeBlendTree" id=7]
+graph_offset = Vector2( -798.981, 58.67 )
+nodes/ClosedHand1/node = SubResource( 2 )
+nodes/ClosedHand1/position = Vector2( -600, 300 )
+nodes/ClosedHand2/node = SubResource( 3 )
+nodes/ClosedHand2/position = Vector2( -360, 300 )
+nodes/Grip/node = SubResource( 4 )
+nodes/Grip/position = Vector2( 0, 20 )
+nodes/OpenHand/node = SubResource( 5 )
+nodes/OpenHand/position = Vector2( -600, 100 )
+nodes/Trigger/node = SubResource( 6 )
+nodes/Trigger/position = Vector2( -360, 20 )
+node_connections = [ "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2", "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "output", 0, "Grip" ]
+
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="LeftHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
 }
-open_hand = ExtResource( 4 )
-closed_hand = ExtResource( 5 )
 
 [node name="Hand_Nails_L" parent="." instance=ExtResource( 1 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
@@ -28,10 +61,14 @@ material/0 = ExtResource( 6 )
 [node name="AnimationPlayer" parent="Hand_Nails_L" instance=ExtResource( 2 )]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = ExtResource( 7 )
+tree_root = SubResource( 7 )
 anim_player = NodePath("../Hand_Nails_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_Nails_L"]

--- a/addons/godot-xr-tools/hands/scenes/highpoly/left_physics_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/left_physics_hand.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/AnimationPlayer.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_Nails_L.gltf" type="PackedScene" id=2]
@@ -11,7 +11,14 @@
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 5.anim" type="Animation" id=9]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=10]
 
-[node name="LeftPhysicsHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="LeftPhysicsHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
@@ -183,5 +190,9 @@ anim_player = NodePath("../Hand_Nails_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_Nails_L"]

--- a/addons/godot-xr-tools/hands/scenes/highpoly/right_fullglove_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/right_fullglove_hand.tscn
@@ -1,20 +1,23 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_R.gltf" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/AnimationPlayer.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/hands/hand.gd" type="Script" id=3]
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/cleaning_glove.material" type="Material" id=4]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 5.anim" type="Animation" id=5]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=6]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip.anim" type="Animation" id=7]
 
-[node name="RightHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="RightHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
 }
-open_hand = ExtResource( 5 )
-closed_hand = ExtResource( 7 )
 
 [node name="Hand_R" parent="." instance=ExtResource( 1 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
@@ -33,5 +36,9 @@ anim_player = NodePath("../Hand_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_R"]

--- a/addons/godot-xr-tools/hands/scenes/highpoly/right_fullglove_physics_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/right_fullglove_physics_hand.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_R.gltf" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/AnimationPlayer.tscn" type="PackedScene" id=2]
@@ -7,7 +7,14 @@
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/labglove.material" type="Material" id=5]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=6]
 
-[node name="RightPhysicsHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="RightPhysicsHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
@@ -175,5 +182,9 @@ anim_player = NodePath("../Hand_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_R"]

--- a/addons/godot-xr-tools/hands/scenes/highpoly/right_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/right_hand.tscn
@@ -1,20 +1,23 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_Nails_R.gltf" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/AnimationPlayer.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/hands/hand.gd" type="Script" id=3]
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/caucasian_hand.material" type="Material" id=4]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=5]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 5.anim" type="Animation" id=6]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip.anim" type="Animation" id=7]
 
-[node name="RightHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="RightHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
 }
-open_hand = ExtResource( 6 )
-closed_hand = ExtResource( 7 )
 
 [node name="Hand_Nails_R" parent="." instance=ExtResource( 1 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
@@ -33,5 +36,9 @@ anim_player = NodePath("../Hand_Nails_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_Nails_R"]

--- a/addons/godot-xr-tools/hands/scenes/highpoly/right_physics_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/right_physics_hand.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/AnimationPlayer.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_Nails_R.gltf" type="PackedScene" id=2]
@@ -7,7 +7,14 @@
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/caucasian_hand.material" type="Material" id=5]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=6]
 
-[node name="RightPhysicsHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="RightPhysicsHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
@@ -175,5 +182,9 @@ anim_player = NodePath("../Hand_Nails_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_Nails_R"]

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/left_fullglove_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/left_fullglove_low.tscn
@@ -1,20 +1,53 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/AnimationPlayer.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_low_L.gltf" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/hands/hand.gd" type="Script" id=3]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip.anim" type="Animation" id=4]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 5.anim" type="Animation" id=5]
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/cleaning_glove.material" type="Material" id=6]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=7]
 
-[node name="LeftHand" type="Spatial"]
+[sub_resource type="AnimationNodeAnimation" id=2]
+animation = "Grip"
+
+[sub_resource type="AnimationNodeAnimation" id=3]
+animation = "Grip"
+
+[sub_resource type="AnimationNodeBlend2" id=4]
+filter_enabled = true
+filters = [ "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L" ]
+
+[sub_resource type="AnimationNodeAnimation" id=5]
+animation = "Grip 5"
+
+[sub_resource type="AnimationNodeBlend2" id=6]
+filter_enabled = true
+filters = [ "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L" ]
+
+[sub_resource type="AnimationNodeBlendTree" id=7]
+graph_offset = Vector2( -798.981, 58.67 )
+nodes/ClosedHand1/node = SubResource( 2 )
+nodes/ClosedHand1/position = Vector2( -600, 300 )
+nodes/ClosedHand2/node = SubResource( 3 )
+nodes/ClosedHand2/position = Vector2( -360, 300 )
+nodes/Grip/node = SubResource( 4 )
+nodes/Grip/position = Vector2( 0, 20 )
+nodes/OpenHand/node = SubResource( 5 )
+nodes/OpenHand/position = Vector2( -600, 100 )
+nodes/Trigger/node = SubResource( 6 )
+nodes/Trigger/position = Vector2( -360, 20 )
+node_connections = [ "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2", "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "output", 0, "Grip" ]
+
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="LeftHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
 }
-open_hand = ExtResource( 5 )
-closed_hand = ExtResource( 4 )
 
 [node name="Hand_low_L" parent="." instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
@@ -28,10 +61,14 @@ material/0 = ExtResource( 6 )
 [node name="AnimationPlayer" parent="Hand_low_L" instance=ExtResource( 1 )]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = ExtResource( 7 )
+tree_root = SubResource( 7 )
 anim_player = NodePath("../Hand_low_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_low_L"]

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn
@@ -1,20 +1,53 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_Nails_low_L.gltf" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/AnimationPlayer.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/hands/hand.gd" type="Script" id=3]
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/caucasian_hand.material" type="Material" id=4]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 5.anim" type="Animation" id=5]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip.anim" type="Animation" id=6]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=7]
 
-[node name="LeftHand" type="Spatial"]
+[sub_resource type="AnimationNodeAnimation" id=1]
+animation = "Grip"
+
+[sub_resource type="AnimationNodeAnimation" id=2]
+animation = "Grip"
+
+[sub_resource type="AnimationNodeBlend2" id=3]
+filter_enabled = true
+filters = [ "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L" ]
+
+[sub_resource type="AnimationNodeAnimation" id=4]
+animation = "Grip 5"
+
+[sub_resource type="AnimationNodeBlend2" id=5]
+filter_enabled = true
+filters = [ "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L" ]
+
+[sub_resource type="AnimationNodeBlendTree" id=6]
+graph_offset = Vector2( -798.981, 58.67 )
+nodes/ClosedHand1/node = SubResource( 1 )
+nodes/ClosedHand1/position = Vector2( -600, 300 )
+nodes/ClosedHand2/node = SubResource( 2 )
+nodes/ClosedHand2/position = Vector2( -360, 300 )
+nodes/Grip/node = SubResource( 3 )
+nodes/Grip/position = Vector2( 0, 20 )
+nodes/OpenHand/node = SubResource( 4 )
+nodes/OpenHand/position = Vector2( -600, 100 )
+nodes/Trigger/node = SubResource( 5 )
+nodes/Trigger/position = Vector2( -360, 20 )
+node_connections = [ "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2", "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "output", 0, "Grip" ]
+
+[sub_resource type="CapsuleShape" id=7]
+radius = 0.07
+height = 0.1
+
+[node name="LeftHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
 }
-open_hand = ExtResource( 5 )
-closed_hand = ExtResource( 6 )
 
 [node name="Hand_Nails_low_L" parent="." instance=ExtResource( 1 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
@@ -28,10 +61,14 @@ material/0 = ExtResource( 4 )
 [node name="AnimationPlayer" parent="Hand_Nails_low_L" instance=ExtResource( 2 )]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = ExtResource( 7 )
+tree_root = SubResource( 6 )
 anim_player = NodePath("../Hand_Nails_low_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 7 )
 
 [editable path="Hand_Nails_low_L"]

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/left_physics_fullglove_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/left_physics_fullglove_low.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_low_L.gltf" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/AnimationPlayer.tscn" type="PackedScene" id=2]
@@ -9,7 +9,14 @@
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip.anim" type="Animation" id=7]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=8]
 
-[node name="LeftPhysicsHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="LeftPhysicsHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
@@ -179,5 +186,9 @@ anim_player = NodePath("../Hand_low_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_low_L"]

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/left_physics_hand_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/left_physics_hand_low.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/AnimationPlayer.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_Nails_low_L.gltf" type="PackedScene" id=2]
@@ -9,7 +9,14 @@
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip.anim" type="Animation" id=7]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=8]
 
-[node name="LeftPhysicsHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="LeftPhysicsHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
@@ -179,5 +186,9 @@ anim_player = NodePath("../Hand_Nails_low_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_Nails_low_L"]

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/right_fullglove_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/right_fullglove_low.tscn
@@ -1,20 +1,23 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/AnimationPlayer.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_low_R.gltf" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/cleaning_glove.material" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/hands/hand.gd" type="Script" id=4]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 5.anim" type="Animation" id=5]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip.anim" type="Animation" id=6]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=7]
 
-[node name="RightHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="RightHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 4 )
 __meta__ = {
 "_editor_description_": ""
 }
-open_hand = ExtResource( 5 )
-closed_hand = ExtResource( 6 )
 
 [node name="Hand_low_R" parent="." instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
@@ -33,5 +36,9 @@ anim_player = NodePath("../Hand_low_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_low_R"]

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/right_hand_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/right_hand_low.tscn
@@ -1,20 +1,23 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/AnimationPlayer.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_Nails_low_R.gltf" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-xr-tools/hands/hand.gd" type="Script" id=3]
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/caucasian_hand.material" type="Material" id=4]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" type="AnimationNodeBlendTree" id=5]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip.anim" type="Animation" id=6]
-[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 5.anim" type="Animation" id=7]
 
-[node name="RightHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="RightHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
 }
-open_hand = ExtResource( 7 )
-closed_hand = ExtResource( 6 )
 
 [node name="Hand_Nails_low_R" parent="." instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15 )
@@ -33,5 +36,9 @@ anim_player = NodePath("../Hand_Nails_low_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_Nails_low_R"]

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/right_physics_fullglove_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/right_physics_fullglove_low.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/AnimationPlayer.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_low_R.gltf" type="PackedScene" id=2]
@@ -9,7 +9,14 @@
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip.anim" type="Animation" id=7]
 [ext_resource path="res://addons/godot-xr-tools/hands/hand_physics_bone.gd" type="Script" id=8]
 
-[node name="RightPhysicsHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="RightPhysicsHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 4 )
 __meta__ = {
 "_editor_description_": ""
@@ -179,5 +186,9 @@ anim_player = NodePath("../Hand_low_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_low_R"]

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/right_physics_hand_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/right_physics_hand_low.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/AnimationPlayer.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/model/Hand_Nails_low_R.gltf" type="PackedScene" id=2]
@@ -9,7 +9,14 @@
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip.anim" type="Animation" id=7]
 [ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 5.anim" type="Animation" id=8]
 
-[node name="RightPhysicsHand" type="Spatial"]
+[sub_resource type="CapsuleShape" id=1]
+radius = 0.07
+height = 0.1
+
+[node name="RightPhysicsHand" type="Area"]
+collision_layer = 131072
+collision_mask = 0
+monitoring = false
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": ""
@@ -179,5 +186,9 @@ anim_player = NodePath("../Hand_Nails_low_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
+
+[node name="HandCollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0.08 )
+shape = SubResource( 1 )
 
 [editable path="Hand_Nails_low_R"]

--- a/addons/godot-xr-tools/interactables/interactable_area_button.gd
+++ b/addons/godot-xr-tools/interactables/interactable_area_button.gd
@@ -29,6 +29,12 @@ export var displacement : Vector3 = Vector3(0.0, -0.02, 0.0)
 ## Displacement duration
 export var duration : float = 0.1
 
+## If true, bodies are detected
+export var detect_bodies : bool = true
+
+## If true, areas are detected
+export var detect_areas : bool = false
+
 
 # Button pressed state
 var pressed : bool = false
@@ -55,14 +61,16 @@ func _ready():
 	add_child(_tween)
 
 	# Connect area signals
-	if connect("area_entered", self, "_on_button_entered"):
-		push_error("Unable to connect button area signal")
-	if connect("area_exited", self, "_on_button_exited"):
-		push_error("Unable to connect button area signal")
-	if connect("body_entered", self, "_on_button_entered"):
-		push_error("Unable to connect button area signal")
-	if connect("body_exited", self, "_on_button_exited"):
-		push_error("Unable to connect button area signal")
+	if detect_areas:
+		if connect("area_entered", self, "_on_button_entered"):
+			push_error("Unable to connect button area signal")
+		if connect("area_exited", self, "_on_button_exited"):
+			push_error("Unable to connect button area signal")
+	if detect_bodies:
+		if connect("body_entered", self, "_on_button_entered"):
+			push_error("Unable to connect button area signal")
+		if connect("body_exited", self, "_on_button_exited"):
+			push_error("Unable to connect button area signal")
 
 
 # Called when an area or body enters the button area

--- a/addons/godot-xr-tools/objects/hand_pose_area.gd
+++ b/addons/godot-xr-tools/objects/hand_pose_area.gd
@@ -1,0 +1,58 @@
+class_name XRToolsHandPoseArea
+extends Area
+
+
+## XR Tools Hand Pose Area Script
+##
+## This script adds hand pose overrides when hands enter this area.
+
+
+## Left open-hand animation pose
+export var left_open_hand : Animation
+
+## Left closed-hand animation pose
+export var left_closed_hand : Animation
+
+## Right open-hand animation pose
+export var right_open_hand : Animation
+
+## Left closed-hand animation pose
+export var right_closed_hand : Animation
+
+
+## Called when the node enters the scene tree for the first time.
+func _ready():
+	if connect("area_entered", self, "_on_area_entered"):
+		push_error("Unable to connect area entered signal")
+	if connect("area_exited", self, "_on_area_exited"):
+		push_error("Unable to connect area entered signal")
+
+
+## Called when an area enters this area - intended to detect hands
+func _on_area_entered(area : Area) -> void:
+	# Make sure area is a hand
+	var hand := area as XRToolsHand
+	if !hand:
+		return
+
+	# Get the hand controller
+	var controller := hand.get_parent() as ARVRController
+	if !controller:
+		return
+
+	# Add the overrides
+	if controller.controller_id == 1:
+		hand.add_hand_override(self, left_open_hand, left_closed_hand)
+	elif controller.controller_id == 2:
+		hand.add_hand_override(self, right_open_hand, right_closed_hand)
+
+
+## Called when an area leaves this area - intended to detect hands
+func _on_area_exited(area : Area) -> void:
+	# Make sure area is a hand
+	var hand := area as XRToolsHand
+	if !hand:
+		return
+
+	# Remove any overrides
+	hand.remove_hand_override(self)

--- a/addons/godot-xr-tools/objects/hand_pose_area.tscn
+++ b/addons/godot-xr-tools/objects/hand_pose_area.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.gd" type="Script" id=1]
+
+[node name="HandPoseArea" type="Area"]
+collision_layer = 0
+collision_mask = 131072
+monitorable = false
+script = ExtResource( 1 )

--- a/assets/meshes/interactables/joystick_smooth.tscn
+++ b/assets/meshes/interactables/joystick_smooth.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_joystick.gd" type="Script" id=2]
 [ext_resource path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_handle.gd" type="Script" id=4]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 3.anim" type="Animation" id=6]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 3.anim" type="Animation" id=7]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.1, 0.1, 0.05 )
@@ -77,4 +80,11 @@ script = ExtResource( 4 )
 reset_transform_on_pickup = false
 
 [node name="CollisionShape" type="CollisionShape" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle"]
+shape = SubResource( 7 )
+
+[node name="HandPoseArea" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle" instance=ExtResource( 5 )]
+left_closed_hand = ExtResource( 6 )
+right_closed_hand = ExtResource( 7 )
+
+[node name="CollisionShape" type="CollisionShape" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle/HandPoseArea"]
 shape = SubResource( 7 )

--- a/assets/meshes/interactables/joystick_snap.tscn
+++ b/assets/meshes/interactables/joystick_snap.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_joystick.gd" type="Script" id=2]
 [ext_resource path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_handle.gd" type="Script" id=4]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 3.anim" type="Animation" id=6]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 3.anim" type="Animation" id=7]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.1, 0.1, 0.05 )
@@ -27,6 +30,10 @@ radial_segments = 16
 rings = 8
 
 [sub_resource type="SphereShape" id=7]
+margin = 0.12
+radius = 0.06
+
+[sub_resource type="SphereShape" id=8]
 margin = 0.12
 radius = 0.06
 
@@ -80,3 +87,10 @@ reset_transform_on_pickup = false
 
 [node name="CollisionShape" type="CollisionShape" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )
+
+[node name="HandPoseArea" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle" instance=ExtResource( 5 )]
+left_closed_hand = ExtResource( 6 )
+right_closed_hand = ExtResource( 7 )
+
+[node name="CollisionShape" type="CollisionShape" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle/HandPoseArea"]
+shape = SubResource( 8 )

--- a/assets/meshes/interactables/joystick_zero.tscn
+++ b/assets/meshes/interactables/joystick_zero.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_joystick.gd" type="Script" id=2]
 [ext_resource path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_handle.gd" type="Script" id=4]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 3.anim" type="Animation" id=6]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 3.anim" type="Animation" id=7]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.1, 0.1, 0.05 )
@@ -27,6 +30,10 @@ radial_segments = 16
 rings = 8
 
 [sub_resource type="SphereShape" id=7]
+margin = 0.12
+radius = 0.06
+
+[sub_resource type="SphereShape" id=8]
 margin = 0.12
 radius = 0.06
 
@@ -79,3 +86,10 @@ reset_transform_on_pickup = false
 
 [node name="CollisionShape" type="CollisionShape" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )
+
+[node name="HandPoseArea" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle" instance=ExtResource( 5 )]
+left_closed_hand = ExtResource( 6 )
+right_closed_hand = ExtResource( 7 )
+
+[node name="CollisionShape" type="CollisionShape" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle/HandPoseArea"]
+shape = SubResource( 8 )

--- a/assets/meshes/interactables/lever_smooth.tscn
+++ b/assets/meshes/interactables/lever_smooth.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_hinge.gd" type="Script" id=2]
 [ext_resource path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_handle.gd" type="Script" id=4]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 3.anim" type="Animation" id=6]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 3.anim" type="Animation" id=7]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.1, 0.3, 0.05 )
@@ -27,6 +30,10 @@ radial_segments = 16
 rings = 8
 
 [sub_resource type="SphereShape" id=7]
+margin = 0.12
+radius = 0.06
+
+[sub_resource type="SphereShape" id=8]
 margin = 0.12
 radius = 0.06
 
@@ -78,3 +85,10 @@ reset_transform_on_pickup = false
 
 [node name="CollisionShape" type="CollisionShape" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )
+
+[node name="HandPoseArea" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle" instance=ExtResource( 5 )]
+left_closed_hand = ExtResource( 6 )
+right_closed_hand = ExtResource( 7 )
+
+[node name="CollisionShape" type="CollisionShape" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle/HandPoseArea"]
+shape = SubResource( 8 )

--- a/assets/meshes/interactables/lever_snap.tscn
+++ b/assets/meshes/interactables/lever_snap.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_hinge.gd" type="Script" id=2]
 [ext_resource path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_handle.gd" type="Script" id=4]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 3.anim" type="Animation" id=6]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 3.anim" type="Animation" id=7]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.1, 0.3, 0.05 )
@@ -27,6 +30,10 @@ radial_segments = 16
 rings = 8
 
 [sub_resource type="SphereShape" id=7]
+margin = 0.12
+radius = 0.06
+
+[sub_resource type="SphereShape" id=8]
 margin = 0.12
 radius = 0.06
 
@@ -79,3 +86,10 @@ reset_transform_on_pickup = false
 
 [node name="CollisionShape" type="CollisionShape" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )
+
+[node name="HandPoseArea" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle" instance=ExtResource( 5 )]
+left_closed_hand = ExtResource( 6 )
+right_closed_hand = ExtResource( 7 )
+
+[node name="CollisionShape" type="CollisionShape" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle/HandPoseArea"]
+shape = SubResource( 8 )

--- a/assets/meshes/interactables/lever_zero.tscn
+++ b/assets/meshes/interactables/lever_zero.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_hinge.gd" type="Script" id=2]
 [ext_resource path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_handle.gd" type="Script" id=4]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 3.anim" type="Animation" id=6]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 3.anim" type="Animation" id=7]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.1, 0.3, 0.05 )
@@ -27,6 +30,10 @@ radial_segments = 16
 rings = 8
 
 [sub_resource type="SphereShape" id=7]
+margin = 0.12
+radius = 0.06
+
+[sub_resource type="SphereShape" id=8]
 margin = 0.12
 radius = 0.06
 
@@ -79,3 +86,10 @@ reset_transform_on_pickup = false
 
 [node name="CollisionShape" type="CollisionShape" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )
+
+[node name="HandPoseArea" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle" instance=ExtResource( 5 )]
+left_closed_hand = ExtResource( 6 )
+right_closed_hand = ExtResource( 7 )
+
+[node name="CollisionShape" type="CollisionShape" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle/HandPoseArea"]
+shape = SubResource( 8 )

--- a/assets/meshes/interactables/push_button.tscn
+++ b/assets/meshes/interactables/push_button.tscn
@@ -1,11 +1,14 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_area_button.gd" type="Script" id=2]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=3]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Sign_Point.anim" type="Animation" id=4]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Sign_Point.anim" type="Animation" id=5]
 
 [sub_resource type="CylinderShape" id=1]
-radius = 0.05
 height = 0.05
+radius = 0.05
 
 [sub_resource type="CylinderMesh" id=2]
 top_radius = 0.05
@@ -15,8 +18,8 @@ radial_segments = 16
 rings = 0
 
 [sub_resource type="CylinderShape" id=3]
-radius = 0.04
 height = 0.04
+radius = 0.04
 
 [sub_resource type="CylinderMesh" id=4]
 top_radius = 0.04
@@ -29,8 +32,11 @@ rings = 0
 albedo_color = Color( 1, 0, 0, 1 )
 
 [sub_resource type="CylinderShape" id=6]
-radius = 0.04
 height = 0.05
+radius = 0.04
+
+[sub_resource type="SphereShape" id=7]
+radius = 0.05
 
 [node name="PushButton" type="Spatial"]
 
@@ -56,9 +62,20 @@ material/0 = SubResource( 5 )
 [node name="InteractableAreaButton" type="Area" parent="."]
 collision_layer = 0
 collision_mask = 131072
+monitorable = false
 script = ExtResource( 2 )
 button = NodePath("../Button")
 
 [node name="CollisionShape" type="CollisionShape" parent="InteractableAreaButton"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0 )
 shape = SubResource( 6 )
+
+[node name="HandPoseArea" parent="." instance=ExtResource( 3 )]
+left_open_hand = ExtResource( 4 )
+left_closed_hand = ExtResource( 4 )
+right_open_hand = ExtResource( 5 )
+right_closed_hand = ExtResource( 5 )
+
+[node name="CollisionShape" type="CollisionShape" parent="HandPoseArea"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.0197686, 0 )
+shape = SubResource( 7 )

--- a/assets/meshes/interactables/slider_smooth.tscn
+++ b/assets/meshes/interactables/slider_smooth.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_slider.gd" type="Script" id=2]
 [ext_resource path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_handle.gd" type="Script" id=4]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 3.anim" type="Animation" id=6]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 3.anim" type="Animation" id=7]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.1, 0.3, 0.05 )
@@ -27,6 +30,10 @@ radial_segments = 16
 rings = 8
 
 [sub_resource type="SphereShape" id=7]
+margin = 0.12
+radius = 0.06
+
+[sub_resource type="SphereShape" id=8]
 margin = 0.12
 radius = 0.06
 
@@ -81,3 +88,10 @@ reset_transform_on_pickup = false
 
 [node name="CollisionShape" type="CollisionShape" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )
+
+[node name="HandPoseArea" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle" instance=ExtResource( 5 )]
+left_closed_hand = ExtResource( 6 )
+right_closed_hand = ExtResource( 7 )
+
+[node name="CollisionShape" type="CollisionShape" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle/HandPoseArea"]
+shape = SubResource( 8 )

--- a/assets/meshes/interactables/slider_snap.tscn
+++ b/assets/meshes/interactables/slider_snap.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_slider.gd" type="Script" id=2]
 [ext_resource path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_handle.gd" type="Script" id=4]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 3.anim" type="Animation" id=6]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 3.anim" type="Animation" id=7]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.1, 0.3, 0.05 )
@@ -27,6 +30,10 @@ radial_segments = 16
 rings = 8
 
 [sub_resource type="SphereShape" id=7]
+margin = 0.12
+radius = 0.06
+
+[sub_resource type="SphereShape" id=8]
 margin = 0.12
 radius = 0.06
 
@@ -82,3 +89,10 @@ reset_transform_on_pickup = false
 
 [node name="CollisionShape" type="CollisionShape" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )
+
+[node name="HandPoseArea" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle" instance=ExtResource( 5 )]
+left_closed_hand = ExtResource( 6 )
+right_closed_hand = ExtResource( 7 )
+
+[node name="CollisionShape" type="CollisionShape" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle/HandPoseArea"]
+shape = SubResource( 8 )

--- a/assets/meshes/interactables/slider_zero.tscn
+++ b/assets/meshes/interactables/slider_zero.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_slider.gd" type="Script" id=2]
 [ext_resource path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_handle.gd" type="Script" id=4]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=5]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 3.anim" type="Animation" id=6]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 3.anim" type="Animation" id=7]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.1, 0.3, 0.05 )
@@ -27,6 +30,10 @@ radial_segments = 16
 rings = 8
 
 [sub_resource type="SphereShape" id=7]
+margin = 0.12
+radius = 0.06
+
+[sub_resource type="SphereShape" id=8]
 margin = 0.12
 radius = 0.06
 
@@ -82,3 +89,10 @@ reset_transform_on_pickup = false
 
 [node name="CollisionShape" type="CollisionShape" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )
+
+[node name="HandPoseArea" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle" instance=ExtResource( 5 )]
+left_closed_hand = ExtResource( 6 )
+right_closed_hand = ExtResource( 7 )
+
+[node name="CollisionShape" type="CollisionShape" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle/HandPoseArea"]
+shape = SubResource( 8 )

--- a/assets/meshes/interactables/wheel_smooth.tscn
+++ b/assets/meshes/interactables/wheel_smooth.tscn
@@ -1,12 +1,15 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" type="Material" id=1]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_hinge.gd" type="Script" id=2]
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_handle.gd" type="Script" id=3]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/right/Grip 2.anim" type="Animation" id=4]
+[ext_resource path="res://addons/godot-xr-tools/hands/animations/left/Grip 2.anim" type="Animation" id=5]
+[ext_resource path="res://addons/godot-xr-tools/objects/hand_pose_area.tscn" type="PackedScene" id=6]
 
 [sub_resource type="CylinderShape" id=1]
-radius = 0.2
 height = 0.02
+radius = 0.2
 
 [sub_resource type="CylinderMesh" id=2]
 top_radius = 0.2
@@ -17,6 +20,10 @@ rings = 0
 
 [sub_resource type="BoxShape" id=3]
 extents = Vector3( 0.01, 0.04, 0.05 )
+
+[sub_resource type="CylinderShape" id=4]
+height = 0.04
+radius = 0.22
 
 [node name="WheelSmooth" type="Spatial"]
 
@@ -142,3 +149,11 @@ reset_transform_on_pickup = false
 
 [node name="CollisionShape" type="CollisionShape" parent="HingeOrigin/InteractableHinge/Handle8/InteractableHandle"]
 shape = SubResource( 3 )
+
+[node name="HandPoseArea" parent="HingeOrigin" instance=ExtResource( 6 )]
+left_closed_hand = ExtResource( 5 )
+right_closed_hand = ExtResource( 4 )
+
+[node name="CollisionShape" type="CollisionShape" parent="HingeOrigin/HandPoseArea"]
+transform = Transform( -4.37114e-08, -1, 4.37114e-08, 1, -4.37114e-08, -4.37114e-08, 4.37114e-08, 4.37114e-08, 1, 0, 0, 0 )
+shape = SubResource( 4 )

--- a/project.godot
+++ b/project.godot
@@ -14,6 +14,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/misc/arvr_helpers.gd"
 }, {
+"base": "ARVROrigin",
+"class": "FirstPersonControllerVR",
+"language": "GDScript",
+"path": "res://addons/godot-openxr/scenes/first_person_controller_vr.gd"
+}, {
 "base": "Spatial",
 "class": "Teleport",
 "language": "GDScript",
@@ -59,7 +64,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/overrides/ground_physics_settings.gd"
 }, {
-"base": "Spatial",
+"base": "Area",
 "class": "XRToolsHand",
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/hands/hand.gd"
@@ -68,6 +73,11 @@ _global_script_classes=[ {
 "class": "XRToolsHandPhysicsBone",
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/hands/hand_physics_bone.gd"
+}, {
+"base": "Area",
+"class": "XRToolsHandPoseArea",
+"language": "GDScript",
+"path": "res://addons/godot-xr-tools/objects/hand_pose_area.gd"
 }, {
 "base": "Node",
 "class": "XRToolsHighlightMaterial",
@@ -251,6 +261,7 @@ _global_script_classes=[ {
 } ]
 _global_script_class_icons={
 "ARVRHelpers": "",
+"FirstPersonControllerVR": "",
 "Teleport": "",
 "XRTools": "",
 "XRToolsClimbable": "res://addons/godot-xr-tools/editor/icons/hand.svg",
@@ -262,6 +273,7 @@ _global_script_class_icons={
 "XRToolsGroundPhysicsSettings": "",
 "XRToolsHand": "res://addons/godot-xr-tools/editor/icons/hand.svg",
 "XRToolsHandPhysicsBone": "",
+"XRToolsHandPoseArea": "",
 "XRToolsHighlightMaterial": "",
 "XRToolsHighlightRing": "",
 "XRToolsHighlightVisible": "",

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -94,7 +94,6 @@ node_connections = [ "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2", "Trigger", 
 
 [node name="MainMenuLevel" instance=ExtResource( 1 )]
 script = ExtResource( 23 )
-environment = null
 
 [node name="LeftHand" parent="ARVROrigin/LeftHand" index="0" instance=ExtResource( 3 )]
 


### PR DESCRIPTION
This pull request implements #268 by performing the following changes:
 - Added hand-pose override stack to XRToolsHand
 - Modified XRToolsHand to be an Area (the hand bounding area)
 - Modified all hand scenes to configure hand Areas
 - Added XRToolsHandPoseArea to support setting poses in the hand-pose override stack

The change to making XRToolsHand an area caused a name-collision in XRToolsPhysicsHand where there was a "collision_layer" property to set the collisions for all bones, but the area also introduced its collision_layer. As such the existing property was renamed to bone_collision_area.

Additionally making XRToolsHand an area made XRToolsInteractableAreaButton trigger on the area instead of just on the physics bones. As such XRToolsInteractableArea now has detect_areas and detect_bodies exported bool properties, and the detect_areas is off by default.

In order to demonstrate hand poses, all the demo interactable objects placed in the interactable_demo scene now have poses.
