### PR TITLE
Flapping wings. Add vertical impulse when flapping arms

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,5 +13,6 @@ Other people who have helped out by submitting fixes, enhancements, etc are:
 - [Sam Sarette](https://github.com/lunarcloud)
 - [Henodude](https://github.com/Henodude)
 - [Miodrag Sejic](https://github.com/DigitalN8m4r3)
+- [Carlos Padial](https://github.com/surreal6)
 
 Want to be on this list? We would love your help.

--- a/addons/godot-xr-tools/functions/movement_glide.gd
+++ b/addons/godot-xr-tools/functions/movement_glide.gd
@@ -28,13 +28,6 @@ signal player_glide_end
 ## Signal invoked when the player flaps
 signal player_flapped
 
-## flap activated (when both controllers are near the ARVRCamera height)
-var flap_armed : bool = false
-
-## last controllers position to calculate flapping velocity
-var last_local_left_position : Vector3
-var last_local_right_position : Vector3
-
 ## Movement provider order
 export var order : int = 35
 
@@ -75,6 +68,12 @@ export var wings_force : float = 1.0
 ## if set to 0, you need to reach head level with hands to rearm flaps
 export var rearm_distance_offset : float = 0.2
 
+## flap activated (when both controllers are near the ARVRCamera height)
+var flap_armed : bool = false
+
+## last controllers position to calculate flapping velocity
+var last_local_left_position : Vector3
+var last_local_right_position : Vector3
 
 # Left controller
 onready var _left_controller := ARVRHelpers.get_left_controller(self)
@@ -97,23 +96,21 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 		!_right_controller.get_is_active():
 		_set_gliding(false)
 		return
-		
+
 	# If on the ground, then not gliding
 	if player_body.on_ground:
 		_set_gliding(false)
 		return
-	
+
 	# Get the controller left and right global horizontal positions
 	var left_position := _left_controller.global_transform.origin
 	var right_position := _right_controller.global_transform.origin
-	
-	
-	
+
 	#set default wings impulse to zero
 	var wings_impulse_velocity := 0.0
 	# if wings impulse is active, calculate flapping impulse
 	if wings_impulse:
-		## get head position
+		# get head position
 		var camera_position := _camera_node.global_transform.origin
 		# check controllers position relative to head
 		var left_hand_over_head = camera_position.y < left_position.y + rearm_distance_offset
@@ -122,39 +119,38 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 			flap_armed = true
 
 		if flap_armed:
-		# get controller local positions
-		var local_left_position := _left_controller.transform.origin
-		var local_right_position := _right_controller.transform.origin
+			# get controller local positions
+			var local_left_position := _left_controller.transform.origin
+			var local_right_position := _right_controller.transform.origin
 
-		# store last frame controller positions for the first step
-		if !last_local_left_position:
-			last_local_left_position = local_left_position
-		if !last_local_right_position:
-			last_local_right_position = local_right_position
+			# store last frame controller positions for the first step
+			if !last_local_left_position:
+				last_local_left_position = local_left_position
+			if !last_local_right_position:
+				last_local_right_position = local_right_position
 
-		# calculate controllers velocity only when flapping downwards
-		var left_wing_velocity = 0.0
-		var right_wing_velocity = 0.0
-		if local_left_position.y < last_local_left_position.y:
-				left_wing_velocity = local_left_position.distance_to(last_local_left_position) / delta
-		if local_right_position.y < last_local_right_position.y:
-				right_wing_velocity = local_right_position.distance_to(last_local_right_position) / delta
-			
-			var flap_min_speed_delta = flap_min_speed
-			
+			# calculate controllers velocity only when flapping downwards
+			var left_wing_velocity = 0.0
+			var right_wing_velocity = 0.0
+			if local_left_position.y < last_local_left_position.y:
+					left_wing_velocity = local_left_position.distance_to(last_local_left_position) / delta
+			if local_right_position.y < last_local_right_position.y:
+					right_wing_velocity = local_right_position.distance_to(last_local_right_position) / delta
 
-		# calculate wings impulse
-			if left_wing_velocity > flap_min_speed_delta && right_wing_velocity > flap_min_speed_delta:
-			wings_impulse_velocity = (left_wing_velocity + right_wing_velocity) / 2
+			# calculate wings impulse
+			if left_wing_velocity > flap_min_speed && right_wing_velocity > flap_min_speed:
+				wings_impulse_velocity = (left_wing_velocity + right_wing_velocity) / 2
 				wings_impulse_velocity = wings_impulse_velocity * wings_force * delta * 50
 				emit_signal("player_flapped")
+				flap_armed = false
 
-		# store controller position for next frame
-		last_local_left_position = local_left_position
-		last_local_right_position = local_right_position
+			# store controller position for next frame
+			last_local_left_position = local_left_position
+			last_local_right_position = local_right_position
 
 	# If not falling, then not gliding
-	var vertical_velocity := player_body.velocity.dot(player_body.up_gravity_vector) + wings_impulse_velocity
+	var vertical_velocity := player_body.velocity.dot(player_body.up_gravity_vector)
+	vertical_velocity += wings_impulse_velocity
 	if vertical_velocity >= glide_min_fall_speed && wings_impulse_velocity == 0.0:
 		_set_gliding(false)
 		return

--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -72,7 +72,6 @@ jump_button_id = 7
 [node name="MovementGlide" parent="ARVROrigin" index="5" instance=ExtResource( 7 )]
 turn_with_roll = true
 wings_impulse = true
-wings_force = 1.5
 
 [node name="MovementWind" parent="ARVROrigin" index="6" instance=ExtResource( 22 )]
 
@@ -239,4 +238,4 @@ scene_base = NodePath("..")
 title = ExtResource( 13 )
 
 [node name="Instructions" parent="." index="5" instance=ExtResource( 18 )]
-transform = Transform( -0.5, 0, -0.866025, 0, 1, 0, 0.866025, 0, -0.5, -80, 40, -60 )
+transform = Transform( -0.5, 0, -0.866025, 0, 1, 0, 0.866025, 0, -0.5, -80, 40.164, -60 )

--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -72,7 +72,7 @@ jump_button_id = 7
 [node name="MovementGlide" parent="ARVROrigin" index="5" instance=ExtResource( 7 )]
 turn_with_roll = true
 wings_impulse = true
-wings_force = 3.0
+wings_force = 1.5
 
 [node name="MovementWind" parent="ARVROrigin" index="6" instance=ExtResource( 22 )]
 

--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/staging/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/hands/scenes/lowpoly/right_tac_glove_low.tscn" type="PackedScene" id=2]
@@ -18,6 +18,7 @@
 [ext_resource path="res://scenes/climbing_gliding_demo/objects/hill.tscn" type="PackedScene" id=16]
 [ext_resource path="res://addons/godot-xr-tools/hands/materials/ghost_hand.tres" type="Material" id=17]
 [ext_resource path="res://scenes/climbing_gliding_demo/objects/instructions.tscn" type="PackedScene" id=18]
+[ext_resource path="res://scenes/climbing_gliding_demo/objects/ring.tscn" type="PackedScene" id=19]
 [ext_resource path="res://addons/godot-xr-tools/functions/movement_wind.tscn" type="PackedScene" id=22]
 
 [sub_resource type="CubeMesh" id=1]
@@ -70,6 +71,8 @@ jump_button_id = 7
 
 [node name="MovementGlide" parent="ARVROrigin" index="5" instance=ExtResource( 7 )]
 turn_with_roll = true
+wings_impulse = true
+wings_force = 3.0
 
 [node name="MovementWind" parent="ARVROrigin" index="6" instance=ExtResource( 22 )]
 
@@ -203,6 +206,27 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 27, 25, -10 )
 
 [node name="WindArea8" parent="Terrain/Winds" index="7" instance=ExtResource( 12 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 27, 35, -10 )
+
+[node name="Rings" type="Spatial" parent="Terrain" index="4"]
+transform = Transform( 0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, 0.866025, -6.839, 49.8018, 12.5189 )
+
+[node name="ring1" parent="Terrain/Rings" index="0" instance=ExtResource( 19 )]
+transform = Transform( 0.92394, -1.61434e-08, -0.382538, 1.28187e-08, 1, -1.12399e-08, 0.382538, 5.48136e-09, 0.92394, -51.9777, 0, -5.49984 )
+
+[node name="ring2" parent="Terrain/Rings" index="1" instance=ExtResource( 19 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 7.14596, 3.37725, 2.24743 )
+
+[node name="ring3" parent="Terrain/Rings" index="2" instance=ExtResource( 19 )]
+transform = Transform( 0.963626, -1.0912e-08, -0.267255, 9.32201e-09, 1, -7.218e-09, 0.267255, 4.4641e-09, 0.963626, 72.52, 12.0066, 15.9844 )
+
+[node name="ring4" parent="Terrain/Rings" index="3" instance=ExtResource( 19 )]
+transform = Transform( -0.910597, -2.61121e-08, 0.413295, -5.74028e-08, 1, -6.32931e-08, -0.413295, -8.13588e-08, -0.910597, 69.9441, 26.6401, -48.2277 )
+
+[node name="ring5" parent="Terrain/Rings" index="4" instance=ExtResource( 19 )]
+transform = Transform( -0.999975, -4.34426e-08, 0.00708592, -4.39791e-08, 1, -7.55545e-08, -0.00708592, -7.58643e-08, -0.999975, 6.63248, 23.3205, -63.4222 )
+
+[node name="ring6" parent="Terrain/Rings" index="5" instance=ExtResource( 19 )]
+transform = Transform( -0.880287, -5.90551e-08, -0.474442, -2.31349e-08, 1, -8.15478e-08, 0.474442, -6.08093e-08, -0.880287, -47.6503, 14.5468, -50.2337 )
 
 [node name="MainMenuTeleport1" parent="." index="3" instance=ExtResource( 14 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -83, 36, -68 )

--- a/scenes/climbing_gliding_demo/objects/instructions.tscn
+++ b/scenes/climbing_gliding_demo/objects/instructions.tscn
@@ -6,13 +6,13 @@
 
 [sub_resource type="CubeMesh" id=1]
 material = ExtResource( 3 )
-size = Vector3( 4.2, 2.7, 0.1 )
+size = Vector3( 4.2, 3, 0.1 )
 
 [node name="Instructions" type="Spatial"]
 
 [node name="Viewport2Din3D" parent="." instance=ExtResource( 2 )]
-screen_size = Vector2( 4, 2.5 )
-viewport_size = Vector2( 400, 250 )
+screen_size = Vector2( 4, 2.8 )
+viewport_size = Vector2( 400, 280 )
 unshaded = true
 scene = ExtResource( 1 )
 update_mode = 0

--- a/scenes/climbing_gliding_demo/objects/instructions_2d.tscn
+++ b/scenes/climbing_gliding_demo/objects/instructions_2d.tscn
@@ -4,19 +4,19 @@
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_right = -624.0
-margin_bottom = -350.0
+margin_bottom = -320.0
 rect_pivot_offset = Vector2( -421, -85 )
 
 [node name="ColorRect" type="ColorRect" parent="."]
 margin_right = 400.0
-margin_bottom = 250.0
+margin_bottom = 280.0
 color = Color( 0, 0, 0, 0.87451 )
 
 [node name="Description" type="RichTextLabel" parent="."]
 margin_left = 10.0
 margin_top = 10.0
 margin_right = 390.0
-margin_bottom = 240.0
+margin_bottom = 271.0
 text = "Climbing & Gliding Demo
 
 This scene demonstrates climbing, gliding, and wind using the following controls:
@@ -30,4 +30,6 @@ This scene demonstrates climbing, gliding, and wind using the following controls
    - Climbing: Grip
    - Jumping: A/X Button
 
-Holding the arms in a T-Pose triggers gliding."
+Holding the arms in a T-Pose triggers gliding.
+Rolling the arms triggers turning.
+Flapping the arms triggers vertical impulse."

--- a/scenes/climbing_gliding_demo/objects/ring.tscn
+++ b/scenes/climbing_gliding_demo/objects/ring.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=2]
+
+[sub_resource type="SpatialMaterial" id=1]
+albedo_color = Color( 1, 0.172549, 0, 1 )
+
+[node name="ring" type="Spatial"]
+
+[node name="CSGTorus" type="CSGTorus" parent="."]
+transform = Transform( -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, 0, 0 )
+use_collision = true
+inner_radius = 3.0
+outer_radius = 3.5
+sides = 16
+material = SubResource( 1 )


### PR DESCRIPTION
This PR adds a new option to the movement_glide script. It adds a vertical impulse when flapping your arms. The impulse is relative to the downwards velocity of the controllers.

It has a boolean 'wings_impulse' to activate the feature (default is set to false)
It also has an exported 'wings_force' variable to multiply the vertical impulse.

Also added some floating rings to the glide scene to play fly through them.