### PR TITLE
Change player body to implement kinematic body on root level

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,7 @@
 # 3.3.0 (Development)
 - Added reset-scene and scene-control functions to scene-base
 - Fixed snap-zones stealing objects picked out of other near-by snap-zones
+- Improved player body so it can be used to child objects to
 
 # 3.2.0
 - Minimum supported Godot version set to 3.5

--- a/addons/godot-xr-tools/functions/movement_climb.gd
+++ b/addons/godot-xr-tools/functions/movement_climb.gd
@@ -119,12 +119,12 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 		offset = right_pickup_pos - right_grab_pos
 
 	# Move the player by the offset
-	var old_position := player_body.kinematic_node.global_transform.origin
-	player_body.kinematic_node.move_and_collide(-offset)
+	var old_position := player_body.global_transform.origin
+	player_body.move_and_collide(-offset)
 	player_body.velocity = Vector3.ZERO
 
 	# Update the players average-velocity data
-	var distance := player_body.kinematic_node.global_transform.origin - old_position
+	var distance := player_body.global_transform.origin - old_position
 	_averager.add_distance(delta, distance)
 
 	# Report exclusive motion performed (to bypass gravity)

--- a/addons/godot-xr-tools/functions/movement_wall_walk.gd
+++ b/addons/godot-xr-tools/functions/movement_wall_walk.gd
@@ -19,7 +19,7 @@ export var stick_strength : float = 9.8
 
 func physics_pre_movement(_delta: float, player_body: XRToolsPlayerBody):
 	# Test for collision with wall under feet
-	var wall_collision := player_body.kinematic_node.move_and_collide(
+	var wall_collision := player_body.move_and_collide(
 		player_body.up_player_vector * -stick_distance, true, true, true)
 	if !wall_collision:
 		return

--- a/addons/godot-xr-tools/player/player_body.tscn
+++ b/addons/godot-xr-tools/player/player_body.tscn
@@ -1,18 +1,8 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/player/player_body.gd" type="Script" id=1]
 
-[sub_resource type="CapsuleShape" id=1]
-radius = 0.4
-height = 1.4
-
-[node name="PlayerBody" type="Node"]
-script = ExtResource( 1 )
-
-[node name="KinematicBody" type="KinematicBody" parent="." groups=["player_body"]]
+[node name="PlayerBody" type="KinematicBody" groups=["player_body"]]
 collision_layer = 524288
 collision_mask = 1023
-
-[node name="CollisionShape" type="CollisionShape" parent="KinematicBody"]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.9, 0 )
-shape = SubResource( 1 )
+script = ExtResource( 1 )

--- a/project.godot
+++ b/project.godot
@@ -185,6 +185,11 @@ _global_script_classes=[ {
 "path": "res://addons/godot-xr-tools/functions/movement_flight.gd"
 }, {
 "base": "XRToolsMovementProvider",
+"class": "XRToolsMovementFootstep",
+"language": "GDScript",
+"path": "res://addons/godot-xr-tools/functions/movement_footstep.gd"
+}, {
+"base": "XRToolsMovementProvider",
 "class": "XRToolsMovementGlide",
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/functions/movement_glide.gd"
@@ -239,7 +244,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/objects/pickable.gd"
 }, {
-"base": "Node",
+"base": "KinematicBody",
 "class": "XRToolsPlayerBody",
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/player/player_body.gd"
@@ -273,6 +278,16 @@ _global_script_classes=[ {
 "class": "XRToolsStartXR",
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/xr/start_xr.gd"
+}, {
+"base": "Node",
+"class": "XRToolsSurfaceAudio",
+"language": "GDScript",
+"path": "res://addons/godot-xr-tools/audio/surface_audio.gd"
+}, {
+"base": "Resource",
+"class": "XRToolsSurfaceAudioType",
+"language": "GDScript",
+"path": "res://addons/godot-xr-tools/audio/surface_audio_type.gd"
 }, {
 "base": "Reference",
 "class": "XRToolsVelocityAverager",
@@ -335,6 +350,7 @@ _global_script_class_icons={
 "XRToolsMovementCrouch": "",
 "XRToolsMovementDirect": "",
 "XRToolsMovementFlight": "",
+"XRToolsMovementFootstep": "",
 "XRToolsMovementGlide": "",
 "XRToolsMovementGrapple": "",
 "XRToolsMovementJump": "",
@@ -353,6 +369,8 @@ _global_script_class_icons={
 "XRToolsSnapZone": "",
 "XRToolsStaging": "",
 "XRToolsStartXR": "",
+"XRToolsSurfaceAudio": "res://addons/godot-xr-tools/editor/icons/foot.svg",
+"XRToolsSurfaceAudioType": "res://addons/godot-xr-tools/editor/icons/body.svg",
 "XRToolsVelocityAverager": "",
 "XRToolsVelocityAveragerLinear": "",
 "XRToolsVignette": "",

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -67,7 +67,7 @@ nodes/OpenHand/node = SubResource( 4 )
 nodes/OpenHand/position = Vector2( -600, 100 )
 nodes/Trigger/node = SubResource( 5 )
 nodes/Trigger/position = Vector2( -360, 20 )
-node_connections = [ "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2", "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "output", 0, "Grip" ]
+node_connections = [ "output", 0, "Grip", "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2" ]
 
 [sub_resource type="AnimationNodeAnimation" id=7]
 animation = "Grip"
@@ -98,15 +98,12 @@ nodes/OpenHand/node = SubResource( 10 )
 nodes/OpenHand/position = Vector2( -600, 100 )
 nodes/Trigger/node = SubResource( 11 )
 nodes/Trigger/position = Vector2( -360, 40 )
-node_connections = [ "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2", "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "output", 0, "Grip" ]
+node_connections = [ "output", 0, "Grip", "Trigger", 0, "OpenHand", "Trigger", 1, "ClosedHand1", "Grip", 0, "Trigger", "Grip", 1, "ClosedHand2" ]
 
 [node name="MainMenuLevel" instance=ExtResource( 1 )]
 script = ExtResource( 23 )
 
 [node name="LeftHand" parent="ARVROrigin/LeftHand" index="0" instance=ExtResource( 3 )]
-
-[node name="Skeleton" parent="ARVROrigin/LeftHand/LeftHand/Hand_low_L/Armature" index="0"]
-bones/9/bound_children = [ NodePath("BoneAttachment") ]
 
 [node name="BoneAttachment" type="BoneAttachment" parent="ARVROrigin/LeftHand/LeftHand/Hand_low_L/Armature/Skeleton" index="1"]
 transform = Transform( 0.54083, 0.840813, -0.0231736, -0.0826267, 0.0805243, 0.993322, 0.837064, -0.535303, 0.113023, 0.0399019, 0.0402828, -0.150096 )
@@ -128,9 +125,6 @@ strafe = true
 
 [node name="RightHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 2 )]
 hand_material_override = ExtResource( 28 )
-
-[node name="Skeleton" parent="ARVROrigin/RightHand/RightHand/Hand_low_R/Armature" index="0"]
-bones/9/bound_children = [ NodePath("BoneAttachment") ]
 
 [node name="mesh_Hand_low_R" parent="ARVROrigin/RightHand/RightHand/Hand_low_R/Armature/Skeleton" index="0"]
 material_override = ExtResource( 28 )
@@ -162,73 +156,73 @@ strafe = false
 [node name="Demos" type="Spatial" parent="." index="2"]
 
 [node name="ToBasicMovementDemo" parent="Demos" index="0" instance=ExtResource( 9 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, -11 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10 )
 scene_base = NodePath("../..")
 scene = ExtResource( 7 )
 title = ExtResource( 10 )
 
 [node name="ToFootstepMovementDemo" parent="Demos" index="1" instance=ExtResource( 9 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, -11 )
+transform = Transform( 0.866025, 0, 0.5, 0, 1, 0, -0.5, 0, 0.866025, -5, 0, -8.66025 )
 scene_base = NodePath("../..")
 scene = ExtResource( 37 )
 title = ExtResource( 36 )
 
 [node name="ToTeleportDemo" parent="Demos" index="2" instance=ExtResource( 9 )]
-transform = Transform( 0.841254, 0, 0.540641, 0, 1, 0, -0.540641, 0, 0.841254, -5.40641, 0, -8.41253 )
+transform = Transform( 0.5, 0, 0.866025, 0, 1, 0, -0.866025, 0, 0.5, -8.66025, 0, -5 )
 scene_base = NodePath("../..")
 scene = ExtResource( 11 )
 title = ExtResource( 12 )
 
 [node name="ToClimbingGlidingDemo" parent="Demos" index="3" instance=ExtResource( 9 )]
-transform = Transform( 0.415415, 0, 0.909632, 0, 1, 0, -0.909632, 0, 0.415415, -9.09632, 0, -4.15415 )
+transform = Transform( -4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -10, 0, 4.37114e-07 )
 scene_base = NodePath("../..")
 scene = ExtResource( 14 )
 title = ExtResource( 13 )
 
 [node name="ToGrapplingDemo" parent="Demos" index="4" instance=ExtResource( 9 )]
-transform = Transform( -0.142315, 0, 0.989821, 0, 1, 0, -0.989821, 0, -0.142315, -9.89821, 0, 1.42315 )
+transform = Transform( -0.5, 0, 0.866025, 0, 1, 0, -0.866025, 0, -0.5, -8.66025, 0, 5 )
 scene_base = NodePath("../..")
 scene = ExtResource( 15 )
 title = ExtResource( 16 )
 
 [node name="ToInteractablesDemo" parent="Demos" index="5" instance=ExtResource( 9 )]
-transform = Transform( -0.654861, 0, 0.75575, 0, 1, 0, -0.75575, 0, -0.654861, -7.5575, 0, 6.54861 )
+transform = Transform( -0.866025, 0, 0.5, 0, 1, 0, -0.5, 0, -0.866025, -5, 0, 8.66025 )
 scene_base = NodePath("../..")
 scene = ExtResource( 18 )
 title = ExtResource( 17 )
 
 [node name="ToPointerDemo" parent="Demos" index="6" instance=ExtResource( 9 )]
-transform = Transform( -0.959493, 0, 0.281733, 0, 1, 0, -0.281733, 0, -0.959493, -2.81733, 0, 9.59493 )
+transform = Transform( -1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 8.74228e-07, 0, 10 )
 scene_base = NodePath("../..")
 scene = ExtResource( 19 )
 title = ExtResource( 20 )
 
 [node name="ToPickableDemo" parent="Demos" index="7" instance=ExtResource( 9 )]
-transform = Transform( -0.959493, 0, -0.281733, 0, 1, 0, 0.281733, 0, -0.959493, 2.81733, 0, 9.59493 )
+transform = Transform( -0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, -0.866025, 5, 0, 8.66025 )
 scene_base = NodePath("../..")
 scene = ExtResource( 21 )
 title = ExtResource( 22 )
 
 [node name="ToPokeDemo" parent="Demos" index="8" instance=ExtResource( 9 )]
-transform = Transform( -0.654861, 0, -0.75575, 0, 1, 0, 0.75575, 0, -0.654861, 7.5575, 0, 6.54861 )
+transform = Transform( -0.5, 0, -0.866025, 0, 1, 0, 0.866025, 0, -0.5, 8.66025, 0, 5 )
 scene_base = NodePath("../..")
 scene = ExtResource( 24 )
 title = ExtResource( 25 )
 
 [node name="ToSprintingDemo" parent="Demos" index="9" instance=ExtResource( 9 )]
-transform = Transform( -0.142315, 0, -0.989821, 0, 1, 0, 0.989821, 0, -0.142315, 9.89821, 0, 1.42315 )
+transform = Transform( 1.19249e-08, 0, -1, 0, 1, 0, 1, 0, 1.19249e-08, 10, 0, -1.19249e-07 )
 scene_base = NodePath("../..")
 scene = ExtResource( 30 )
 title = ExtResource( 31 )
 
 [node name="ToOriginGravityDemo" parent="Demos" index="10" instance=ExtResource( 9 )]
-transform = Transform( 0.415415, 0, -0.909632, 0, 1, 0, 0.909632, 0, 0.415415, 9.09632, 0, -4.15415 )
+transform = Transform( 0.5, 0, -0.866025, 0, 1, 0, 0.866025, 0, 0.5, 8.66025, 0, -5 )
 scene_base = NodePath("../..")
 scene = ExtResource( 33 )
 title = ExtResource( 32 )
 
 [node name="ToSphereWorldDemo" parent="Demos" index="11" instance=ExtResource( 9 )]
-transform = Transform( 0.841253, 0, -0.540641, 0, 1, 0, 0.540641, 0, 0.841253, 5.40641, 0, -8.41253 )
+transform = Transform( 0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, 0.866025, 5, 0, -8.66025 )
 scene_base = NodePath("../..")
 scene = ExtResource( 35 )
 title = ExtResource( 34 )

--- a/scenes/pickable_demo/objects/BeltSnapZone.tscn
+++ b/scenes/pickable_demo/objects/BeltSnapZone.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/objects/highlight/highlight_ring.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/godot-xr-tools/objects/snap_zone.tscn" type="PackedScene" id=2]
+
+[sub_resource type="SpatialMaterial" id=1]
+flags_transparent = true
+params_cull_mode = 1
+albedo_color = Color( 0.0627451, 0.905882, 0.886275, 0.545098 )
+
+[sub_resource type="SphereMesh" id=2]
+material = SubResource( 1 )
+radius = 0.05
+height = 0.1
+radial_segments = 32
+rings = 16
+
+[node name="BeltSnapZone" instance=ExtResource( 2 )]
+collision_layer = 4
+collision_mask = 65540
+grab_distance = 0.1
+
+[node name="Sphere" type="MeshInstance" parent="." index="1"]
+cast_shadow = 0
+mesh = SubResource( 2 )
+
+[node name="HighlightRing" parent="." index="2" instance=ExtResource( 1 )]

--- a/scenes/pickable_demo/pickable_demo.tscn
+++ b/scenes/pickable_demo/pickable_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=24 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/staging/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/maps/basic_map.tscn" type="PackedScene" id=2]
@@ -22,6 +22,7 @@
 [ext_resource path="res://scenes/pickable_demo/objects/saucer.tscn" type="PackedScene" id=20]
 [ext_resource path="res://scenes/pickable_demo/objects/teacup_stand.tscn" type="PackedScene" id=21]
 [ext_resource path="res://scenes/pickable_demo/objects/instructions.tscn" type="PackedScene" id=22]
+[ext_resource path="res://scenes/pickable_demo/objects/BeltSnapZone.tscn" type="PackedScene" id=23]
 
 [node name="PickableDemo" instance=ExtResource( 1 )]
 
@@ -61,6 +62,21 @@ laser_length = 1
 collision_mask = 1048576
 
 [node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 9 )]
+
+[node name="BeltSnapZone01" parent="ARVROrigin/PlayerBody" index="0" instance=ExtResource( 23 )]
+transform = Transform( 0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, -0.176713, 1, -0.176713 )
+
+[node name="BeltSnapZone02" parent="ARVROrigin/PlayerBody" index="1" instance=ExtResource( 23 )]
+transform = Transform( 0.92388, 0, 0.382683, 0, 1, 0, -0.382683, 0, 0.92388, -0.0956363, 1, -0.230887 )
+
+[node name="BeltSnapZone03" parent="ARVROrigin/PlayerBody" index="2" instance=ExtResource( 23 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 7.45058e-09, 1, -0.24991 )
+
+[node name="BeltSnapZone04" parent="ARVROrigin/PlayerBody" index="3" instance=ExtResource( 23 )]
+transform = Transform( 0.92388, 0, -0.382683, 0, 1, 0, 0.382683, 0, 0.92388, 0.0956363, 1, -0.230887 )
+
+[node name="BeltSnapZone05" parent="ARVROrigin/PlayerBody" index="4" instance=ExtResource( 23 )]
+transform = Transform( 0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, 0.707107, 0.176713, 1, -0.176713 )
 
 [node name="BasicMap" parent="." index="1" instance=ExtResource( 2 )]
 


### PR DESCRIPTION
This PR changes the `player_body.tscn` scene so it's root node is the KinematicBody node. It uses `set_as_toplevel` to ensure it is moved in global space and does not get its positioning from its parent.

This ensures that the player body node moves with the player and can be used to anchor objects to the player. 

There is also added logic that ensures the player body faces forward based on the camera position. This has been improved that when the player looks up or down, the up vector of the head is used giving more accuracy and stability. 

This direction is now also mixed in with a direction based on the relative positions of the hands, there is a new property called `Body Forward Mix` that gives you control of this. If set to 0 we purely use the camera forward position, if 1.0 it purely uses the forward vector of the hands. The default is 0.75 which gave decent results for me. It will never be perfect, as I've said before, we don't track the players body so any logic is guesswork.
There is a limit to this that the forward vector can not deviate more than 60 degrees to either side of the direction the player is looking at.

The pickable demo has been enhanced by adding a belt of storage snap zones to the player. These right now are unrestricted so you can do some funky things, but it is a good demonstration of attaching something useful to the player body and neatly visualises how the new forward facing logic is working.