### PR TITLE
Added snap-zone deferred pickup to fix snap-zone stealing.

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,6 @@
 # 3.3.0 (Development)
 - Added reset-scene and scene-control functions to scene-base
+- Fixed snap-zones stealing objects picked out of other near-by snap-zones
 
 # 3.2.0
 - Minimum supported Godot version set to 3.5

--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -200,8 +200,8 @@ func _on_snap_zone_body_entered(target: Spatial) -> void:
 
 	# If this snap zone is configured to snap objects that are dropped, then
 	# start listening for the objects dropped signal
-	if snap_mode == SnapMode.DROPPED:
-		target.connect("dropped", self, "_on_target_dropped")
+	if snap_mode == SnapMode.DROPPED and target.has_signal("dropped"):
+		target.connect("dropped", self, "_on_target_dropped", [], CONNECT_DEFERRED)
 
 	# Show highlight when something could be snapped
 	if not is_instance_valid(picked_up_object):
@@ -214,7 +214,8 @@ func _on_snap_zone_body_exited(target: Spatial) -> void:
 	_object_in_grab_area.erase(target)
 
 	# Stop listening for dropped signals
-	target.disconnect("dropped", self, "_on_target_dropped")
+	if target.has_signal("dropped") and target.is_connected("dropped", self, "_on_target_dropped"):
+		target.disconnect("dropped", self, "_on_target_dropped")
 
 	# Hide highlight when nothing could be snapped
 	if _object_in_grab_area.empty():
@@ -268,7 +269,7 @@ func _update_snap_mode() -> void:
 
 			# Start monitoring all objects in range for drop
 			for o in _object_in_grab_area:
-				o.connect("dropped", self, "_on_target_dropped")
+				o.connect("dropped", self, "_on_target_dropped", [], CONNECT_DEFERRED)
 
 		SnapMode.RANGE:
 			# Enable _process to scan for RANGE pickups
@@ -287,6 +288,10 @@ func _on_target_dropped(target: Spatial) -> void:
 
 	# Skip if already holding a valid object
 	if is_instance_valid(picked_up_object):
+		return
+
+	# Skip if the target is not valid
+	if not is_instance_valid(target):
 		return
 
 	# Pick up the target if we can


### PR DESCRIPTION
This pull request fixes issue #359. The problem of snap-zone stealing is caused by snap-zones listening for objects dropped in their sphere-of-influence, and immediately picking them up. The problem is that when a player picks an object out of a snap-zone the snap-zone first drops the object. If there's a snap-zone in the vicinity that observes that initial drop then it will steal the object before the player has a chance to pick it up.

This pull request causes snap-zones to defer their pickup until idle; and then to check if the object is still available to be picked up. 