### PR TITLE
Function pickup modified to allow child-ing to other scene nodes

### DIFF
--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -10,6 +10,13 @@ extends Spatial
 ## Additionally this script can work in conjunction with the 
 ## [XRToolsMovementProvider] class support climbing. Most climbable objects are
 ## instances of the [XRToolsClimbable] class.
+##
+## This script typically assumes the function pickup is a direct child of a controller node.
+## However, optionally, the developer can choose a different parent of the function pickup.
+## In that instance, the developer should select a NodePath for the controller to tether
+## the FunctionPickup's functionality to.  This may be useful, for instance, if using
+## a full body IK system, a full "physics hand" system, or another type of 
+## setup in which the "hands" or intended pickup point may be divorced from the controller position.
 
 
 ## Signal emitted when the pickup picks something up
@@ -19,14 +26,14 @@ signal has_picked_up(what)
 signal has_dropped
 
 
-# Constant for worst-case grab distance
+## Constant for worst-case grab distance
 const MAX_GRAB_DISTANCE2: float = 1000000.0
 
 
 ## Pickup enabled property
 export var enabled : bool = true
 
-## Controller tied to this pickup function
+## NodePath to controller tied to this pickup function (Optional setting)
 export (NodePath) var _pickup_controller_node_path
 
 ## Grip controller button
@@ -76,12 +83,12 @@ var _ranged_area : Area
 var _ranged_collision : CollisionShape
 
 
-
 ## Grip threshold (from configuration)
 onready var grip_threshold = XRTools.get_grip_threshold()
 
-## Controller node from Node Path
+## Fetch controller node from optional Node Path export variable
 onready var _controller : ARVRController = get_node(_pickup_controller_node_path)
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():


### PR DESCRIPTION
-Update function pickup to allow selection of controller node from anywhere in scene tree, allowing function pickup to be child of a node other than the controller

-This may be useful for using the XR Avatar project, other full body projects, "physics body" projects or projects where the meshes for interactions are more obscure such as a claw object, such that objects being "held" by the controllers directly rather than as a child of the mesh may create a "floaty" effect to the object pickup.  In other words, where the pickup point may meaningfully diverge from the controller location, being able to set the function pickup to the intended location is helpful, such as to a hand bone attachment on a body mesh or the exact intended point of a moving claw.

-Because default functionality still assumes function pickup is a child of the controller, this change does not damage any pre-existing projects and is non-breaking.  Someone who does not select a controller node but has the function_pickup as a child to the controller does not have to do anything else for this to work out of the box (that is, choosing a node path is purely optional).

-There is an output warning statement if the dev mistakenly does not child the function pickup to a controller and also does not choose a nodepath for a controller, and in that event the function pickup is disabled.