### PR TITLE
add option to rotate player on arms roll movement, during glide action

### DIFF
--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -69,6 +69,7 @@ jump_button_id = 7
 [node name="MovementClimb" parent="ARVROrigin" index="4" instance=ExtResource( 8 )]
 
 [node name="MovementGlide" parent="ARVROrigin" index="5" instance=ExtResource( 7 )]
+turn_with_roll = true
 
 [node name="MovementWind" parent="ARVROrigin" index="6" instance=ExtResource( 22 )]
 


### PR DESCRIPTION
This PR adds an option to enable yaw movement for the player on roll action with hands. You can turn by rolling left or right without moving your feets. There is also a new exported variable to multiply the turning angle.

By rolling i mean rotate the torso by moving one hand up and the other down, as in a plane or glide.

I created an intermediate variable called left_to_right_vector to avoid repeating the left_to_right vector calculation.

I copied _rotate_player function from MovementTurn node script to apply the movement. Not sure if it's the most convenient way to do this.

It's my first collaboration, so please let me know if you find it interesting or if  i need to fix something.

