### PR TITLE
Prevent Enter VR button from showing if XR is already active.

### DIFF
--- a/addons/godot-xr-tools/xr/start_xr.gd
+++ b/addons/godot-xr-tools/xr/start_xr.gd
@@ -213,6 +213,10 @@ func _setup_for_webxr() -> bool:
 	# something sufficiently high
 	Engine.iterations_per_second = 144
 
+	# If the viewport is already in XR mode then we are done.
+	if get_viewport().arvr:
+		return true
+
 	# This returns immediately - our _webxr_session_supported() method
 	# (which we connected to the "session_supported" signal above) will
 	# be called sometime later to let us know if it's supported or not.


### PR DESCRIPTION
This pull request fixes issue #315 by only kicking off the WebXR session initialization sequence if XR isn't already running.