### PR TITLE
Make Demos show fancier

### DIFF
--- a/assets/meshes/teleport/teleport.gd
+++ b/assets/meshes/teleport/teleport.gd
@@ -44,7 +44,7 @@ func _on_TeleportArea_body_entered(body: Node3D):
 	else:
 		_scene_base.emit_signal("exit_to_main_menu")
 
-func collision_disabled(value):
+func set_collision_disabled(value):
 	if !Engine.is_editor_hint():
 		for child in get_node("TeleportBody").get_children():
 			if child is CollisionShape3D:

--- a/assets/meshes/teleport/teleport.gd
+++ b/assets/meshes/teleport/teleport.gd
@@ -44,6 +44,12 @@ func _on_TeleportArea_body_entered(body: Node3D):
 	else:
 		_scene_base.emit_signal("exit_to_main_menu")
 
+func collision_disabled(value):
+	if !Engine.is_editor_hint():
+		for child in get_node("TeleportBody").get_children():
+			if child is CollisionShape3D:
+				child.disabled=value
+
 func _set_title(value):
 	title = value
 	if is_inside_tree():

--- a/assets/meshes/teleport/teleport.gd
+++ b/assets/meshes/teleport/teleport.gd
@@ -12,6 +12,9 @@ extends Node3D
 ## Title texture
 @export var title: Texture2D: set = _set_title
 
+## Can Teleporter be used
+@export var active := true
+
 
 # Scene base to trigger loading
 @onready var _scene_base: XRToolsSceneBase = get_node(scene_base)
@@ -29,6 +32,10 @@ func _on_TeleportArea_body_entered(body: Node3D):
 
 	# Skip if not the player body
 	if not body.is_in_group("player_body"):
+		return
+
+	#Skip if not active
+	if not active:
 		return
 
 	# Teleport

--- a/scenes/main_menu/main_menu_level.gd
+++ b/scenes/main_menu/main_menu_level.gd
@@ -4,10 +4,11 @@ extends "../scene_base.gd"
 func _update_demo_positions() -> void:
 	var count = 0#$Demos.get_child_count()
 	var vis_chd := []
-	for _c in $Demos.get_children():
-		if _c.visible:
+	for _tp in $Demos.get_children():
+		_tp.active=_tp.visible
+		if _tp.visible:
 			count+=1
-			vis_chd.append(_c)
+			vis_chd.append(_tp)
 	if count > 1:
 		var angle = 2.0 * PI / count
 		for i in count:

--- a/scenes/main_menu/main_menu_level.gd
+++ b/scenes/main_menu/main_menu_level.gd
@@ -6,10 +6,7 @@ func _update_demo_positions() -> void:
 	var visible_children := []
 	for teleporter in $Demos.get_children():
 		teleporter.active=teleporter.visible
-		if !Engine.is_editor_hint():
-			for child in teleporter.get_node("TeleportBody").get_children():
-				if child is CollisionShape3D:
-					child.disabled=!teleporter.visible
+		teleporter.set_collision_disabled(!teleporter.visible)
 		if teleporter.visible:
 			count+=1
 			visible_children.append(teleporter)

--- a/scenes/main_menu/main_menu_level.gd
+++ b/scenes/main_menu/main_menu_level.gd
@@ -2,13 +2,13 @@
 extends "../scene_base.gd"
 
 func _update_demo_positions() -> void:
-	var count = 0#$Demos.get_child_count()
-	var vis_chd := []
-	for _tp in $Demos.get_children():
-		_tp.active=_tp.visible
-		if _tp.visible:
+	var count = 0
+	var visible_children := []
+	for teleporter in $Demos.get_children():
+		teleporter.active=teleporter.visible
+		if teleporter.visible:
 			count+=1
-			vis_chd.append(_tp)
+			visible_children.append(teleporter)
 	if count > 1:
 		var angle = 2.0 * PI / count
 		for i in count:
@@ -16,15 +16,15 @@ func _update_demo_positions() -> void:
 			t.origin = Vector3(0.0, 0.0, -10.0)
 			t = t.rotated(Vector3.UP, angle * i)
 
-			vis_chd[i].transform = t
+			visible_children[i].transform = t
 
 
 func _ready():
 	super._ready()
 	_update_demo_positions()
 	
-	for _c in $Demos.get_children():
-		_c.connect("visibility_changed",_update_demo_positions)
+	for teleporter in $Demos.get_children():
+		teleporter.connect("visibility_changed",_update_demo_positions)
 
 
 func _on_Demos_child_entered_tree(_node):

--- a/scenes/main_menu/main_menu_level.gd
+++ b/scenes/main_menu/main_menu_level.gd
@@ -6,6 +6,9 @@ func _update_demo_positions() -> void:
 	var visible_children := []
 	for teleporter in $Demos.get_children():
 		teleporter.active=teleporter.visible
+		for child in teleporter.get_node("TeleportBody").get_children():
+			if child is CollisionShape3D:
+				child.disabled=!teleporter.visible
 		if teleporter.visible:
 			count+=1
 			visible_children.append(teleporter)

--- a/scenes/main_menu/main_menu_level.gd
+++ b/scenes/main_menu/main_menu_level.gd
@@ -2,7 +2,12 @@
 extends "../scene_base.gd"
 
 func _update_demo_positions() -> void:
-	var count = $Demos.get_child_count()
+	var count = 0#$Demos.get_child_count()
+	var vis_chd := []
+	for _c in $Demos.get_children():
+		if _c.visible:
+			count+=1
+			vis_chd.append(_c)
 	if count > 1:
 		var angle = 2.0 * PI / count
 		for i in count:
@@ -10,12 +15,15 @@ func _update_demo_positions() -> void:
 			t.origin = Vector3(0.0, 0.0, -10.0)
 			t = t.rotated(Vector3.UP, angle * i)
 
-			$Demos.get_child(i).transform = t
+			vis_chd[i].transform = t
 
 
 func _ready():
 	super._ready()
 	_update_demo_positions()
+	
+	for _c in $Demos.get_children():
+		_c.connect("visibility_changed",_update_demo_positions)
 
 
 func _on_Demos_child_entered_tree(_node):

--- a/scenes/main_menu/main_menu_level.gd
+++ b/scenes/main_menu/main_menu_level.gd
@@ -6,9 +6,10 @@ func _update_demo_positions() -> void:
 	var visible_children := []
 	for teleporter in $Demos.get_children():
 		teleporter.active=teleporter.visible
-		for child in teleporter.get_node("TeleportBody").get_children():
-			if child is CollisionShape3D:
-				child.disabled=!teleporter.visible
+		if !Engine.is_editor_hint():
+			for child in teleporter.get_node("TeleportBody").get_children():
+				if child is CollisionShape3D:
+					child.disabled=!teleporter.visible
 		if teleporter.visible:
 			count+=1
 			visible_children.append(teleporter)


### PR DESCRIPTION
I added code so if you hide demo in editor it will hide it and reposition active demos instead of keeping them on positions. Teleporters also got is active checkbox/property.