### PR TITLE
Update movement_sprint.gd

### DIFF
--- a/addons/godot-xr-tools/functions/movement_sprint.gd
+++ b/addons/godot-xr-tools/functions/movement_sprint.gd
@@ -162,6 +162,8 @@ func _get_configuration_warning():
 
 	# Call base class
 	return ._get_configuration_warning()
+
+
 ## Find an [XRToolsMovementSprint] node.
 ##
 ## This function searches from the specified node for an [XRToolsMovementSprint]

--- a/addons/godot-xr-tools/functions/movement_sprint.gd
+++ b/addons/godot-xr-tools/functions/movement_sprint.gd
@@ -162,3 +162,12 @@ func _get_configuration_warning():
 
 	# Call base class
 	return ._get_configuration_warning()
+## Find an [XRToolsMovementSprint] node.
+##
+## This function searches from the specified node for an [XRToolsMovementSprint]
+## assuming the node is a sibling of the body under an [ARVROrigin].
+static func find_instance(node: Node) -> XRToolsMovementSprint:
+	return XRTools.find_child(
+		ARVRHelpers.get_arvr_origin(node),
+		"*",
+		"XRToolsMovementSprint") as XRToolsMovementSprint


### PR DESCRIPTION
added missing find_instance

this might look trivial but it is good to have it just in case or like in my case where am working on a stamina provider to get the instance of the sprint and disable it that way