### PR TITLE
Modified the teleport title to perform texture-tiling internally

### DIFF
--- a/assets/meshes/teleport/teleport_title_material.tres
+++ b/assets/meshes/teleport/teleport_title_material.tres
@@ -1,4 +1,4 @@
-[gd_resource type="ShaderMaterial" load_steps=9 format=2]
+[gd_resource type="ShaderMaterial" load_steps=10 format=2]
 
 [sub_resource type="VisualShaderNodeTextureUniform" id=5]
 uniform_name = "Title"
@@ -25,9 +25,12 @@ operator = 2
 default_input_values = [ 0, 0.0, 1, 5.0 ]
 operator = 4
 
+[sub_resource type="VisualShaderNodeVectorFunc" id=13]
+function = 20
+
 [sub_resource type="VisualShader" id=6]
 code = "shader_type spatial;
-render_mode specular_schlick_ggx, unshaded;
+render_mode specular_schlick_ggx, async_visible, unshaded;
 
 uniform sampler2D Title : hint_albedo;
 
@@ -60,11 +63,14 @@ void fragment() {
 // VectorOp:6
 	vec3 n_out6p0 = n_out5p0 + n_out7p0;
 
+// VectorFunc:9
+	vec3 n_out9p0 = fract(n_out6p0);
+
 // TextureUniform:2
 	vec3 n_out2p0;
 	float n_out2p1;
 	{
-		vec4 n_tex_read = texture(Title, n_out6p0.xy);
+		vec4 n_tex_read = texture(Title, n_out9p0.xy);
 		n_out2p0 = n_tex_read.rgb;
 		n_out2p1 = n_tex_read.a;
 	}
@@ -79,11 +85,11 @@ void light() {
 
 }
 "
-graph_offset = Vector2( -921.082, 269.413 )
+graph_offset = Vector2( -905.504, -97.5646 )
 flags/unshaded = true
-nodes/fragment/0/position = Vector2( 798, 252 )
+nodes/fragment/0/position = Vector2( 1060, 260 )
 nodes/fragment/2/node = SubResource( 5 )
-nodes/fragment/2/position = Vector2( 378, 315 )
+nodes/fragment/2/position = Vector2( 640, 320 )
 nodes/fragment/3/node = SubResource( 7 )
 nodes/fragment/3/position = Vector2( -378, 567 )
 nodes/fragment/4/node = SubResource( 8 )
@@ -91,12 +97,14 @@ nodes/fragment/4/position = Vector2( -640, 320 )
 nodes/fragment/5/node = SubResource( 9 )
 nodes/fragment/5/position = Vector2( -189, 294 )
 nodes/fragment/6/node = SubResource( 10 )
-nodes/fragment/6/position = Vector2( 84, 378 )
+nodes/fragment/6/position = Vector2( 60, 380 )
 nodes/fragment/7/node = SubResource( 11 )
 nodes/fragment/7/position = Vector2( -189, 546 )
 nodes/fragment/8/node = SubResource( 12 )
 nodes/fragment/8/position = Vector2( -400, 300 )
-nodes/fragment/connections = PoolIntArray( 5, 0, 6, 0, 6, 0, 2, 0, 3, 0, 7, 0, 7, 0, 6, 1, 2, 0, 0, 0, 8, 0, 5, 0, 4, 0, 8, 0 )
+nodes/fragment/9/node = SubResource( 13 )
+nodes/fragment/9/position = Vector2( 340, 400 )
+nodes/fragment/connections = PoolIntArray( 5, 0, 6, 0, 3, 0, 7, 0, 7, 0, 6, 1, 2, 0, 0, 0, 8, 0, 5, 0, 4, 0, 8, 0, 6, 0, 9, 0, 9, 0, 2, 0 )
 
 [resource]
 resource_local_to_scene = true


### PR DESCRIPTION
This modified the 3.x version of the teleport title shader to work the same as the 4.0 version in that the shader performs the texture-tiling rather than relying on tiling being turned on for the texture.