### PR TITLE
Remove strict class type in FunctionPickup for more flexibility in how controllers are used

### DIFF
--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -202,7 +202,7 @@ static func find_right(node : Node) -> XRToolsFunctionPickup:
 
 
 ## Get the [ARVRController] driving this pickup.
-func get_controller() -> ARVRController:
+func get_controller() -> Node:
 	return _controller
 
 

--- a/addons/godot-xr-tools/functions/movement_turn.gd
+++ b/addons/godot-xr-tools/functions/movement_turn.gd
@@ -57,7 +57,7 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: b
 		deadzone = XRTools.get_snap_turning_deadzone()
 
 	# Read the left/right joystick axis
-	var left_right := _controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_X_AXIS)
+	var left_right = _controller.get_joystick_axis(XRTools.Axis.VR_PRIMARY_X_AXIS)
 	if abs(left_right) <= deadzone:
 		# Not turning
 		_turn_step = 0.0

--- a/addons/godot-xr-tools/misc/arvr_helpers.gd
+++ b/addons/godot-xr-tools/misc/arvr_helpers.gd
@@ -79,18 +79,24 @@ static func get_arvr_camera(node: Node, path: NodePath = NodePath("")) -> ARVRCa
 ## The caller may provide an optional path (relative to the node) to the
 ## [ARVRController] to support out-of-tree searches.
 ##
+
 ## The search is performed assuming the node is under the [ARVRController].
-static func get_arvr_controller(node: Node, path: NodePath = NodePath("")) -> ARVRController:
-	var controller: ARVRController
+static func get_arvr_controller(node: Node, path: NodePath = NodePath("")) -> Node:
+	var controller: Node
 
 	# Try using the node path first
 	if path:
-		controller = node.get_node(path) as ARVRController
-		if controller:
+		controller = node.get_node(path)
+		if controller and controller.has_signal("button_pressed"):
 			return controller
 
 	# Search up from the node for the controller
-	return XRTools.find_ancestor(node, "*", "ARVRController") as ARVRController
+	# XRTools.find_ancestor(node, "*", "ARVRController") as ARVRController
+	while node:
+		if node.has_signal("button_pressed"):
+			break
+		node = node.get_parent()
+	return node
 
 ## Find the Left Hand Controller from a player node and an optional path
 static func get_left_controller(node: Node, path: NodePath = NodePath("")) -> ARVRController:


### PR DESCRIPTION
In trying to get my own networking avatar code to work with the base toolkit again, I hit a blocker in the over-requirement of the FunctionPickup feature to point to a genuine ARVRController object, rather than a node that has the methods and signals it needs to work (ie duck-typing).

![image](https://user-images.githubusercontent.com/677254/211560596-4a23e075-e28e-4693-992b-b3f32c2278f3.png)

It is necessary to attach the FunctionPickup feature to a node whose transform position is not directly set by the hardware controller in order to implement features such as (1) physics hands that don't go through walls, (2) heavy hands that droop when carrying a large object, and (3) to make hand tracking and controller tracking inputs interchangeable by mapping their transforms to the same GripArea.