### PR TITLE
Rename access methods for Godot 4 Beta 15 and onwards

### DIFF
--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -148,7 +148,7 @@ func _process(delta):
 		return
 
 	# Handle our grip
-	var grip_value = _controller.get_value(pickup_axis_action)
+	var grip_value = _controller.get_float(pickup_axis_action)
 	if (grip_pressed and grip_value < (_grip_threshold - 0.1)):
 		grip_pressed = false
 		_on_grip_release()

--- a/addons/godot-xr-tools/functions/function_teleport.gd
+++ b/addons/godot-xr-tools/functions/function_teleport.gd
@@ -266,7 +266,7 @@ func _physics_process(delta):
 				color = cant_teleport_color
 
 			# check our axis to see if we need to rotate
-			teleport_rotation += (delta * controller.get_axis(rotation_action).x * -4.0)
+			teleport_rotation += (delta * controller.get_vector2(rotation_action).x * -4.0)
 
 			# update target and colour
 			var target_basis = Basis()

--- a/addons/godot-xr-tools/functions/movement_direct.gd
+++ b/addons/godot-xr-tools/functions/movement_direct.gd
@@ -41,11 +41,11 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 		return
 
 	# Apply forwards/backwards ground control
-	player_body.ground_control_velocity.y += _controller.get_axis(input_action).y * max_speed
+	player_body.ground_control_velocity.y += _controller.get_vector2(input_action).y * max_speed
 
 	# Apply left/right ground control
 	if strafe:
-		player_body.ground_control_velocity.x += _controller.get_axis(input_action).x * max_speed
+		player_body.ground_control_velocity.x += _controller.get_vector2(input_action).x * max_speed
 
 	# Clamp ground control
 	var length := player_body.ground_control_velocity.length()

--- a/addons/godot-xr-tools/functions/movement_flight.gd
+++ b/addons/godot-xr-tools/functions/movement_flight.gd
@@ -168,8 +168,8 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	var side := forwards.cross(player_body.up_player_vector)
 
 	# Construct the target velocity
-	var joy_forwards := _controller.get_axis("primary").y
-	var joy_side := _controller.get_axis("primary").x
+	var joy_forwards := _controller.get_vector2("primary").y
+	var joy_side := _controller.get_vector2("primary").x
 	var heading := forwards * joy_forwards + side * joy_side
 
 	# Calculate the flight velocity

--- a/addons/godot-xr-tools/functions/movement_turn.gd
+++ b/addons/godot-xr-tools/functions/movement_turn.gd
@@ -59,7 +59,7 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: b
 		deadzone = XRTools.get_snap_turning_deadzone()
 
 	# Read the left/right joystick axis
-	var left_right := _controller.get_axis(input_action).x
+	var left_right := _controller.get_vector2(input_action).x
 	if abs(left_right) <= deadzone:
 		# Not turning
 		_turn_step = 0.0

--- a/addons/godot-xr-tools/hands/hand.gd
+++ b/addons/godot-xr-tools/hands/hand.gd
@@ -118,8 +118,8 @@ func _process(_delta: float) -> void:
 	# Animate the hand mesh with the controller inputs
 	var controller : XRController3D = get_parent()
 	if controller:
-		var grip : float = controller.get_value(grip_action)
-		var trigger : float = controller.get_value(trigger_action)
+		var grip : float = controller.get_float(grip_action)
+		var trigger : float = controller.get_float(trigger_action)
 
 		# Allow overriding of grip and trigger
 		if _force_grip >= 0.0: grip = _force_grip


### PR DESCRIPTION
This fixes a breaking change in beta 15 renaming a number of key functions.