### PR TITLE
Fixed advanced node-find routines

### DIFF
--- a/addons/godot-xr-tools/effects/vignette.gd
+++ b/addons/godot-xr-tools/effects/vignette.gd
@@ -1,4 +1,5 @@
 tool
+class_name XRToolsVignette
 extends Spatial
 
 export var radius = 1.0 setget set_radius
@@ -95,19 +96,16 @@ func set_auto_rotation_limit(new_auto_rotation_limit):
 	auto_rotation_limit = new_auto_rotation_limit
 	auto_rotation_limit_rad = deg2rad(auto_rotation_limit)
 
-func _get_origin_node() -> ARVROrigin:
-	var parent = get_parent()
-	while parent:
-		if parent and parent is ARVROrigin:
-			return parent
-		parent = parent.get_parent()
 
-	return null
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsVignette" or .is_class(name)
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	if !Engine.editor_hint:
-		origin_node = _get_origin_node()
+		origin_node = ARVRHelpers.get_arvr_origin(self)
 		_update_mesh()
 		_update_radius()
 		_update_fade()
@@ -180,8 +178,7 @@ func _process(delta):
 # - ARVRCamera is our parent
 func _get_configuration_warning():
 	# Check the origin node
-	var node = _get_origin_node()
-	if !node:
+	if !ARVRHelpers.get_arvr_origin(self):
 		return "Parent node must be in a branch from ARVROrigin"
 
 	# check camera node

--- a/addons/godot-xr-tools/examples/fall_damage.gd
+++ b/addons/godot-xr-tools/examples/fall_damage.gd
@@ -51,6 +51,11 @@ export var damage_threshold : float = 8.0
 var _previous_velocity : Vector3 = Vector3.ZERO
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsFallDamage" or .is_class(name)
+
+
 func _ready():
 	# Set as always active
 	is_active = true

--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -71,17 +71,22 @@ var _grab_area : Area
 var _grab_collision : CollisionShape
 var _ranged_area : Area
 var _ranged_collision : CollisionShape
-var _controller : ARVRController
 
+
+## Controller
+onready var _controller := ARVRHelpers.get_arvr_controller(self)
 
 ## Grip threshold (from configuration)
 onready var grip_threshold = XRTools.get_grip_threshold()
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsFunctionPickup" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	_controller = get_parent()
-
 	# Create the grab collision shape
 	_grab_collision = CollisionShape.new()
 	_grab_collision.set_name("GrabCollisionShape")
@@ -154,6 +159,39 @@ func _process(delta):
 		_velocity_averager.add_transform(delta, global_transform)
 
 	_update_closest_object()
+
+
+## Find an [XRToolsFunctionPickup] node.
+##
+## This function searches from the specified node for an [XRToolsFunctionPickup]
+## assuming the node is a sibling of the pickup under an [ARVRController].
+static func find_instance(node : Node) -> XRToolsFunctionPickup:
+	return XRTools.find_child(
+		ARVRHelpers.get_arvr_controller(node),
+		"*",
+		"XRToolsFunctionPickup") as XRToolsFunctionPickup
+
+
+## Find the left [XRToolsFunctionPickup] node.
+##
+## This function searches from the specified node for the left controller 
+## [XRToolsFunctionPickup] assuming the node is a sibling of the [ARVROrigin].
+static func find_left(node : Node) -> XRToolsFunctionPickup:
+	return XRTools.find_child(
+		ARVRHelpers.get_left_controller(node),
+		"*",
+		"XRToolsFunctionPickup") as XRToolsFunctionPickup
+
+
+## Find the right [XRToolsFunctionPickup] node.
+##
+## This function searches from the specified node for the right controller 
+## [XRToolsFunctionPickup] assuming the node is a sibling of the [ARVROrigin].
+static func find_right(node : Node) -> XRToolsFunctionPickup:
+	return XRTools.find_child(
+		ARVRHelpers.get_right_controller(node),
+		"*",
+		"XRToolsFunctionPickup") as XRToolsFunctionPickup
 
 
 # Called when the grab distance has been modified

--- a/addons/godot-xr-tools/functions/function_pointer.gd
+++ b/addons/godot-xr-tools/functions/function_pointer.gd
@@ -80,6 +80,11 @@ var last_collided_at : Vector3 = Vector3.ZERO
 var ws : float = 1.0
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsFunctionPointer" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Do not initialise if in the editor
@@ -91,9 +96,10 @@ func _ready():
 
 	# If pointer-trigger is a button then subscribe to button signals
 	if active_button != XRTools.Buttons.VR_ACTION:
-		# Get button press feedback from our parent (should be an ARVRController)
-		get_parent().connect("button_pressed", self, "_on_button_pressed")
-		get_parent().connect("button_release", self, "_on_button_release")
+		# Get button press feedback from controller
+		var controller := ARVRHelpers.get_arvr_controller(self)
+		controller.connect("button_pressed", self, "_on_button_pressed")
+		controller.connect("button_release", self, "_on_button_release")
 
 	# init our state
 	_update_y_offset()

--- a/addons/godot-xr-tools/functions/movement_climb.gd
+++ b/addons/godot-xr-tools/functions/movement_climb.gd
@@ -45,12 +45,6 @@ export var fling_multiplier : float = 1.0
 ## Averages for velocity measurement
 export var velocity_averages : int = 5
 
-## Pickup function for the left hand
-export var left_pickup : NodePath
-
-## Pickup function for the right hand
-export var right_pickup : NodePath
-
 
 ## Left climbable
 var _left_climbable : XRToolsClimbable
@@ -65,9 +59,16 @@ var _dominant : XRToolsFunctionPickup
 # Velocity averager
 onready var _averager := XRToolsVelocityAveragerLinear.new(velocity_averages)
 
-# Node references
-onready var _left_pickup_node : XRToolsFunctionPickup = get_node(left_pickup)
-onready var _right_pickup_node : XRToolsFunctionPickup = get_node(right_pickup)
+# Left pickup node
+onready var _left_pickup_node := XRToolsFunctionPickup.find_left(self)
+
+# Right pickup node
+onready var _right_pickup_node := XRToolsFunctionPickup.find_right(self)
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementClimb" or .is_class(name)
 
 
 ## Called when the node enters the scene tree for the first time.
@@ -205,15 +206,13 @@ func _on_right_dropped() -> void:
 
 # This method verifies the movement provider has a valid configuration.
 func _get_configuration_warning():
-	# Verify the left controller
-	var test_left_pickup_node = get_node_or_null(left_pickup) if left_pickup else null
-	if !test_left_pickup_node or !test_left_pickup_node is XRToolsFunctionPickup:
-		return "Unable to find left XRToolsFunctionPickup"
+	# Verify the left controller pickup
+	if !XRToolsFunctionPickup.find_left(self):
+		return "Unable to find left XRToolsFunctionPickup node"
 
-	# Verify the right controller
-	var test_right_pickup_node = get_node_or_null(right_pickup) if right_pickup else null
-	if !test_right_pickup_node or !test_right_pickup_node is XRToolsFunctionPickup:
-		return "Unable to find right XRToolsFunctionPickup"
+	# Verify the right controller pickup
+	if !XRToolsFunctionPickup.find_right(self):
+		return "Unable to find right XRToolsFunctionPickup node"
 
 	# Verify velocity averages
 	if velocity_averages < 2:

--- a/addons/godot-xr-tools/functions/movement_crouch.gd
+++ b/addons/godot-xr-tools/functions/movement_crouch.gd
@@ -39,7 +39,12 @@ var _crouch_button_down : bool = false
 
 
 # Controller node
-onready var _controller : ARVRController = get_parent()
+onready var _controller := ARVRHelpers.get_arvr_controller(self)
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementCrouch" or .is_class(name)
 
 
 # Perform jump movement
@@ -77,9 +82,8 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 # This method verifies the movement provider has a valid configuration.
 func _get_configuration_warning():
 	# Check the controller node
-	var test_controller = get_parent()
-	if !test_controller or !test_controller is ARVRController:
-		return "Unable to find ARVR Controller node"
+	if !ARVRHelpers.get_arvr_controller(self):
+		return "This node must be within a branch of an ARVRController node"
 
 	# Call base class
 	return ._get_configuration_warning()

--- a/addons/godot-xr-tools/functions/movement_direct.gd
+++ b/addons/godot-xr-tools/functions/movement_direct.gd
@@ -30,7 +30,12 @@ export var strafe : bool = false
 
 
 # Controller node
-onready var _controller : ARVRController = get_parent()
+onready var _controller := ARVRHelpers.get_arvr_controller(self)
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementDirect" or .is_class(name)
 
 
 # Perform jump movement
@@ -55,9 +60,30 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 # This method verifies the movement provider has a valid configuration.
 func _get_configuration_warning():
 	# Check the controller node
-	var test_controller = get_parent()
-	if !test_controller or !test_controller is ARVRController:
-		return "Unable to find ARVR Controller node"
+	if !ARVRHelpers.get_arvr_controller(self):
+		return "This node must be within a branch of an ARVRController node"
 
 	# Call base class
 	return ._get_configuration_warning()
+
+
+## Find the left [XRToolsMovementDirect] node.
+##
+## This function searches from the specified node for the left controller 
+## [XRToolsMovementDirect] assuming the node is a sibling of the [ARVROrigin].
+static func find_left(node : Node) -> XRToolsMovementDirect:
+	return XRTools.find_child(
+		ARVRHelpers.get_left_controller(node),
+		"*",
+		"XRToolsMovementDirect") as XRToolsMovementDirect
+
+
+## Find the right [XRToolsMovementDirect] node.
+##
+## This function searches from the specified node for the right controller 
+## [XRToolsMovementDirect] assuming the node is a sibling of the [ARVROrigin].
+static func find_right(node : Node) -> XRToolsMovementDirect:
+	return XRTools.find_child(
+		ARVRHelpers.get_right_controller(node),
+		"*",
+		"XRToolsMovementDirect") as XRToolsMovementDirect

--- a/addons/godot-xr-tools/functions/movement_flight.gd
+++ b/addons/godot-xr-tools/functions/movement_flight.gd
@@ -108,9 +108,14 @@ var _controller : ARVRController
 
 
 # Node references
-onready var _camera : ARVRCamera = ARVRHelpers.get_arvr_camera(self)
-onready var _left_controller : ARVRController = ARVRHelpers.get_left_controller(self)
-onready var _right_controller : ARVRController = ARVRHelpers.get_right_controller(self)
+onready var _camera := ARVRHelpers.get_arvr_camera(self)
+onready var _left_controller := ARVRHelpers.get_left_controller(self)
+onready var _right_controller := ARVRHelpers.get_right_controller(self)
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementFlight" or .is_class(name)
 
 
 func _ready():
@@ -209,5 +214,17 @@ func set_flying(active: bool) -> void:
 
 # This method verifies the movement provider has a valid configuration.
 func _get_configuration_warning():
+	# Verify the camera
+	if !ARVRHelpers.get_arvr_camera(self):
+		return "Unable to find ARVRCamera"
+
+	# Verify the left controller
+	if !ARVRHelpers.get_left_controller(self):
+		return "Unable to find left ARVRController node"
+
+	# Verify the right controller
+	if !ARVRHelpers.get_right_controller(self):
+		return "Unable to find left ARVRController node"
+
 	# Call base class
 	return ._get_configuration_warning()

--- a/addons/godot-xr-tools/functions/movement_glide.gd
+++ b/addons/godot-xr-tools/functions/movement_glide.gd
@@ -55,9 +55,16 @@ export var horizontal_slew_rate : float = 1.0
 export var vertical_slew_rate : float = 2.0
 
 
-# Node references
+# Left controller
 onready var _left_controller := ARVRHelpers.get_left_controller(self)
+
+# Right controller
 onready var _right_controller := ARVRHelpers.get_right_controller(self)
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementGlide" or .is_class(name)
 
 
 func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bool):
@@ -120,14 +127,12 @@ func _set_gliding(active: bool) -> void:
 # This method verifies the movement provider has a valid configuration.
 func _get_configuration_warning():
 	# Verify the left controller
-	var test_left_controller_node := ARVRHelpers.get_left_controller(self)
-	if !test_left_controller_node:
-		return "Unable to find left ARVR Controller node"
+	if !ARVRHelpers.get_left_controller(self):
+		return "Unable to find left ARVRController node"
 
 	# Verify the right controller
-	var test_right_controller_node := ARVRHelpers.get_right_controller(self)
-	if !test_right_controller_node:
-		return "Unable to find right ARVR Controller node"
+	if !ARVRHelpers.get_right_controller(self):
+		return "Unable to find right ARVRController node"
 
 	# Check glide parameters
 	if glide_min_fall_speed > 0:

--- a/addons/godot-xr-tools/functions/movement_grapple.gd
+++ b/addons/godot-xr-tools/functions/movement_grapple.gd
@@ -73,13 +73,18 @@ onready var _line : CSGCylinder = $LineHelper/Line
 
 # Get Controller node - consider way to universalize this if user wanted to attach this
 # to a gun instead of player's hand.  Could consider variable to select controller instead.
-onready var _controller : ARVRController = get_parent()
+onready var _controller := ARVRHelpers.get_arvr_controller(self)
 
 # Get Raycast node
 onready var _grapple_raycast : RayCast = $Grapple_RayCast
 
 # Get Grapple Target Node
 onready var _grapple_target : Spatial = $Grapple_Target
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementGrapple" or .is_class(name)
 
 
 # Function run when node is added to scene
@@ -206,9 +211,8 @@ func _set_grappling(active: bool) -> void:
 # This method verifies the movement provider has a valid configuration.
 func _get_configuration_warning():
 	# Check the controller node
-	var test_controller = get_parent()
-	if !test_controller or !test_controller is ARVRController:
-		return "Unable to find ARVR Controller node"
+	if !ARVRHelpers.get_arvr_controller(self):
+		return "This node must be within a branch of an ARVRController node"
 
 	# Call base class
 	return ._get_configuration_warning()

--- a/addons/godot-xr-tools/functions/movement_jump.gd
+++ b/addons/godot-xr-tools/functions/movement_jump.gd
@@ -22,8 +22,15 @@ export var order : int = 20
 ## Button to trigger jump
 export (XRTools.Buttons) var jump_button_id : int = XRTools.Buttons.VR_TRIGGER
 
+
 # Node references
-onready var _controller: ARVRController = get_parent()
+onready var _controller := ARVRHelpers.get_arvr_controller(self)
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementJump" or .is_class(name)
+
 
 # Perform jump movement
 func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
@@ -39,9 +46,8 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 # This method verifies the movement provider has a valid configuration.
 func _get_configuration_warning():
 	# Check the controller node
-	var test_controller = get_parent()
-	if !test_controller or !test_controller is ARVRController:
-		return "Unable to find ARVR Controller node"
+	if !ARVRHelpers.get_arvr_controller(self):
+		return "This node must be within a branch of an ARVRController node"
 
 	# Call base class
 	return ._get_configuration_warning()

--- a/addons/godot-xr-tools/functions/movement_physical_jump.gd
+++ b/addons/godot-xr-tools/functions/movement_physical_jump.gd
@@ -52,10 +52,10 @@ var _controller_left_velocity : SlidingAverage = SlidingAverage.new(5)
 var _controller_right_velocity : SlidingAverage = SlidingAverage.new(5)
 
 # Node references
-onready var _origin_node : ARVROrigin = ARVRHelpers.get_arvr_origin(self)
-onready var _camera_node : ARVRCamera = ARVRHelpers.get_arvr_camera(self)
-onready var _controller_left_node : ARVRController = ARVRHelpers.get_left_controller(self)
-onready var _controller_right_node : ARVRController = ARVRHelpers.get_right_controller(self)
+onready var _origin_node := ARVRHelpers.get_arvr_origin(self)
+onready var _camera_node := ARVRHelpers.get_arvr_camera(self)
+onready var _controller_left_node := ARVRHelpers.get_left_controller(self)
+onready var _controller_right_node := ARVRHelpers.get_right_controller(self)
 
 
 # Sliding Average class
@@ -93,6 +93,11 @@ class SlidingAverage:
 		return _sum / _size
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementPhysicalJump" or .is_class(name)
+
+
 # Perform jump detection
 func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
 	# Handle detecting body jump
@@ -102,6 +107,28 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: b
 	# Handle detecting arms jump
 	if arms_jump_enable:
 		_detect_arms_jump(delta, player_body)
+
+
+# This method verifies the movement provider has a valid configuration.
+func _get_configuration_warning():
+	# Verify the camera
+	if !ARVRHelpers.get_arvr_origin(self):
+		return "This node must be within a branch of an ARVROrigin node"
+
+	# Verify the camera
+	if !ARVRHelpers.get_arvr_camera(self):
+		return "Unable to find ARVRCamera"
+
+	# Verify the left controller
+	if !ARVRHelpers.get_left_controller(self):
+		return "Unable to find left ARVRController node"
+
+	# Verify the right controller
+	if !ARVRHelpers.get_right_controller(self):
+		return "Unable to find left ARVRController node"
+
+	# Call base class
+	return ._get_configuration_warning()
 
 
 # Detect the player jumping with their body (using the headset camera)

--- a/addons/godot-xr-tools/functions/movement_provider.gd
+++ b/addons/godot-xr-tools/functions/movement_provider.gd
@@ -25,25 +25,6 @@ export var enabled : bool = true
 var is_active := false
 
 
-# Get our XRToolsPlayerBody, this should be a node on our ARVROrigin node.
-func get_player_body() -> XRToolsPlayerBody:
-	# get our origin node
-	var arvr_origin := ARVRHelpers.get_arvr_origin(self)
-	if !arvr_origin:
-		return null
-
-	# checking if the node exists before fetching it prevents error spam
-	if !arvr_origin.has_node("PlayerBody"):
-		return null
-
-	# get our player node
-	var player_body := arvr_origin.get_node("PlayerBody") as XRToolsPlayerBody
-	if player_body:
-		return player_body
-
-	return null
-
-
 # If missing we need to add our XRToolsPlayerBody
 func _create_player_body_node():
 	# get our origin node
@@ -52,14 +33,19 @@ func _create_player_body_node():
 		return
 
 	# Double check if it hasn't already been created by another movement function
-	var player_body = get_player_body()
+	var player_body := XRToolsPlayerBody.find_instance(self)
 	if !player_body:
 		# create our XRToolsPlayerBody node and add it into our tree
-		player_body = preload("res://addons/godot-xr-tools/player/player_body.tscn")
-		player_body = player_body.instance()
+		var player_body_scene = preload("res://addons/godot-xr-tools/player/player_body.tscn")
+		player_body = player_body_scene.instance()
 		player_body.set_name("PlayerBody")
 		arvr_origin.add_child(player_body)
 		player_body.set_owner(get_tree().get_edited_scene_root())
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementProvider" or .is_class(name)
 
 
 # Function run when node is added to scene
@@ -67,7 +53,7 @@ func _ready():
 	# If we're in the editor, help the user out by creating our XRToolsPlayerBody node
 	# automatically when needed.
 	if Engine.editor_hint:
-		var player_body = get_player_body()
+		var player_body = XRToolsPlayerBody.find_instance(self)
 		if !player_body:
 			# This call needs to be deferred, we can't add nodes during scene construction
 			call_deferred("_create_player_body_node")
@@ -81,12 +67,10 @@ func physics_movement(_delta: float, _player_body: XRToolsPlayerBody, _disabled:
 # This method verifies the movement provider has a valid configuration.
 func _get_configuration_warning():
 	# Verify we're within the tree of an ARVROrigin node
-	var arvr_origin = ARVRHelpers.get_arvr_origin(self)
-	if !arvr_origin:
+	if !ARVRHelpers.get_arvr_origin(self):
 		return "This node must be within a branch on an ARVROrigin node"
 
-	var player_body = get_player_body()
-	if !player_body:
+	if !XRToolsPlayerBody.find_instance(self):
 		return "Missing PlayerBody node on the ARVROrigin"
 
 	# Verify movement provider is in the correct group

--- a/addons/godot-xr-tools/functions/movement_sprint.gd
+++ b/addons/godot-xr-tools/functions/movement_sprint.gd
@@ -17,7 +17,9 @@ signal sprinting_started()
 ## Signal emitted when sprinting finishes
 signal sprinting_finished()
 
-## Enumeration of controller to use for triggering sprinting.  This allows the developer to assign the sprint button to either controller
+
+## Enumeration of controller to use for triggering sprinting.  This allows the
+## developer to assign the sprint button to either controller.
 enum SprintController {
 	LEFT,		# Use left controller
 	RIGHT,		# Use right controler
@@ -28,6 +30,7 @@ enum SprintType {
 	HOLD_TO_SPRINT,	## Hold button to sprint
 	TOGGLE_SPRINT,	## Toggle sprinting on button press
 }
+
 
 ## Type of sprinting
 export (SprintType) var sprint_type : int = SprintType.HOLD_TO_SPRINT
@@ -44,11 +47,9 @@ export (SprintController) var controller : int = SprintController.LEFT
 ## Sprint button
 export (XRTools.Buttons) var sprint_button : int = XRTools.Buttons.VR_PAD
 
+
 # Sprint controller
 var _controller : ARVRController
-
-## Sprinting flag
-var _sprinting : bool = false
 
 ## Sprint button down state
 var _sprint_button_down : bool = false
@@ -59,41 +60,28 @@ var _left_controller_original_max_speed : float = 0.0
 ## Variable to hold right controller direct movement node original max speed
 var _right_controller_original_max_speed : float = 0.0
 
+
 ## Variable used to cache left controller direct movement function, if any 
-var _left_controller_direct_move : XRToolsMovementDirect = null 
+onready var _left_controller_direct_move := XRToolsMovementDirect.find_left(self)
 
 ## Variable used to cache right controller direct movement function, if any
-var _right_controller_direct_move : XRToolsMovementDirect = null
+onready var _right_controller_direct_move := XRToolsMovementDirect.find_right(self)
 
-## Fetch left controller
-onready var _left_controller : ARVRController = ARVRHelpers.get_left_controller(self)
 
-## Fetch right controller
-onready var _right_controller : ARVRController = ARVRHelpers.get_right_controller(self)
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementSprint" or .is_class(name)
 
 
 func _ready():
 	# Get the sprinting controller
 	if controller == SprintController.LEFT:
-		_controller = _left_controller
+		_controller = ARVRHelpers.get_left_controller(self)
 	else:
-		_controller = _right_controller
+		_controller = ARVRHelpers.get_right_controller(self)
 
-	# Cache the left controller direct movement node, if any
-	var left_controller_nodes = _left_controller.get_children()
-	for child in left_controller_nodes:
-		if child is XRToolsMovementDirect:
-			_left_controller_direct_move = child
-			break
-	
-	# Cache the right controller direct movement node, if any
-	var right_controller_nodes = _right_controller.get_children()
-	for child in right_controller_nodes:
-		if child is XRToolsMovementDirect:
-			_right_controller_direct_move = child
-			break
-	
-	
+
 # Perform sprinting
 func physics_movement(_delta: float, player_body: XRToolsPlayerBody, disabled: bool):
 	# Skip if the controller isn't active or is not enabled 
@@ -107,7 +95,7 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, disabled: b
 	_sprint_button_down = sprint_button_down
 
 	# Calculate new sprinting state
-	var sprinting := _sprinting
+	var sprinting := is_active
 	match sprint_type:
 		SprintType.HOLD_TO_SPRINT:
 			# Sprint when button down
@@ -119,14 +107,10 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, disabled: b
 				sprinting = !sprinting
 
 	# Update sprinting state
-	if sprinting != _sprinting:
-		_sprinting = sprinting
-		if sprinting:
-			set_sprinting(true)
-		else:
-			set_sprinting(false)
-			
-			
+	if sprinting != is_active:
+		set_sprinting(sprinting)
+
+
 # Public function used to set sprinting active or not active
 func set_sprinting(active: bool) -> void:
 	# Skip if no change
@@ -140,25 +124,22 @@ func set_sprinting(active: bool) -> void:
 	if is_active:
 		# We are sprinting
 		emit_signal("sprinting_started")
-		_sprinting = true
-		
+
 		# Since max speeds could be changed while game is running, check now for original max speeds of left and right nodes	
 		if _left_controller_direct_move:
 			_left_controller_original_max_speed = _left_controller_direct_move.max_speed
 		if _right_controller_direct_move:
 			_right_controller_original_max_speed = _right_controller_direct_move.max_speed
-		
+
 		# Set both controllers' direct movement functions, if appliable, to the sprinting speed
 		if _left_controller_direct_move:
 			_left_controller_direct_move.max_speed = _left_controller_original_max_speed * sprint_speed_multiplier
 		if _right_controller_direct_move:
 			_right_controller_direct_move.max_speed = _right_controller_original_max_speed * sprint_speed_multiplier
-	
 	else:
 		# We are not sprinting
 		emit_signal("sprinting_finished")
-		_sprinting = false
-		
+
 		# Set both controllers' direct movement functions, if applicable, to their original speeds
 		if _left_controller_direct_move:
 			_left_controller_direct_move.max_speed = _left_controller_original_max_speed
@@ -168,21 +149,9 @@ func set_sprinting(active: bool) -> void:
 
 # This method verifies the movement provider has a valid configuration.
 func _get_configuration_warning():
+	# Make sure player has at least one direct movement node
+	if !XRToolsMovementDirect.find_left(self) and !XRToolsMovementDirect.find_right(self):
+		return "Unable to find XRToolsMovementDirect instance for player to support sprinting"
 	
-#	# Make sure player has at least one direct movement node
-	var test_left_controller_nodes = _left_controller.get_children()
-	for child in test_left_controller_nodes:
-		if child is XRToolsMovementDirect:
-			# At least one direct movement node found, so call base class
-			return ._get_configuration_warning()
-	
-	# Get the right controller direct movement node, if any
-	var test_right_controller_nodes = _right_controller.get_children()
-	for child in test_right_controller_nodes:
-		if child is XRToolsMovementDirect:
-			# At least one direct movement node found, so call base class
-			return ._get_configuration_warning()
-
-	# Could not find any direct movement node if have not returned so far, so display error
-	return "Unable to find XRToolsMovementDirect instance for player to support sprinting"
-	
+	# Call base class
+	return ._get_configuration_warning()

--- a/addons/godot-xr-tools/functions/movement_turn.gd
+++ b/addons/godot-xr-tools/functions/movement_turn.gd
@@ -42,15 +42,13 @@ var _turn_step : float = 0.0
 
 
 # Controller node
-onready var _controller : ARVRController = get_parent()
+onready var _controller := ARVRHelpers.get_arvr_controller(self)
 
-func _snap_turning():
-	if turn_mode == TurnMode.SNAP:
-		return true
-	elif turn_mode == TurnMode.SMOOTH:
-		return false
-	else:
-		return XRToolsUserSettings.snap_turning
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementTurn" or .is_class(name)
+
 
 # Perform jump movement
 func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
@@ -99,9 +97,17 @@ func _rotate_player(player_body: XRToolsPlayerBody, angle: float):
 # This method verifies the movement provider has a valid configuration.
 func _get_configuration_warning():
 	# Check the controller node
-	var test_controller = get_parent()
-	if !test_controller or !test_controller is ARVRController:
+	if !ARVRHelpers.get_arvr_controller(self):
 		return "Unable to find ARVR Controller node"
 
 	# Call base class
 	return ._get_configuration_warning()
+
+
+func _snap_turning():
+	if turn_mode == TurnMode.SNAP:
+		return true
+	elif turn_mode == TurnMode.SMOOTH:
+		return false
+	else:
+		return XRToolsUserSettings.snap_turning

--- a/addons/godot-xr-tools/functions/movement_wind.gd
+++ b/addons/godot-xr-tools/functions/movement_wind.gd
@@ -27,6 +27,11 @@ var _in_wind_areas := Array()
 var _active_wind_area : XRToolsWindArea
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMovementWind" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Skip if running in the editor

--- a/addons/godot-xr-tools/hands/hand.gd
+++ b/addons/godot-xr-tools/hands/hand.gd
@@ -64,6 +64,11 @@ var _tree_root : AnimationNodeBlendTree
 var _pose_overrides := []
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsHand" or .is_class(name)
+
+
 ## Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	# Save the initial hand transform
@@ -141,6 +146,17 @@ func _get_configuration_warning():
 
 	# Passed basic validation
 	return ""
+
+
+## Find an [XRToolsHand] node.
+##
+## This function searches from the specified node for an [XRToolsHand] assuming
+## the node is a sibling of the hand under an [ARVRController].
+static func find_instance(node : Node) -> XRToolsHand:
+	return XRTools.find_child(
+		ARVRHelpers.get_arvr_controller(node),
+		"*",
+		"XRToolsHand") as XRToolsHand
 
 
 ## Set the hand material override

--- a/addons/godot-xr-tools/hands/hand_physics_bone.gd
+++ b/addons/godot-xr-tools/hands/hand_physics_bone.gd
@@ -48,10 +48,15 @@ var _physics_bone : KinematicBody
 var _skeletal_bone : Spatial
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsHandPhysicsBone" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Connect the 'hand_scale_changed' signal
-	var physics_hand := _find_physics_hand()
+	var physics_hand := XRToolsHand.find_instance(self) as XRToolsPhysicsHand
 	if physics_hand:
 		physics_hand.connect("hand_scale_changed", self, "_on_hand_scale_changed")
 
@@ -134,17 +139,3 @@ func _on_hand_scale_changed(scale: float) -> void:
 	# Adjust the shape
 	_bone_shape.radius = width_scaled
 	_bone_shape.height = length_scaled
-
-
-# Find the physics hand for this bone
-func _find_physics_hand() -> XRToolsPhysicsHand:
-	# Search up for a node with the 'hand_scale_changed' signal
-	var current : Node = self
-	while current:
-		var hand := current as XRToolsPhysicsHand
-		if hand:
-			return hand
-		current = current.get_parent()
-
-	# Could not find hand
-	return null

--- a/addons/godot-xr-tools/hands/physics_hand.gd
+++ b/addons/godot-xr-tools/hands/physics_hand.gd
@@ -20,3 +20,8 @@ export var margin : float = 0.004
 
 ## Bone group for all bones in the hand
 export var bone_group : String = ""
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsPhysicsHand" or .is_class(name)

--- a/addons/godot-xr-tools/interactables/interactable_area_button.gd
+++ b/addons/godot-xr-tools/interactables/interactable_area_button.gd
@@ -47,6 +47,11 @@ onready var _button_up := _button.transform.origin
 onready var _button_down := _button_up + displacement
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsInteractableAreaButton" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Construct the button animation tween

--- a/addons/godot-xr-tools/interactables/interactable_handle.gd
+++ b/addons/godot-xr-tools/interactables/interactable_handle.gd
@@ -29,6 +29,11 @@ export var snap_distance : float = 0.3
 onready var handle_origin: Spatial = get_parent()
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsInteractableHandle" or .is_class(name)
+
+
 # Called when this handle is added to the scene
 func _ready() -> void:
 	# Ensure we start at our origin

--- a/addons/godot-xr-tools/interactables/interactable_handle_driven.gd
+++ b/addons/godot-xr-tools/interactables/interactable_handle_driven.gd
@@ -26,6 +26,11 @@ signal released(interactable)
 var grabbed_handles := Array()
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsInteractableHandleDriven" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Hook picked_up and dropped signals from all child handles

--- a/addons/godot-xr-tools/interactables/interactable_hinge.gd
+++ b/addons/godot-xr-tools/interactables/interactable_hinge.gd
@@ -48,6 +48,11 @@ onready var _hinge_position_rad : float = deg2rad(hinge_position)
 onready var _default_position_rad : float = deg2rad(default_position)
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsInteractableHinge" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Set the initial position to match the initial hinge position value

--- a/addons/godot-xr-tools/interactables/interactable_joystick.gd
+++ b/addons/godot-xr-tools/interactables/interactable_joystick.gd
@@ -76,6 +76,11 @@ onready var _default_x_position_rad : float = deg2rad(default_x_position)
 onready var _default_y_position_rad : float = deg2rad(default_y_position)
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsInteractableJoystick" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Set the initial position to match the initial joystick position value

--- a/addons/godot-xr-tools/interactables/interactable_slider.gd
+++ b/addons/godot-xr-tools/interactables/interactable_slider.gd
@@ -41,6 +41,11 @@ export var default_position : float = 0.0
 export var default_on_release : bool = false
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsInteractableSlider" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	# Set the initial position to match the initial slider position value

--- a/addons/godot-xr-tools/misc/hold_button.gd
+++ b/addons/godot-xr-tools/misc/hold_button.gd
@@ -26,6 +26,11 @@ var time_held = 0.0
 var material : ShaderMaterial
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsHoldButton" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	material = $Visualise.get_surface_material(0)

--- a/addons/godot-xr-tools/misc/move_to.gd
+++ b/addons/godot-xr-tools/misc/move_to.gd
@@ -34,6 +34,11 @@ var _duration: float
 var _time: float = 0.0
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsMoveTo" or .is_class(name)
+
+
 ## Initialize the XRToolsMoveTo
 func _init():
 	# Disable processing until needed

--- a/addons/godot-xr-tools/objects/climbable.gd
+++ b/addons/godot-xr-tools/objects/climbable.gd
@@ -17,6 +17,11 @@ var press_to_hold : bool = true
 var grab_locations := {}
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsClimbable" or .is_class(name)
+
+
 # Called by XRToolsFunctionPickup
 func is_picked_up() -> bool:
 	return false

--- a/addons/godot-xr-tools/objects/hand_pose_area.gd
+++ b/addons/godot-xr-tools/objects/hand_pose_area.gd
@@ -16,3 +16,8 @@ export var left_pose : Resource
 
 ## Right hand pose settings (XRToolsHandPoseSettings)
 export var right_pose : Resource
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsHandPoseArea" or .is_class(name)

--- a/addons/godot-xr-tools/objects/highlight/highlight_material.gd
+++ b/addons/godot-xr-tools/objects/highlight/highlight_material.gd
@@ -14,6 +14,11 @@ var _original_materials = Array()
 var _highlight_mesh_instance: MeshInstance
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsHighlightMaterial" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Get the mesh to highlight

--- a/addons/godot-xr-tools/objects/highlight/highlight_ring.gd
+++ b/addons/godot-xr-tools/objects/highlight/highlight_ring.gd
@@ -3,6 +3,11 @@ class_name XRToolsHighlightRing
 extends MeshInstance
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsHighlightRing" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Turn off until requested

--- a/addons/godot-xr-tools/objects/highlight/highlight_visible.gd
+++ b/addons/godot-xr-tools/objects/highlight/highlight_visible.gd
@@ -3,6 +3,10 @@ class_name XRToolsHighlightVisible
 extends Spatial
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsHighlightVisible" or .is_class(name)
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/addons/godot-xr-tools/objects/interactable_area.gd
+++ b/addons/godot-xr-tools/objects/interactable_area.gd
@@ -7,3 +7,8 @@ signal pointer_released(at)
 signal pointer_moved(from, to)
 signal pointer_entered()
 signal pointer_exited()
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsInteractableArea" or .is_class(name)

--- a/addons/godot-xr-tools/objects/keyboard/virtual_keyboard_2d.gd
+++ b/addons/godot-xr-tools/objects/keyboard/virtual_keyboard_2d.gd
@@ -21,6 +21,11 @@ var _alt_down := false
 var _mode: int = KeyboardMode.LOWER_CASE
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsVirtualKeyboard2D" or .is_class(name)
+
+
 # Handle key pressed from VirtualKey
 func on_key_pressed(scan_code_text: String, unicode: int, shift: bool):
 	# Find the scan code

--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -104,6 +104,11 @@ onready var original_collision_mask : int = collision_mask
 onready var original_collision_layer : int = collision_layer
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsPickable" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Attempt to get the pickup center if provided

--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -44,6 +44,11 @@ var picked_up_ranged : bool = true
 var _object_in_grab_area = Array()
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsSnapZone" or .is_class(name)
+
+
 func _ready():
 	# Set collision shape radius
 	$CollisionShape.shape.radius = grab_distance

--- a/addons/godot-xr-tools/objects/wind_area.gd
+++ b/addons/godot-xr-tools/objects/wind_area.gd
@@ -6,3 +6,8 @@ export var wind_vector : Vector3 = Vector3.ZERO
 
 ## Wind drag factor
 export var drag : float = 1.0
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsWindArea" or .is_class(name)

--- a/addons/godot-xr-tools/overrides/ground_physics.gd
+++ b/addons/godot-xr-tools/overrides/ground_physics.gd
@@ -19,6 +19,11 @@ extends Node
 export var physics : Resource
 
 
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsGroundPhysics" or .is_class(name)
+
+
 # This method verifies the ground physics has a valid configuration.
 func _get_configuration_warning():
 	# Verify physics specified

--- a/addons/godot-xr-tools/player/player_body.gd
+++ b/addons/godot-xr-tools/player/player_body.gd
@@ -138,6 +138,12 @@ class SortProviderByOrder:
 	static func sort_by_order(a, b) -> bool:
 		return true if a.order < b.order else false
 
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsPlayerBody" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Get the movement providers ordered by increasing order
@@ -483,31 +489,12 @@ func _get_configuration_warning():
 	# Passed basic validation
 	return ""
 
-## Find the Player Body from a player node and an optional path
-static func get_player_body(node: Node, path: NodePath = NodePath("")) -> XRToolsPlayerBody:
-	var player_body: XRToolsPlayerBody
-
-	# Try using the node path first
-	if path:
-		player_body = node.get_node(path) as XRToolsPlayerBody
-		if player_body:
-			return player_body
-
-	# Get the origin
-	var arvr_origin := ARVRHelpers.get_arvr_origin(node)
-	if !arvr_origin:
-		return null
-
-	# Attempt to get by the default name
-	player_body = arvr_origin.get_node_or_null("PlayerBody") as XRToolsPlayerBody
-	if player_body:
-		return player_body
-
-	# Search all children of the origin for the XRToolsPlayerBody
-	for child in arvr_origin.get_children():
-		player_body = child as XRToolsPlayerBody
-		if player_body:
-			return player_body
-
-	# Could not find XRToolsPlayerBody
-	return null
+## Find an [XRToolsPlayerBody] node.
+##
+## This function searches from the specified node for an [XRToolsPlayerBody]
+## assuming the node is a sibling of the body under an [ARVROrigin].
+static func find_instance(node: Node) -> XRToolsPlayerBody:
+	return XRTools.find_child(
+		ARVRHelpers.get_arvr_origin(node),
+		"*",
+		"XRToolsPlayerBody") as XRToolsPlayerBody

--- a/addons/godot-xr-tools/player/poke/poke.gd
+++ b/addons/godot-xr-tools/player/poke/poke.gd
@@ -55,6 +55,12 @@ func _update_color() -> void:
 	if material:
 		material.albedo_color = color
 
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsPoke" or .is_class(name)
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Set as top level ensures we're placing this object in global space

--- a/addons/godot-xr-tools/staging/scene_base.gd
+++ b/addons/godot-xr-tools/staging/scene_base.gd
@@ -22,6 +22,12 @@ export (Environment) var environment
 
 ## Interface
 
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsSceneBase" or .is_class(name)
+
+
 func center_player_on(p_transform : Transform):
 	# In order to center our player so the players feet are at the location
 	# indicated by p_transform, and having our player looking in the required

--- a/addons/godot-xr-tools/staging/staging.gd
+++ b/addons/godot-xr-tools/staging/staging.gd
@@ -77,6 +77,12 @@ var arvr_camera : ARVRCamera
 var current_scene : XRToolsSceneBase
 var current_scene_path : String
 
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsStaging" or .is_class(name)
+
+
 func _on_exit_to_main_menu():
 	load_scene(main_scene)
 

--- a/addons/godot-xr-tools/xr_tools.gd
+++ b/addons/godot-xr-tools/xr_tools.gd
@@ -108,3 +108,135 @@ static func set_player_standard_height(p_height : float) -> void:
 		return
 
 	ProjectSettings.set_setting("godot_xr_tools/player/standard_height", p_height)
+
+## Find all children of the specified node matching the given criteria
+##
+## This function returns an array containing all children of the specified
+## node matching the given criteria. This function can be slow and find_child
+## is faster if only one child is needed.
+##
+## The pattern argument specifies the match pattern to check against the
+## node name. Use "*" to match anything.
+##
+## The type argument specifies the type of node to find. Use "" to match any
+## type.
+##
+## The recursive argument specifies whether the search deeply though all child
+## nodes, or whether to only check the immediate children.
+##
+## The owned argument specifies whether the node must be owned.
+static func find_children(
+		node : Node, 
+		pattern : String, 
+		type : String = "", 
+		recursive : bool = true, 
+		owned : bool = true) -> Array:
+	# Find the children
+	var found := []
+	if node:
+		_find_children(found, node, pattern, type, recursive, owned)
+	return found
+
+## Find a child of the specified node matching the given criteria
+##
+## This function finds the first child of the specified node matching the given
+## criteria.
+##
+## The pattern argument specifies the match pattern to check against the
+## node name. Use "*" to match anything.
+##
+## The type argument specifies the type of node to find. Use "" to match any
+## type.
+##
+## The recursive argument specifies whether the search deeply though all child
+## nodes, or whether to only check the immediate children.
+##
+## The owned argument specifies whether the node must be owned.
+static func find_child(
+		node : Node, 
+		pattern : String, 
+		type : String = "", 
+		recursive : bool = true, 
+		owned : bool = true) -> Node:
+	# Find the child
+	if node:
+		return _find_child(node, pattern, type, recursive, owned)
+
+	# Invalid node
+	return null
+
+## Find an ancestor of the specified node matching the given criteria
+##
+## This function finds the first ancestor of the specified node matching the 
+## given criteria.
+##
+## The pattern argument specifies the match pattern to check against the
+## node name. Use "*" to match anything.
+##
+## The type argument specifies the type of node to find. Use "" to match any
+## type.
+static func find_ancestor(
+		node : Node, 
+		pattern : String, 
+		type : String = "") -> Node:
+	# Loop finding ancestor
+	while node:
+		# If node matches filter then break
+		if (node.name.match(pattern) and (type == "" or node.is_class(type))):
+			break
+
+		# Advance to parent
+		node = node.get_parent()
+
+	# Return found node (or null)
+	return node
+
+# Recursive helper function for find_children.
+static func _find_children(
+		found : Array,
+		node : Node,
+		pattern : String,
+		type : String,
+		recursive : bool,
+		owned : bool) -> void:
+	# Iterate over all children
+	for i in node.get_child_count():
+		# Get the child
+		var child := node.get_child(i)
+
+		# If child matches filter then add it to the array
+		if (child.name.match(pattern) and
+			(type == "" or child.is_class(type)) and
+			(not owned or child.owner)):
+			found.push_back(child)
+
+		# If recursive is enabled then descend into children
+		if recursive:
+			_find_children(found, child, pattern, type, recursive, owned)
+
+# Recursive helper functiomn for find_child
+static func _find_child(
+		node : Node,
+		pattern : String,
+		type : String,
+		recursive : bool,
+		owned : bool) -> Node:
+	# Iterate over all children
+	for i in node.get_child_count():
+		# Get the child
+		var child := node.get_child(i)
+
+		# If child matches filter then return it
+		if (child.name.match(pattern) and
+			(type == "" or child.is_class(type)) and
+			(not owned or child.owner)):
+			return child
+
+		# If recursive is enabled then descend into children
+		if recursive:
+			var found := _find_child(child, pattern, type, recursive, owned)
+			if found:
+				return found
+	
+	# Not found
+	return null

--- a/project.godot
+++ b/project.godot
@@ -50,7 +50,7 @@ _global_script_classes=[ {
 "path": "res://addons/godot-xr-tools/functions/function_pointer.gd"
 }, {
 "base": "Spatial",
-"class": "XRToolsFunctionPoseArea",
+"class": "XRToolsFunctionPoseDetector",
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/functions/function_pose_detector.gd"
 }, {
@@ -259,6 +259,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/misc/velocity_averager_linear.gd"
 }, {
+"base": "Spatial",
+"class": "XRToolsVignette",
+"language": "GDScript",
+"path": "res://addons/godot-xr-tools/effects/vignette.gd"
+}, {
 "base": "CanvasLayer",
 "class": "XRToolsVirtualKeyboard2D",
 "language": "GDScript",
@@ -278,7 +283,7 @@ _global_script_class_icons={
 "XRToolsFallDamage": "",
 "XRToolsFunctionPickup": "res://addons/godot-xr-tools/editor/icons/function.svg",
 "XRToolsFunctionPointer": "res://addons/godot-xr-tools/editor/icons/function.svg",
-"XRToolsFunctionPoseArea": "res://addons/godot-xr-tools/editor/icons/hand.svg",
+"XRToolsFunctionPoseDetector": "res://addons/godot-xr-tools/editor/icons/hand.svg",
 "XRToolsFunctionTeleport": "res://addons/godot-xr-tools/editor/icons/function.svg",
 "XRToolsGroundPhysics": "",
 "XRToolsGroundPhysicsSettings": "",
@@ -320,6 +325,7 @@ _global_script_class_icons={
 "XRToolsStaging": "",
 "XRToolsVelocityAverager": "",
 "XRToolsVelocityAveragerLinear": "",
+"XRToolsVignette": "",
 "XRToolsVirtualKeyboard2D": "",
 "XRToolsWindArea": ""
 }


### PR DESCRIPTION
This pull request fixes issue #263 by adding find-support to all XRTools classes. This change includes:
- Adding is_class() override to XRTools classes to support node-search routines
- Moving static node-search routines from ARVRHelpers to XRTools class
- Adding static ARVRHelpers.get_arvr_controller() method
- Adding static find methods to key XRTools classes

The XRTools classes now make use of these find routines in many areas, which results in the following changes:
- Numerous bespoke search routines could be removed simplifying code
- Many nodes can find their dependency nodes using onready assignment - simplifying their implementation
- The new ARVRHelpers.get_arvr_controller allows for more flexible node hierarchies under controllers
