### PR TITLE
Clean godot-xr-tools to have no warnings against gdlint

### DIFF
--- a/.github/workflows/gdlint-on-push.yml
+++ b/.github/workflows/gdlint-on-push.yml
@@ -1,0 +1,25 @@
+# Workflow to automatically lint gdscript code
+name: gdlint on push
+
+on:
+  [push, pull_request]
+
+jobs:
+  gdlint:
+    name: gdlint scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install 'gdtoolkit==3.*'
+      - name: Lint Godot XR Tools
+        run: |
+          gdlint addons/godot-xr-tools

--- a/addons/godot-xr-tools/assets/resource_queue/resource_queue.gd
+++ b/addons/godot-xr-tools/assets/resource_queue/resource_queue.gd
@@ -1,166 +1,221 @@
+class_name XRToolsResourceQueue
 extends Node
 
-var thread
-var mutex
-var semaphore
-var exit_thread = false
 
-var time_max = 100 # Milliseconds.
-
-var queue = []
-var pending = {}
-
-func _lock(_caller):
-	mutex.lock()
+## XRTools Threaded Resource Loader
+##
+## This class can be used to perform resource loading in the background without
+## interrupting the application.
 
 
-func _unlock(_caller):
-	mutex.unlock()
+# Thread to perform the loading
+var _thread : Thread
+
+# Mutex for safe synchronization
+var _mutex : Mutex
+
+# Semaphore to wake up the loader thread
+var _semaphore : Semaphore
+
+# Thread exit flag
+var _exit_thread : bool = false
+
+# Queue of ResourceInteractiveLoader instances loading resources
+var _queue = []
+
+# Dictionary of pending results by resource path.
+#
+# If the resource is still loading then the value is a ResourceInteractiveLoader.
+# If the resource has loaded then the value is a Resource.
+var _pending = {}
 
 
-func _post(_caller):
-	semaphore.post()
+## Queue the loading of a resource
+func queue_resource(path : String, p_in_front : bool = false) -> void:
+	# Lock the synchronization mutex
+	_mutex.lock()
 
-
-func _wait(_caller):
-	semaphore.wait()
-
-
-func queue_resource(path, p_in_front = false):
-	_lock("queue_resource")
-	if path in pending:
-		_unlock("queue_resource")
-		return
-	elif ResourceLoader.has_cached(path):
-		var res = ResourceLoader.load(path)
-		pending[path] = res
-		_unlock("queue_resource")
-		return
-	else:
-		var res = ResourceLoader.load_interactive(path)
-		res.set_meta("path", path)
-		if p_in_front:
-			queue.insert(0, res)
-		else:
-			queue.push_back(res)
-		pending[path] = res
-		_post("queue_resource")
-		_unlock("queue_resource")
+	# Test if the resource has already been queued
+	if path in _pending:
+		# Work already queued, nothing to do.
+		_mutex.unlock()
 		return
 
+	# Test if the ResourceLoader already has it cached
+	if ResourceLoader.has_cached(path):
+		# Put the resource in the pending-results dictionary
+		_pending[path] = ResourceLoader.load(path)
+		_mutex.unlock()
+		return
 
-func cancel_resource(path):
-	_lock("cancel_resource")
-	if path in pending:
-		if pending[path] is ResourceInteractiveLoader:
-			queue.erase(pending[path])
-		pending.erase(path)
-	_unlock("cancel_resource")
+	# Construct a ResourceInteractiveLoader for the resource
+	var loader = ResourceLoader.load_interactive(path)
 
+	# Save the resource path in the metadata for later use
+	loader.set_meta("path", path)
 
-func get_progress(path):
-	_lock("get_progress")
-	var ret = -1
-	if path in pending:
-		if pending[path] is ResourceInteractiveLoader:
-			ret = float(pending[path].get_stage()) / float(pending[path].get_stage_count())
-		else:
-			ret = 1.0
-	_unlock("get_progress")
-	return ret
-
-
-func is_ready(path):
-	var ret
-	_lock("is_ready")
-	if path in pending:
-		ret = !(pending[path] is ResourceInteractiveLoader)
+	# Insert into the loading-queue (front for high priority)
+	if p_in_front:
+		_queue.push_front(loader)
 	else:
-		ret = false
-	_unlock("is_ready")
-	return ret
+		_queue.push_back(loader)
+
+	# Save the loader in the pending-results dictionary
+	_pending[path] = loader
+
+	# Post the semaphore to wake the worker thread
+	_mutex.unlock()
+	_semaphore.post()
 
 
-func _wait_for_resource(res, path):
-	_unlock("wait_for_resource")
-	while true:
-		VisualServer.sync()
-		OS.delay_usec(16000) # Wait approximately 1 frame.
-		_lock("wait_for_resource")
-		if queue.size() == 0 || queue[0] != res:
-			return pending[path]
-		_unlock("wait_for_resource")
+## Cancel loading a resource
+func cancel_resource(path : String) -> void:
+	# Lock the synchronization mutex
+	_mutex.lock()
+
+	# Inspect the pending-results dictionary
+	if path in _pending:
+		# Extract the item from the pending-results dictionary
+		var item = _pending[path]
+		_pending.erase(path)
+
+		# If the item is still being loaded then remove it from the loading-queue
+		if item is ResourceInteractiveLoader:
+			_queue.erase(item)
+
+	# Loading cancelled
+	_mutex.unlock()
 
 
-func get_resource(path):
-	_lock("get_resource")
-	if path in pending:
-		if pending[path] is ResourceInteractiveLoader:
-			var res = pending[path]
-			if res != queue[0]:
-				var pos = queue.find(res)
-				queue.remove(pos)
-				queue.insert(0, res)
+## Get the progress of a loading resource
+func get_progress(path : String) -> float:
+	# Lock the synchronization mutex
+	_mutex.lock()
 
-			res = _wait_for_resource(res, path)
-			pending.erase(path)
-			_unlock("return")
-			return res
+	# Inspect the pending results dictionary for the progress
+	var progress := -1.0
+	if path in _pending:
+		var item = _pending[path]
+		if item is ResourceInteractiveLoader:
+			# The item is still loading, calculate the progress
+			progress = float(item.get_stage()) / float(item.get_stage_count())
 		else:
-			var res = pending[path]
-			pending.erase(path)
-			_unlock("return")
-			return res
-	else:
-		_unlock("return")
+			# The item is fully loaded
+			progress = 1.0
+
+	# Return the progress
+	_mutex.unlock()
+	return progress
+
+
+## Test if a resouece is ready
+func is_ready(path : String) -> bool:
+	# Lock the synchronization mutex
+	_mutex.lock()
+
+	# Inspect the pending results dictionary for the ready status
+	var ready := false
+	if path in _pending:
+		var item = _pending[path]
+		ready = not item is ResourceInteractiveLoader
+
+	# Return the ready status
+	_mutex.unlock()
+	return ready
+
+
+## Get the resource
+func get_resource(path : String) -> Resource:
+	# Lock the synchronization mutex
+	_mutex.lock()
+
+	# Test if the resource is unknown
+	if not path in _pending:
+		# Not queued, just load immediately
+		_mutex.unlock()
 		return ResourceLoader.load(path)
 
-
-func thread_process():
-	_wait("thread_process")
-	_lock("process")
-
-	while queue.size() > 0:
-		var res = queue[0]
-		_unlock("process_poll")
-		var ret = res.poll()
-		_lock("process_check_queue")
-
-		if ret == ERR_FILE_EOF || ret != OK:
-			var path = res.get_meta("path")
-			if path in pending: # Else, it was already retrieved.
-				pending[res.get_meta("path")] = res.get_resource()
-			# Something might have been put at the front of the queue while
-			# we polled, so use erase instead of remove.
-			queue.erase(res)
-	_unlock("process")
-
-
-func thread_func(_u):
+	# Loop waiting for resource to load
+	var res
 	while true:
-		mutex.lock()
-		var should_exit = exit_thread # Protect with Mutex.
-		mutex.unlock()
+		# Get the item from the pending-results dictionary
+		res = _pending[path]
 
-		if should_exit:
+		# Detect loading complete
+		if res == null or res is Resource:
 			break
-		thread_process()
+
+		# Give thread more time to load the item
+		_mutex.unlock()
+		OS.delay_usec(16000) # Wait approximately 1 frame.
+		_mutex.lock();
+
+	_pending.erase(path)
+	_mutex.unlock()
+	return res
 
 
+## Start the resource queue
 func start():
-	mutex = Mutex.new()
-	semaphore = Semaphore.new()
-	thread = Thread.new()
-	thread.start(self, "thread_func", 0)
+	_mutex = Mutex.new()
+	_semaphore = Semaphore.new()
+	_thread = Thread.new()
+	_thread.start(self, "_thread_func", 0)
+
 
 # Triggered by calling "get_tree().quit()".
 func _exit_tree():
-	mutex.lock()
-	exit_thread = true # Protect with Mutex.
-	mutex.unlock()
+	_mutex.lock()
+	_exit_thread = true # Protect with Mutex.
+	_mutex.unlock()
 
-	# Unblock by posting.
-	semaphore.post()
+	# Wake the worker thread
+	_semaphore.post()
 
 	# Wait until it exits.
-	thread.wait_to_finish()
+	_thread.wait_to_finish()
+
+
+# Thread worker function
+func _thread_func(_u):
+	# Lock the synchronization mutex
+	_mutex.lock()
+
+	# Loop processing work
+	while true:
+		# Handle a request to terminate
+		if _exit_thread:
+			_mutex.unlock()
+			return
+
+		# Handle no work
+		if _queue.size() == 0:
+			# Wait for work (with the mutex unlocked so work can be added)
+			_mutex.unlock()
+			_semaphore.wait()
+			_mutex.lock()
+			continue
+
+		# Get the loader
+		var loader : ResourceInteractiveLoader = _queue.front()
+
+		# Poll the loader (with the mutex unlocked)
+		_mutex.unlock()
+		var err = loader.poll()
+		_mutex.lock()
+
+		# If loader is still busy then continue
+		if err == OK:
+			continue
+
+		# Remove from the loading-queue. Note that something may have been
+		# put at the front of the queue while we polled, so use erase instead
+		# of remove
+		_queue.erase(loader)
+
+		# Get the resource path from the loaders metadata
+		var path : String = loader.get_meta("path")
+
+		# If the result is still pending then update it with the resource
+		if path in _pending:
+			_pending[path] = loader.get_resource()

--- a/addons/godot-xr-tools/effects/vignette.gd
+++ b/addons/godot-xr-tools/effects/vignette.gd
@@ -153,12 +153,15 @@ func _process(delta):
 	# Calculate what our radius should be for our rotation speed
 	var target_radius = 1.0
 	if auto_rotation_limit > 0:
-		target_radius = 1.0 - (clamp(angle / auto_rotation_limit_rad, 0.0, 1.0) * (1.0 - auto_inner_radius))
+		target_radius = 1.0 - (
+			clamp(angle / auto_rotation_limit_rad, 0.0, 1.0) * (1.0 - auto_inner_radius))
 
-	# Now do the same for speed, this includes players physical speed but there isn't much we can do there.
+	# Now do the same for speed, this includes players physical speed but there
+	# isn't much we can do there.
 	if auto_velocity_limit > 0:
 		var velocity = delta_v.length() / delta
-		target_radius = min(target_radius, 1.0 - (clamp(velocity / auto_velocity_limit, 0.0, 1.0) * (1.0 - auto_inner_radius)))
+		target_radius = min(target_radius, 1.0 - (
+				clamp(velocity / auto_velocity_limit, 0.0, 1.0) * (1.0 - auto_inner_radius)))
 
 	# if our radius is small then our current we apply it
 	if target_radius < radius:

--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -37,7 +37,8 @@ export (XRTools.Buttons) var action_button_id = XRTools.Buttons.VR_TRIGGER
 export var grab_distance : float = 0.3 setget _set_grab_distance
 
 ## Grab collision mask
-export (int, LAYERS_3D_PHYSICS) var grab_collision_mask : int = 1 setget _set_grab_collision_mask
+export (int, LAYERS_3D_PHYSICS) \
+		var grab_collision_mask : int = 1 setget _set_grab_collision_mask
 
 ## If true, ranged-grabbing is enabled
 export var ranged_enable : bool = true
@@ -49,7 +50,8 @@ export var ranged_distance : float = 5.0 setget _set_ranged_distance
 export (float, 0.0, 45.0) var ranged_angle : float = 5.0 setget _set_ranged_angle
 
 ## Ranged-grab collision mask
-export (int, LAYERS_3D_PHYSICS) var ranged_collision_mask : int = 1 setget _set_ranged_collision_mask
+export (int, LAYERS_3D_PHYSICS) \
+		var ranged_collision_mask : int = 1 setget _set_ranged_collision_mask
 
 ## Throw impulse factor
 export var impulse_factor : float = 1.0
@@ -325,7 +327,8 @@ func _get_closest_grab() -> Spatial:
 			continue
 
 		# Save if this object is closer than the current best
-		var distance_squared := global_transform.origin.distance_squared_to(o.global_transform.origin)
+		var distance_squared := global_transform.origin.distance_squared_to(
+				o.global_transform.origin)
 		if distance_squared < new_closest_distance:
 			new_closest_obj = o
 			new_closest_distance = distance_squared

--- a/addons/godot-xr-tools/functions/function_teleport.gd
+++ b/addons/godot-xr-tools/functions/function_teleport.gd
@@ -152,8 +152,11 @@ func _physics_process(delta):
 		query.margin = get_safe_margin()
 		query.shape_rid = collision_shape.get_rid()
 
-		# make a transform for rotating and offseting our shape, it's always lying on its side by default...
-		var shape_transform = Transform(Basis(Vector3(1.0, 0.0, 0.0), deg2rad(90.0)), Vector3(0.0, player_height / 2.0, 0.0))
+		# make a transform for rotating and offseting our shape, it's always
+		# lying on its side by default...
+		var shape_transform = Transform(
+				Basis(Vector3(1.0, 0.0, 0.0), deg2rad(90.0)),
+				Vector3(0.0, player_height / 2.0, 0.0))
 
 		# update location
 		var teleport_global_transform = $Teleport.global_transform
@@ -163,7 +166,8 @@ func _physics_process(delta):
 		############################################################
 		# New teleport logic
 		# We're going to use test move in steps to find out where we hit something...
-		# This can be optimised loads by determining the lenght based on the angle between sections extending the length when we're in a flat part of the arch
+		# This can be optimised loads by determining the lenght based on the angle
+		# between sections extending the length when we're in a flat part of the arch
 		# Where we do get a collission we may want to fine tune the collision
 		var cast_length = 0.0
 		var fine_tune = 1.0
@@ -199,7 +203,8 @@ func _physics_process(delta):
 
 				# check for collision
 				if global_target.y > target_global_origin.y:
-					# if we're moving up, we hit the ceiling of something, we don't really care what
+					# if we're moving up, we hit the ceiling of something, we
+					# don't really care what
 					is_on_floor = false
 				else:
 					# now we cast a ray downwards to see if we're on a surface
@@ -219,7 +224,8 @@ func _physics_process(delta):
 						else:
 							is_on_floor = false
 
-						# Update our collision point if it's moved enough, this solves a little bit of jittering
+						# Update our collision point if it's moved enough, this
+						# solves a little bit of jittering
 						var diff = collided_at - intersects["position"]
 
 						if diff.length() > 0.1:
@@ -230,7 +236,8 @@ func _physics_process(delta):
 						if not valid_teleport_mask & collider_mask:
 							is_on_floor = false
 
-				# we are colliding, find our if we're colliding on a wall or floor, one we can do, the other nope...
+				# we are colliding, find our if we're colliding on a wall or
+				# floor, one we can do, the other nope...
 				cast_length += (collided_at - target_global_origin).length()
 				target_global_origin = collided_at
 				hit_something = true
@@ -252,11 +259,15 @@ func _physics_process(delta):
 				color = cant_teleport_color
 
 			# check our axis to see if we need to rotate
-			teleport_rotation += (delta * controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_X_AXIS) * -4.0)
+			teleport_rotation += (delta * controller.get_joystick_axis(
+					XRTools.Axis.VR_PRIMARY_X_AXIS) * -4.0)
 
 			# update target and colour
 			var target_basis = Basis()
-			target_basis.z = Vector3(teleport_global_transform.basis.z.x, 0.0, teleport_global_transform.basis.z.z).normalized()
+			target_basis.z = Vector3(
+					teleport_global_transform.basis.z.x,
+					0.0,
+					teleport_global_transform.basis.z.z).normalized()
 			target_basis.y = normal
 			target_basis.x = target_basis.y.cross(target_basis.z)
 			target_basis.z = target_basis.x.cross(target_basis.y)
@@ -282,18 +293,22 @@ func _physics_process(delta):
 			new_transform.basis.x = new_transform.basis.y.cross(new_transform.basis.z).normalized()
 			new_transform.basis.z = new_transform.basis.x.cross(new_transform.basis.y).normalized()
 
-			# find out our user's feet's transformation
+			# Find out our user's feet's transformation.
+			# The feet are on the ground, but have the same X,Z as the camera
 			var cam_transform = camera_node.transform
 			var user_feet_transform = Transform()
 			user_feet_transform.origin = cam_transform.origin
-			user_feet_transform.origin.y = 0 # the feet are on the ground, but have the same X,Z as the camera
+			user_feet_transform.origin.y = 0
 
 			# ensure this transform is upright
 			user_feet_transform.basis.y = Vector3(0.0, 1.0, 0.0)
-			user_feet_transform.basis.x = user_feet_transform.basis.y.cross(cam_transform.basis.z).normalized()
-			user_feet_transform.basis.z = user_feet_transform.basis.x.cross(user_feet_transform.basis.y).normalized()
+			user_feet_transform.basis.x = user_feet_transform.basis.y.cross(
+					cam_transform.basis.z).normalized()
+			user_feet_transform.basis.z = user_feet_transform.basis.x.cross(
+					user_feet_transform.basis.y).normalized()
 
-			# now move the origin such that the new global user_feet_transform would be == new_transform
+			# now move the origin such that the new global user_feet_transform
+			# would be == new_transform
 			origin_node.global_transform = new_transform * user_feet_transform.inverse()
 
 		# and disable

--- a/addons/godot-xr-tools/functions/movement_direct.gd
+++ b/addons/godot-xr-tools/functions/movement_direct.gd
@@ -38,11 +38,13 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 		return
 
 	# Apply forwards/backwards ground control
-	player_body.ground_control_velocity.y += _controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_Y_AXIS) * max_speed
+	player_body.ground_control_velocity.y += _controller.get_joystick_axis(
+			XRTools.Axis.VR_PRIMARY_Y_AXIS) * max_speed
 
 	# Apply left/right ground control
 	if strafe:
-		player_body.ground_control_velocity.x += _controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_X_AXIS) * max_speed
+		player_body.ground_control_velocity.x += _controller.get_joystick_axis(
+				XRTools.Axis.VR_PRIMARY_X_AXIS) * max_speed
 
 	# Clamp ground control
 	var length := player_body.ground_control_velocity.length()

--- a/addons/godot-xr-tools/functions/movement_flight.gd
+++ b/addons/godot-xr-tools/functions/movement_flight.gd
@@ -146,16 +146,19 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	var bearing_vector: Vector3
 	if bearing == FlightBearing.HEAD:
 		# Use the horizontal part of the 'head' forwards vector
-		bearing_vector = -player_body.up_player_plane.project(_camera.global_transform.basis.z)
+		bearing_vector = -player_body.up_player_plane.project(
+				_camera.global_transform.basis.z)
 	elif bearing == FlightBearing.CONTROLLER:
 		# Use the horizontal part of the 'controller' forwards vector
-		bearing_vector = -player_body.up_player_plane.project(_controller.global_transform.basis.z)
+		bearing_vector = -player_body.up_player_plane.project(
+				_controller.global_transform.basis.z)
 	else:
 		# Use the horizontal part of the 'body' forwards vector
 		var left := _left_controller.global_transform.origin
 		var right := _right_controller.global_transform.origin
 		var left_to_right := right - left
-		bearing_vector = player_body.up_player_plane.project(left_to_right.rotated(player_body.up_player_vector, PI/2))
+		bearing_vector = player_body.up_player_plane.project(
+				left_to_right.rotated(player_body.up_player_vector, PI/2))
 
 	# Construct the flight bearing
 	var forwards := (bearing_vector.normalized() + pitch_vector).normalized()

--- a/addons/godot-xr-tools/functions/movement_glide.gd
+++ b/addons/godot-xr-tools/functions/movement_glide.gd
@@ -68,7 +68,9 @@ func is_class(name : String) -> bool:
 
 func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bool):
 	# Skip if disabled or either controller is off
-	if disabled or !enabled or !_left_controller.get_is_active() or !_right_controller.get_is_active():
+	if disabled or !enabled or \
+		!_left_controller.get_is_active() or \
+		!_right_controller.get_is_active():
 		_set_gliding(false)
 		return
 
@@ -100,7 +102,8 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 
 	# Lerp the horizontal velocity towards forward_speed
 	var horizontal_velocity := player_body.up_gravity_plane.project(player_body.velocity)
-	var dir_forward := player_body.up_gravity_plane.project(left_to_right.rotated(player_body.up_gravity_vector, PI/2)).normalized()
+	var dir_forward := player_body.up_gravity_plane.project(
+			left_to_right.rotated(player_body.up_gravity_vector, PI/2)).normalized()
 	var forward_velocity := dir_forward * glide_forward_speed
 	horizontal_velocity = lerp(horizontal_velocity, forward_velocity, horizontal_slew_rate * delta)
 

--- a/addons/godot-xr-tools/functions/movement_grapple.gd
+++ b/addons/godot-xr-tools/functions/movement_grapple.gd
@@ -33,7 +33,8 @@ export var order : int = 20
 export var grapple_length : float = 15.0
 
 ## Grapple collision mask
-export (int, LAYERS_3D_PHYSICS) var grapple_collision_mask : int = 1 setget _set_grapple_collision_mask
+export (int, LAYERS_3D_PHYSICS) \
+		var grapple_collision_mask : int = 1 setget _set_grapple_collision_mask
 
 ## Impulse speed applied to the player on first grapple
 export var impulse_speed : float = 10.0
@@ -41,14 +42,17 @@ export var impulse_speed : float = 10.0
 ## Winch speed applied to the player while the grapple is held
 export var winch_speed : float = 2.0
 
-## Probably need to add export variables for line size, maybe line material at some point so dev does not need to make children editable to do this
-## For now, right click on grapple node and make children editable to edit these facets.
+## Probably need to add export variables for line size, maybe line material at
+## some point so dev does not need to make children editable to do this.
+## For now, right click on grapple node and make children editable to edit these
+## facets.
 export var rope_width : float = 0.02
 
 ## Air friction while grappling
 export var friction : float = 0.1
 
-## Grapple button (triggers grappling movement).  Be sure this button does not conflict with other functions.
+## Grapple button (triggers grappling movement).  Be sure this button does not
+## conflict with other functions.
 export (XRTools.Buttons) var grapple_button_id : int = XRTools.Buttons.VR_TRIGGER
 
 # Hook related variables
@@ -63,8 +67,9 @@ var _grapple_button := false
 onready var _line_helper : Spatial = $LineHelper
 onready var _line : CSGCylinder = $LineHelper/Line
 
-# Get Controller node - consider way to universalize this if user wanted to attach this
-# to a gun instead of player's hand.  Could consider variable to select controller instead.
+# Get Controller node - consider way to universalize this if user wanted to
+# attach this to a gun instead of player's hand.  Could consider variable to
+# select controller instead.
 onready var _controller := ARVRHelpers.get_arvr_controller(self)
 
 # Get Raycast node
@@ -91,7 +96,7 @@ func _ready():
 		grapple_length = min_hook_length
 
 	# Set ray-cast
-	_grapple_raycast.cast_to = Vector3(0, 0, -grapple_length) * ARVRServer.world_scale #Is WS necessary here?
+	_grapple_raycast.cast_to = Vector3(0, 0, -grapple_length) * ARVRServer.world_scale
 	_grapple_raycast.collision_mask = grapple_collision_mask
 
 	# Deal with line

--- a/addons/godot-xr-tools/functions/movement_physical_jump.gd
+++ b/addons/godot-xr-tools/functions/movement_physical_jump.gd
@@ -177,8 +177,14 @@ func _detect_arms_jump(delta: float, player_body: XRToolsPlayerBody) -> void:
 	controller_right_vel /= ARVRServer.world_scale
 
 	# Clamp the controller instantaneous velocity to +/- 2x the jump threshold
-	controller_left_vel = clamp(controller_left_vel, -2.0 * arms_jump_threshold, 2.0 * arms_jump_threshold)
-	controller_right_vel = clamp(controller_right_vel, -2.0 * arms_jump_threshold, 2.0 * arms_jump_threshold)
+	controller_left_vel = clamp(
+			controller_left_vel,
+			-2.0 * arms_jump_threshold,
+			2.0 * arms_jump_threshold)
+	controller_right_vel = clamp(
+			controller_right_vel,
+			-2.0 * arms_jump_threshold,
+			2.0 * arms_jump_threshold)
 
 	# Get the averaged velocity
 	controller_left_vel = _controller_left_velocity.update(controller_left_vel)

--- a/addons/godot-xr-tools/functions/movement_provider.gd
+++ b/addons/godot-xr-tools/functions/movement_provider.gd
@@ -14,6 +14,10 @@ extends Node
 ##  - Override the physics_movement method to impelment motion
 
 
+## Player body scene
+const PLAYER_BODY := preload("res://addons/godot-xr-tools/player/player_body.tscn")
+
+
 ## Enable movement provider
 export var enabled : bool = true
 
@@ -33,8 +37,7 @@ func _create_player_body_node():
 	var player_body := XRToolsPlayerBody.find_instance(self)
 	if !player_body:
 		# create our XRToolsPlayerBody node and add it into our tree
-		var player_body_scene := preload("res://addons/godot-xr-tools/player/player_body.tscn")
-		player_body = player_body_scene.instance()
+		player_body = PLAYER_BODY.instance()
 		player_body.set_name("PlayerBody")
 		arvr_origin.add_child(player_body)
 		player_body.set_owner(get_tree().get_edited_scene_root())

--- a/addons/godot-xr-tools/functions/movement_sprint.gd
+++ b/addons/godot-xr-tools/functions/movement_sprint.gd
@@ -137,9 +137,11 @@ func set_sprinting(active: bool) -> void:
 		# Set both controllers' direct movement functions, if appliable, to
 		# the sprinting speed
 		if _left_controller_direct_move:
-			_left_controller_direct_move.max_speed = _left_controller_original_max_speed * sprint_speed_multiplier
+			_left_controller_direct_move.max_speed = \
+					_left_controller_original_max_speed * sprint_speed_multiplier
 		if _right_controller_direct_move:
-			_right_controller_direct_move.max_speed = _right_controller_original_max_speed * sprint_speed_multiplier
+			_right_controller_direct_move.max_speed = \
+					_right_controller_original_max_speed * sprint_speed_multiplier
 	else:
 		# We are not sprinting
 		emit_signal("sprinting_finished")

--- a/addons/godot-xr-tools/hands/hand.gd
+++ b/addons/godot-xr-tools/hands/hand.gd
@@ -27,23 +27,6 @@ export var hand_material_override : Material setget set_hand_material_override
 export var default_pose : Resource setget set_default_pose
 
 
-## Pose-override class
-class PoseOverride:
-	## Who requested the override
-	var who : Node
-
-	## Pose priority
-	var priority : int
-
-	## Pose settings
-	var settings : XRToolsHandPoseSettings
-
-	## Pose-override constructor
-	func _init(w : Node, p : int, s : XRToolsHandPoseSettings):
-		who = w
-		priority = p
-		settings = s
-
 
 ## Last world scale (for scaling hands)
 var _last_world_scale : float = 1.0
@@ -71,6 +54,25 @@ var _force_grip := -1.0
 
 ## Force trigger value (< 0 for no force)
 var _force_trigger := -1.0
+
+
+## Pose-override class
+class PoseOverride:
+	## Who requested the override
+	var who : Node
+
+	## Pose priority
+	var priority : int
+
+	## Pose settings
+	var settings : XRToolsHandPoseSettings
+
+	## Pose-override constructor
+	func _init(w : Node, p : int, s : XRToolsHandPoseSettings):
+		who = w
+		priority = p
+		settings = s
+
 
 # Add support for is_class on XRTools classes
 func is_class(name : String) -> bool:

--- a/addons/godot-xr-tools/interactables/interactable_area_button.gd
+++ b/addons/godot-xr-tools/interactables/interactable_area_button.gd
@@ -79,7 +79,14 @@ func _on_button_entered(item: Spatial) -> void:
 		pressed = true
 
 		# Start the tween to move the button transform to the down position
-		_tween.interpolate_property(_button, "transform:origin", null, _button_down, duration, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
+		_tween.interpolate_property(
+				_button,
+				"transform:origin",
+				null,
+				_button_down,
+				duration,
+				Tween.TRANS_LINEAR,
+				Tween.EASE_IN_OUT)
 		_tween.start()
 
 		# Emit the pressed signal
@@ -97,7 +104,14 @@ func _on_button_exited(item: Spatial) -> void:
 		pressed = false
 
 		# Start the tween to move the button transform to the up position
-		_tween.interpolate_property(_button, "transform:origin", null, _button_up, duration, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
+		_tween.interpolate_property(
+				_button,
+				"transform:origin",
+				null,
+				_button_up,
+				duration,
+				Tween.TRANS_LINEAR,
+				Tween.EASE_IN_OUT)
 		_tween.start()
 
 		# Emit the released signal

--- a/addons/godot-xr-tools/interactables/interactable_hinge.gd
+++ b/addons/godot-xr-tools/interactables/interactable_hinge.gd
@@ -70,7 +70,8 @@ func _process(_delta: float) -> void:
 	for item in grabbed_handles:
 		var handle := item as XRToolsInteractableHandle
 		var to_handle: Vector3 = global_transform.xform_inv(handle.global_transform.origin)
-		var to_handle_origin: Vector3 = global_transform.xform_inv(handle.handle_origin.global_transform.origin)
+		var to_handle_origin: Vector3 = global_transform.xform_inv(
+				handle.handle_origin.global_transform.origin)
 		to_handle.x = 0.0
 		to_handle_origin.x = 0.0
 		offset_sum += to_handle_origin.signed_angle_to(to_handle, Vector3.RIGHT)

--- a/addons/godot-xr-tools/interactables/interactable_joystick.gd
+++ b/addons/godot-xr-tools/interactables/interactable_joystick.gd
@@ -105,7 +105,8 @@ func _process(_delta: float) -> void:
 	for item in grabbed_handles:
 		var handle := item as XRToolsInteractableHandle
 		var to_handle: Vector3 = global_transform.xform_inv(handle.global_transform.origin)
-		var to_handle_origin: Vector3 = global_transform.xform_inv(handle.handle_origin.global_transform.origin)
+		var to_handle_origin: Vector3 = global_transform.xform_inv(
+				handle.handle_origin.global_transform.origin)
 
 		var to_handle_x := to_handle * VECTOR_XZ
 		var to_handle_origin_x := to_handle_origin * VECTOR_XZ

--- a/addons/godot-xr-tools/misc/arvr_helpers.gd
+++ b/addons/godot-xr-tools/misc/arvr_helpers.gd
@@ -101,7 +101,11 @@ static func get_right_controller(node: Node, path: NodePath = NodePath("")) -> A
 	return _get_controller(node, "RightHandController", 2, path)
 
 # Find a controller given some search parameters
-static func _get_controller(var node: Node, var default_name: String, var id: int, var path: NodePath) -> ARVRController:
+static func _get_controller(
+		var node: Node,
+		var default_name: String,
+		var id: int,
+		var path: NodePath) -> ARVRController:
 	var controller: ARVRController
 
 	# Try using the node path first

--- a/addons/godot-xr-tools/objects/grab_points/grab_point_hand.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grab_point_hand.gd
@@ -10,24 +10,24 @@ extends XRToolsGrabPoint
 ## grab point position to be fine-tuned in the editor.
 
 
-## Left hand scene path (for editorpreview)
-const LEFT_HAND_PATH := "res://addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn"
-
-## Right hand scene path (for editor preview)
-const RIGHT_HAND_PATH := "res://addons/godot-xr-tools/hands/scenes/lowpoly/right_hand_low.tscn"
-
-
 ## Hand for this grab point
 enum Hand {
 	LEFT,	## Left hand
-	RIGHT	## Right hand
+	RIGHT,	## Right hand
 }
 
 ## Hand preview option
 enum PreviewMode {
 	CLOSED,	## Preview hand closed
-	OPEN	## Preview hand open
+	OPEN,	## Preview hand open
 }
+
+
+## Left hand scene path (for editorpreview)
+const LEFT_HAND_PATH := "res://addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn"
+
+## Right hand scene path (for editor preview)
+const RIGHT_HAND_PATH := "res://addons/godot-xr-tools/hands/scenes/lowpoly/right_hand_low.tscn"
 
 
 ## Which hand this grab point is for
@@ -37,7 +37,8 @@ export (Hand) var hand : int setget _set_hand
 export var hand_pose : Resource setget _set_hand_pose
 
 ## If true, the hand is shown in the editor
-export (PreviewMode) var editor_preview_mode : int = PreviewMode.CLOSED setget _set_editor_preview_mode
+export (PreviewMode) \
+		var editor_preview_mode : int = PreviewMode.CLOSED setget _set_editor_preview_mode
 
 
 ## Hand to use for editor preview

--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -28,10 +28,6 @@ signal action_pressed(pickable)
 signal highlight_updated(pickable, enable)
 
 
-# Priority for grip poses
-const GRIP_POSE_PRIORITY = 100
-
-
 ## Method used to hold object
 enum HoldMethod {
 	REMOTE_TRANSFORM,	## Object is held via a remote transform
@@ -55,8 +51,13 @@ enum PickableState {
 enum ReleaseMode {
 	ORIGINAL = -1,		## Preserve original mode when picked up
 	RIGID = 0,			## Release and make rigid (MODE_RIGID)
-	STATIC = 1			## Release and make static (MODE_STATIC)
+	STATIC = 1,			## Release and make static (MODE_STATIC)
 }
+
+
+## Priority for grip poses
+const GRIP_POSE_PRIORITY = 100
+
 
 ## If true, the grip control must be held to keep the object picked up
 export var press_to_hold : bool = true

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -15,16 +15,16 @@ signal pointer_exited
 
 ## Transparent property
 enum TransparancyMode {
-	OPAQUE,
-	TRANSPARENT,
-	SCISSOR
+	OPAQUE,				## Render opaque
+	TRANSPARENT,		## Render transparent
+	SCISSOR,			## Render using alpha-scissor
 }
 
 ## Viewport Update Mode
 enum UpdateMode {
-	UPDATE_ONCE, ## Note, even if already set to ONCE, if you assign the property again, it will trigger a single redraw
-	UPDATE_ALWAYS,
-	UPDATE_THROTTLED
+	UPDATE_ONCE, 		## Update once (redraw triggered if set again to UPDATE_ONCE)
+	UPDATE_ALWAYS,		## Update on every frame
+	UPDATE_THROTTLED,	## Update at throttled rate
 }
 
 
@@ -38,7 +38,8 @@ export var screen_size : Vector2 = Vector2(3.0, 2.0) setget set_screen_size
 export var viewport_size : Vector2 = Vector2(300.0, 200.0) setget set_viewport_size
 
 ## Transparent property
-export (TransparancyMode) var transparent : int = TransparancyMode.TRANSPARENT setget set_transparent
+export (TransparancyMode) \
+		var transparent : int = TransparancyMode.TRANSPARENT setget set_transparent
 
 ## Alpha Scissor Threshold property
 export var alpha_scissor_threshold : float = 0.25 setget set_alpha_scissor_threshold
@@ -216,7 +217,10 @@ func _update_enabled() -> void:
 func _update_screen_size() -> void:
 	$Screen.mesh.size = screen_size
 	$StaticBody.screen_size = screen_size
-	$StaticBody/CollisionShape.shape.extents = Vector3(screen_size.x * 0.5, screen_size.y * 0.5, 0.01)
+	$StaticBody/CollisionShape.shape.extents = Vector3(
+			screen_size.x * 0.5,
+			screen_size.y * 0.5,
+			0.01)
 
 
 # Viewport size update handler

--- a/addons/godot-xr-tools/overrides/ground_physics.gd
+++ b/addons/godot-xr-tools/overrides/ground_physics.gd
@@ -36,5 +36,7 @@ func _get_configuration_warning():
 	return ""
 
 # Get the physics from a ground physics node
-static func get_physics(node: XRToolsGroundPhysics, default: XRToolsGroundPhysicsSettings) -> XRToolsGroundPhysicsSettings:
+static func get_physics(
+		node: XRToolsGroundPhysics,
+		default: XRToolsGroundPhysicsSettings) -> XRToolsGroundPhysicsSettings:
 	return node.physics as XRToolsGroundPhysicsSettings if node else default

--- a/addons/godot-xr-tools/overrides/ground_physics_settings.gd
+++ b/addons/godot-xr-tools/overrides/ground_physics_settings.gd
@@ -83,7 +83,9 @@ func _init(
 
 
 ## Get the effective move drag value
-static func get_move_drag(override: XRToolsGroundPhysicsSettings, default: XRToolsGroundPhysicsSettings) -> float:
+static func get_move_drag(
+		override: XRToolsGroundPhysicsSettings,
+		default: XRToolsGroundPhysicsSettings) -> float:
 	if override and override.flags & GroundPhysicsFlags.MOVE_DRAG:
 		return override.move_drag
 
@@ -91,7 +93,9 @@ static func get_move_drag(override: XRToolsGroundPhysicsSettings, default: XRToo
 
 
 ## Get the effective move traction value
-static func get_move_traction(override: XRToolsGroundPhysicsSettings, default: XRToolsGroundPhysicsSettings) -> float:
+static func get_move_traction(
+		override: XRToolsGroundPhysicsSettings,
+		default: XRToolsGroundPhysicsSettings) -> float:
 	if override and override.flags & GroundPhysicsFlags.MOVE_TRACTION:
 		return override.move_traction
 
@@ -99,7 +103,9 @@ static func get_move_traction(override: XRToolsGroundPhysicsSettings, default: X
 
 
 ## Get the effective move maximum slope value
-static func get_move_max_slope(override: XRToolsGroundPhysicsSettings, default: XRToolsGroundPhysicsSettings) -> float:
+static func get_move_max_slope(
+		override: XRToolsGroundPhysicsSettings,
+		default: XRToolsGroundPhysicsSettings) -> float:
 	if override and override.flags & GroundPhysicsFlags.MOVE_MAX_SLOPE:
 		return override.move_max_slope
 
@@ -107,7 +113,9 @@ static func get_move_max_slope(override: XRToolsGroundPhysicsSettings, default: 
 
 
 ## Get the effective jump maximum slope value
-static func get_jump_max_slope(override: XRToolsGroundPhysicsSettings, default: XRToolsGroundPhysicsSettings) -> float:
+static func get_jump_max_slope(
+		override: XRToolsGroundPhysicsSettings,
+		default: XRToolsGroundPhysicsSettings) -> float:
 	if override and override.flags & GroundPhysicsFlags.JUMP_MAX_SLOP:
 		return override.jump_max_slope
 
@@ -115,7 +123,9 @@ static func get_jump_max_slope(override: XRToolsGroundPhysicsSettings, default: 
 
 
 ## Get the effective jump velocity value
-static func get_jump_velocity(override: XRToolsGroundPhysicsSettings, default: XRToolsGroundPhysicsSettings) -> float:
+static func get_jump_velocity(
+		override: XRToolsGroundPhysicsSettings,
+		default: XRToolsGroundPhysicsSettings) -> float:
 	if override and override.flags & GroundPhysicsFlags.JUMP_VELOCITY:
 		return override.jump_velocity
 
@@ -123,7 +133,9 @@ static func get_jump_velocity(override: XRToolsGroundPhysicsSettings, default: X
 
 
 ## Get the effective bounciness value
-static func get_bounciness(override: XRToolsGroundPhysicsSettings, default: XRToolsGroundPhysicsSettings) -> float:
+static func get_bounciness(
+		override: XRToolsGroundPhysicsSettings,
+		default: XRToolsGroundPhysicsSettings) -> float:
 	if override and override.flags & GroundPhysicsFlags.BOUNCINESS:
 		return override.bounciness
 
@@ -131,7 +143,9 @@ static func get_bounciness(override: XRToolsGroundPhysicsSettings, default: XRTo
 
 
 ## Get the effective bounce threshold value
-static func get_bounce_threshold(override: XRToolsGroundPhysicsSettings, default: XRToolsGroundPhysicsSettings) -> float:
+static func get_bounce_threshold(
+		override: XRToolsGroundPhysicsSettings,
+		default: XRToolsGroundPhysicsSettings) -> float:
 	if override and override.flags & GroundPhysicsFlags.BOUNCE_THRESHOLD:
 		return override.bounce_threshold
 

--- a/addons/godot-xr-tools/player/player_body.gd
+++ b/addons/godot-xr-tools/player/player_body.gd
@@ -298,12 +298,14 @@ func request_jump(skip_jump_velocity := false):
 		return
 
 	# Skip if jump disabled on this ground
-	var jump_velocity := XRToolsGroundPhysicsSettings.get_jump_velocity(ground_physics, default_physics)
+	var jump_velocity := XRToolsGroundPhysicsSettings.get_jump_velocity(
+			ground_physics, default_physics)
 	if jump_velocity == 0.0:
 		return
 
 	# Skip if the ground is too steep to jump
-	var max_slope := XRToolsGroundPhysicsSettings.get_jump_max_slope(ground_physics, default_physics)
+	var max_slope := XRToolsGroundPhysicsSettings.get_jump_max_slope(
+			ground_physics, default_physics)
 	if ground_angle > max_slope:
 		return
 
@@ -318,7 +320,13 @@ func request_jump(skip_jump_velocity := false):
 ## This method moves the players body using the provided velocity. Movement
 ## providers may use this function if they are exclusively driving the player.
 func move_body(p_velocity: Vector3) -> Vector3:
-	return kinematic_node.move_and_slide(p_velocity, up_gravity_vector, false, 4, 0.785398, push_rigid_bodies)
+	return kinematic_node.move_and_slide(
+			p_velocity,
+			up_gravity_vector,
+			false,
+			4,
+			0.785398,
+			push_rigid_bodies)
 
 ## This method rotates the player by rotating the [ARVROrigin] around the camera.
 func rotate_player(angle: float):
@@ -374,9 +382,10 @@ func override_player_height(key, value: float = -1.0):
 func _update_body_under_camera():
 	# Calculate the player height based on the camera position in the origin and the calibration
 	var player_height: float = clamp(
-		camera_node.transform.origin.y + player_head_height + player_height_offset + XRToolsUserSettings.player_height_adjust,
-		player_height_min * ARVRServer.world_scale,
-		player_height_max * ARVRServer.world_scale)
+			camera_node.transform.origin.y + player_head_height +
+					player_height_offset + XRToolsUserSettings.player_height_adjust,
+			player_height_min * ARVRServer.world_scale,
+			player_height_max * ARVRServer.world_scale)
 
 	# Allow forced overriding of height
 	if _player_height_override >= 0.0:
@@ -462,15 +471,20 @@ func _apply_velocity_and_control(delta: float):
 			var camera_transform := camera_node.global_transform
 			var dir_forward := up_gravity_plane.project(camera_transform.basis.z).normalized()
 			var dir_right := up_gravity_plane.project(camera_transform.basis.x).normalized()
-			control_velocity = (dir_forward * -ground_control_velocity.y + dir_right * ground_control_velocity.x) * ARVRServer.world_scale
+			control_velocity = (
+					dir_forward * -ground_control_velocity.y +
+					dir_right * ground_control_velocity.x
+			) * ARVRServer.world_scale
 
 			# Apply control velocity to horizontal velocity based on traction
-			var current_traction := XRToolsGroundPhysicsSettings.get_move_traction(ground_physics, default_physics)
+			var current_traction := XRToolsGroundPhysicsSettings.get_move_traction(
+					ground_physics, default_physics)
 			var traction_factor: float = clamp(current_traction * delta, 0.0, 1.0)
 			horizontal_velocity = lerp(horizontal_velocity, control_velocity, traction_factor)
 
 			# Prevent the player from moving up steep slopes
-			var current_max_slope := XRToolsGroundPhysicsSettings.get_move_max_slope(ground_physics, default_physics)
+			var current_max_slope := XRToolsGroundPhysicsSettings.get_move_max_slope(
+					ground_physics, default_physics)
 			if ground_angle > current_max_slope:
 				# Get a vector in the down-hill direction
 				var down_direction := up_gravity_plane.project(ground_vector).normalized()
@@ -479,7 +493,8 @@ func _apply_velocity_and_control(delta: float):
 					horizontal_velocity -= down_direction * vdot
 		else:
 			# User is not trying to move, so apply the ground drag
-			var current_drag := XRToolsGroundPhysicsSettings.get_move_drag(ground_physics, default_physics)
+			var current_drag := XRToolsGroundPhysicsSettings.get_move_drag(
+					ground_physics, default_physics)
 			var drag_factor: float = clamp(current_drag * delta, 0, 1)
 			horizontal_velocity = lerp(horizontal_velocity, control_velocity, drag_factor)
 
@@ -491,13 +506,23 @@ func _apply_velocity_and_control(delta: float):
 
 	# Perform bounce test if a collision occurred
 	if kinematic_node.get_slide_count():
-		# Detect bounciness
+		# Get the collider the player collided with
 		var collision := kinematic_node.get_slide_collision(0)
 		var collision_node := collision.collider
-		var collision_physics_node := collision_node.get_node_or_null("GroundPhysics") as XRToolsGroundPhysics
-		var collision_physics = XRToolsGroundPhysics.get_physics(collision_physics_node, default_physics)
-		var bounce_threshold := XRToolsGroundPhysicsSettings.get_bounce_threshold(collision_physics, default_physics)
-		var bounciness := XRToolsGroundPhysicsSettings.get_bounciness(collision_physics, default_physics)
+
+		# Check for a GroundPhysics node attached to the collider
+		var collision_physics_node := \
+				collision_node.get_node_or_null("GroundPhysics") as XRToolsGroundPhysics
+
+		# Get the collision physics associated with the collider
+		var collision_physics = XRToolsGroundPhysics.get_physics(
+				collision_physics_node, default_physics)
+
+		# Get the bounce parameters associated with the collider
+		var bounce_threshold := XRToolsGroundPhysicsSettings.get_bounce_threshold(
+				collision_physics, default_physics)
+		var bounciness := XRToolsGroundPhysicsSettings.get_bounciness(
+				collision_physics, default_physics)
 		var magnitude := -collision.normal.dot(local_velocity)
 
 		# Detect if bounce should be performed

--- a/addons/godot-xr-tools/plugin.gd
+++ b/addons/godot-xr-tools/plugin.gd
@@ -1,7 +1,13 @@
 tool
 extends EditorPlugin
 
-func _define_project_setting(p_name : String, p_type : int, p_hint : int = PROPERTY_HINT_NONE , p_hint_string : String = "", p_default_val = "") -> void:
+
+func _define_project_setting(
+		p_name : String,
+		p_type : int,
+		p_hint : int = PROPERTY_HINT_NONE,
+		p_hint_string : String = "",
+		p_default_val = "") -> void:
 	# p_default_val can be any type!!
 
 	if !ProjectSettings.has_setting(p_name):
@@ -21,15 +27,43 @@ func _define_project_setting(p_name : String, p_type : int, p_hint : int = PROPE
 func _enter_tree():
 	# our plugin is loaded
 
-	# provide meta data for our project settings
-	_define_project_setting("godot_xr_tools/input/grip_threshold", TYPE_REAL, PROPERTY_HINT_RANGE, "0.2,0.8,0.05", 0.7)
-	_define_project_setting("godot_xr_tools/input/snap_turning_deadzone", TYPE_REAL, PROPERTY_HINT_RANGE, "0.0,0.5,0.05", 0.25)
-	_define_project_setting("godot_xr_tools/input/default_snap_turning", TYPE_BOOL, PROPERTY_HINT_NONE, "", true)
+	# Add input grip threshold to the project settings
+	_define_project_setting(
+			"godot_xr_tools/input/grip_threshold",
+			TYPE_REAL,
+			PROPERTY_HINT_RANGE,
+			"0.2,0.8,0.05",
+			0.7)
 
-	_define_project_setting("godot_xr_tools/player/standard_height", TYPE_REAL, PROPERTY_HINT_RANGE, "1.0,2.5,0.05", 1.85)
+	# Add input snap turning dead-zone to the project settings
+	_define_project_setting(
+			"godot_xr_tools/input/snap_turning_deadzone",
+			TYPE_REAL,
+			PROPERTY_HINT_RANGE,
+			"0.0,0.5,0.05",
+			0.25)
 
-	# register our autoload user settings object
-	add_autoload_singleton("XRToolsUserSettings", "res://addons/godot-xr-tools/user_settings/user_settings.gd")
+	# Add input default snap turning to the project settings
+	_define_project_setting(
+			"godot_xr_tools/input/default_snap_turning",
+			TYPE_BOOL,
+			PROPERTY_HINT_NONE,
+			"",
+			true)
+
+	# Add player standard height to the project settings
+	_define_project_setting(
+			"godot_xr_tools/player/standard_height",
+			TYPE_REAL,
+			PROPERTY_HINT_RANGE,
+			"1.0,2.5,0.05",
+			1.85)
+
+	# Register our autoload user settings object
+	add_autoload_singleton(
+			"XRToolsUserSettings",
+			"res://addons/godot-xr-tools/user_settings/user_settings.gd")
+
 
 func _exit_tree():
 	# our plugin is turned off

--- a/addons/godot-xr-tools/staging/staging.gd
+++ b/addons/godot-xr-tools/staging/staging.gd
@@ -2,79 +2,119 @@ tool
 class_name XRToolsStaging
 extends Spatial
 
-## Introduction
-#
-# When creating a game with multiple levels where you want to
-# make use of background loading and have some nice structure
-# in place, the Staging scene can be used as a base to handle
-# all the startup and scene switching code.
-# Just inherit this scene, set it up and make the resulting
-# scene your startup scene.
-#
-# As different XR runtimes need slightly different setups you'll
-# need to add the appropriate ARVROrigin setup to your scene.
-# When using the OpenXR plugin this is as simple as adding the
-# FPController script as a child node.
-#
-# Furthermore this scene has our loading screen and an anchor
-# point into which we load the actual scene we wish the user
-# to interact with. You can configure the first scene to load
-# and kick off your game by setting the Main Scene property.
-#
-# If you are creating a game with a single level you may wish to
-# simplify things. Check out the demo included in the source
-# repository for the OpenXR plugin and then use the techniques
-# explained in individual demos found here.
 
-## Signals
-#
-# Our scene changing logic emits various signals at opportune
-# times so you can embed additional game logic.
+## XR Tools Staging
+##
+## When creating a game with multiple levels where you want to
+## make use of background loading and have some nice structure
+## in place, the Staging scene can be used as a base to handle
+## all the startup and scene switching code.
+## Just inherit this scene, set it up and make the resulting
+## scene your startup scene.
+##
+## As different XR runtimes need slightly different setups you'll
+## need to add the appropriate ARVROrigin setup to your scene.
+## When using the OpenXR plugin this is as simple as adding the
+## FPController script as a child node.
+##
+## Furthermore this scene has our loading screen and an anchor
+## point into which we load the actual scene we wish the user
+## to interact with. You can configure the first scene to load
+## and kick off your game by setting the Main Scene property.
+##
+## If you are creating a game with a single level you may wish to
+## simplify things. Check out the demo included in the source
+## repository for the OpenXR plugin and then use the techniques
+## explained in individual demos found here.
 
+
+## Current scene is being unloaded
 signal scene_exiting(scene)
+
+## Switched to the loading scene
 signal switching_to_loading_scene
+
+## New scene has been loaded
 signal scene_loaded(scene)
+
+## New scene is now visible
 signal scene_visible(scene)
 
-## WorldEnvironment
-#
-# You will note that our staging scene has a world environment
-# node included. Godot does not have a mechanism for having
-# multiple world environments in our scene and marking one as
-# active which makes it impractical to embed these in our demo
-# scenes. Instead we will obtain the environment from our demo
-# scene and manage it here. Our world environment at the start
-# belongs to our loading screen and we need to keep a copy.
 
-onready var loading_screen_environment = $WorldEnvironment.environment
-onready var resource_queue = preload("res://addons/godot-xr-tools/assets/resource_queue/resource_queue.gd").new()
-
-## Fade
-#
-# Our fade object allows us to black out the screen for transitions.
-# Note that our AABB is set to HUGE so it should always be rendered
-# unless hidden.
-
-func set_fade(p_value : float):
-	if p_value == 0.0:
-		$Fade.visible = false
-	else:
-		var material : ShaderMaterial = $Fade.get_surface_material(0)
-		if material:
-			material.set_shader_param("alpha", p_value)
-		$Fade.visible = true
-
-## Scene swapping
-#
-# These functions control our scene swapping
+## Main scene file
 export (String, FILE, '*.tscn') var main_scene : String
+
+## If true, the player is prompted to continue
 export var prompt_for_continue : bool = true
 
-var arvr_origin : ARVROrigin
-var arvr_camera : ARVRCamera
 
+# Current scene
 var current_scene : XRToolsSceneBase
+
+# Current scene path
 var current_scene_path : String
+
+
+## WorldEnvironment
+##
+## You will note that our staging scene has a world environment
+## node included. Godot does not have a mechanism for having
+## multiple world environments in our scene and marking one as
+## active which makes it impractical to embed these in our demo
+## scenes. Instead we will obtain the environment from our demo
+## scene and manage it here. Our world environment at the start
+## belongs to our loading screen and we need to keep a copy.
+onready var loading_screen_environment = $WorldEnvironment.environment
+
+## Resource queue for loading resources
+onready var resource_queue = XRToolsResourceQueue.new()
+
+## XR Origin
+onready var arvr_origin : ARVROrigin = ARVRHelpers.get_arvr_origin(self)
+
+## XR Camera
+onready var arvr_camera : ARVRCamera = ARVRHelpers.get_arvr_camera(self)
+
+
+func _ready():
+	# Do not initialise if in the editor
+	if Engine.editor_hint:
+		return
+
+	# Specify the camera to track
+	if arvr_camera:
+		$LoadingScreen.set_camera(arvr_camera)
+
+	# Start our resource loader
+	resource_queue.start()
+
+	# We start by loading our main level scene
+	load_scene(main_scene)
+
+
+# Verifies our staging has a valid configuration.
+func _get_configuration_warning():
+	# Report missing XR Origin
+	var test_origin : ARVROrigin = ARVRHelpers.get_arvr_origin(self)
+	if !test_origin:
+		return "No ARVROrigin node found, please add one"
+
+	# Report missing XR Camera
+	var test_camera : ARVRCamera = ARVRHelpers.get_arvr_camera(self)
+	if !test_camera:
+		return "No ARVRCamera node found, please add one to your ARVROrigin node"
+
+	# Report main scene not specified
+	if main_scene == "":
+		return "No main scene selected"
+
+	# Report main scene invalid
+	var file = File.new()
+	if !file.file_exists(main_scene):
+		return "Main scene doesn't exist"
+
+	# Passed validation
+	return ""
 
 
 # Add support for is_class on XRTools classes
@@ -82,21 +122,8 @@ func is_class(name : String) -> bool:
 	return name == "XRToolsStaging" or .is_class(name)
 
 
-func _on_exit_to_main_menu():
-	load_scene(main_scene)
-
-func _on_load_scene(p_scene_path : String):
-	load_scene(p_scene_path)
-
-func _add_signals(p_scene : XRToolsSceneBase):
-	p_scene.connect("exit_to_main_menu", self, "_on_exit_to_main_menu")
-	p_scene.connect("load_scene", self, "_on_load_scene")
-
-func _remove_signals(p_scene : XRToolsSceneBase):
-	p_scene.disconnect("exit_to_main_menu", self, "_on_exit_to_main_menu")
-	p_scene.disconnect("load_scene", self, "_on_load_scene")
-
-func load_scene(p_scene_path : String):
+## Load the specified scene
+func load_scene(p_scene_path : String) -> void:
 	# Do not load if in the editor
 	if Engine.editor_hint:
 		return
@@ -200,39 +227,35 @@ func load_scene(p_scene_path : String):
 	current_scene.scene_visible()
 	emit_signal("scene_visible", current_scene)
 
-## Verifies our staging has a valid configuration.
-func _get_configuration_warning():
-	var test_origin : ARVROrigin = ARVRHelpers.get_arvr_origin(self)
-	if !test_origin:
-		return "No ARVROrigin node found, please add one"
 
-	var test_camera : ARVRCamera = ARVRHelpers.get_arvr_camera(self)
-	if !test_camera:
-		return "No ARVRCamera node found, please add one to your ARVROrigin node"
+## Fade
+##
+## Our fade object allows us to black out the screen for transitions.
+## Note that our AABB is set to HUGE so it should always be rendered
+## unless hidden.
+func set_fade(p_value : float):
+	if p_value == 0.0:
+		$Fade.visible = false
+	else:
+		var material : ShaderMaterial = $Fade.get_surface_material(0)
+		if material:
+			material.set_shader_param("alpha", p_value)
+		$Fade.visible = true
 
-	var file = File.new()
-	if main_scene == "":
-		return "No main scene selected"
-	elif !file.file_exists(main_scene):
-		return "Main scene doesn't exist"
 
-	return ""
+func _add_signals(p_scene : XRToolsSceneBase):
+	p_scene.connect("exit_to_main_menu", self, "_on_exit_to_main_menu")
+	p_scene.connect("load_scene", self, "_on_load_scene")
 
-## interface
 
-func _ready():
-	# Do not initialise if in the editor
-	if Engine.editor_hint:
-		return
+func _remove_signals(p_scene : XRToolsSceneBase):
+	p_scene.disconnect("exit_to_main_menu", self, "_on_exit_to_main_menu")
+	p_scene.disconnect("load_scene", self, "_on_load_scene")
 
-	arvr_origin = ARVRHelpers.get_arvr_origin(self)
 
-	arvr_camera = ARVRHelpers.get_arvr_camera(self)
-	if arvr_camera:
-		$LoadingScreen.set_camera(arvr_camera)
-
-	# Start our resource loader
-	resource_queue.start()
-
-	# We start by loading our main level scene
+func _on_exit_to_main_menu():
 	load_scene(main_scene)
+
+
+func _on_load_scene(p_scene_path : String):
+	load_scene(p_scene_path)

--- a/project.godot
+++ b/project.godot
@@ -249,6 +249,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/player/poke/poke.gd"
 }, {
+"base": "Node",
+"class": "XRToolsResourceQueue",
+"language": "GDScript",
+"path": "res://addons/godot-xr-tools/assets/resource_queue/resource_queue.gd"
+}, {
 "base": "Spatial",
 "class": "XRToolsSceneBase",
 "language": "GDScript",
@@ -338,6 +343,7 @@ _global_script_class_icons={
 "XRToolsPickable": "",
 "XRToolsPlayerBody": "res://addons/godot-xr-tools/editor/icons/body.svg",
 "XRToolsPoke": "",
+"XRToolsResourceQueue": "",
 "XRToolsSceneBase": "",
 "XRToolsSnapZone": "",
 "XRToolsStaging": "",

--- a/scenes/pointer_demo/pointer_demo.gd
+++ b/scenes/pointer_demo/pointer_demo.gd
@@ -20,14 +20,16 @@ func _ready():
 
 
 func _on_LeftHand_button_pressed(button):
-	if pointer_left_or_right == Pointer.RIGHT and button == $ARVROrigin/LeftHand/FunctionPointer.active_button:
+	if pointer_left_or_right == Pointer.RIGHT and \
+		button == $ARVROrigin/LeftHand/FunctionPointer.active_button:
 		# switch to left
 		pointer_left_or_right = Pointer.LEFT
 		_set_pointer_enabled()
 
 
 func _on_RightHand_button_pressed(button):
-	if pointer_left_or_right == Pointer.LEFT and button == $ARVROrigin/RightHand/FunctionPointer.active_button:
+	if pointer_left_or_right == Pointer.LEFT and \
+		button == $ARVROrigin/RightHand/FunctionPointer.active_button:
 		# switch to right
 		pointer_left_or_right = Pointer.RIGHT
 		_set_pointer_enabled()


### PR DESCRIPTION
This pull request cleans up all gdlint (https://github.com/Scony/godot-gdscript-toolkit) warnings.

In some cases this took complete reordering of the contents of the files to match the code ordering from the gdscript style guide - https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#code-order
