### PR TITLE
Make new XROrigin3D current after loading new scene

### DIFF
--- a/addons/godot-xr-tools/staging/scene_base.gd
+++ b/addons/godot-xr-tools/staging/scene_base.gd
@@ -48,6 +48,7 @@ func scene_loaded():
 	
 	# Make sure our camera becomes the current camera
 	$XROrigin3D/XRCamera3D.current = true
+	$XROrigin3D.current = true
 	
 	# Center our player on our origin point
 	# Note, this means you can place the XROrigin3D point in the start

--- a/addons/godot-xr-tools/staging/staging.gd
+++ b/addons/godot-xr-tools/staging/staging.gd
@@ -131,6 +131,7 @@ func load_scene(p_scene_path : String):
 
 		# Make our loading screen visible again and reset some stuff
 		xr_origin.set_process_internal(true)
+		xr_origin.current = true
 		xr_camera.current = true
 		$WorldEnvironment.environment = loading_screen_environment
 		$LoadingScreen.progress = 0.0


### PR DESCRIPTION
Without this, when using "staging", the old `XROrigin3D` will remain current, and even though locomotion still "works", it'll move around the old `XROrigin3D` rather than the new one.