### PR TITLE
Use recommended physics layers for all objects

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,7 @@
 - Added reset-scene and scene-control functions to scene-base
 - Fixed snap-zones stealing objects picked out of other near-by snap-zones
 - Improved player body so it can be used to child objects to
+- Updated scene/script default physics layers to match recommendations on website
 
 # 3.2.0
 - Minimum supported Godot version set to 3.5

--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -20,6 +20,12 @@ signal has_picked_up(what)
 signal has_dropped
 
 
+# Default pickup collision mask of 3:pickable and 19:handle
+const DEFAULT_GRAB_MASK := 0b0000_0000_0000_0100_0000_0000_0000_0100
+
+# Default pickup collision mask of 3:pickable
+const DEFAULT_RANGE_MASK := 0b0000_0000_0000_0000_0000_0000_0000_0100
+
 # Constant for worst-case grab distance
 const MAX_GRAB_DISTANCE2: float = 1000000.0
 
@@ -38,7 +44,7 @@ export var grab_distance : float = 0.3 setget _set_grab_distance
 
 ## Grab collision mask
 export (int, LAYERS_3D_PHYSICS) \
-		var grab_collision_mask : int = 1 setget _set_grab_collision_mask
+		var grab_collision_mask : int = DEFAULT_GRAB_MASK setget _set_grab_collision_mask
 
 ## If true, ranged-grabbing is enabled
 export var ranged_enable : bool = true
@@ -51,7 +57,7 @@ export (float, 0.0, 45.0) var ranged_angle : float = 5.0 setget _set_ranged_angl
 
 ## Ranged-grab collision mask
 export (int, LAYERS_3D_PHYSICS) \
-		var ranged_collision_mask : int = 1 setget _set_ranged_collision_mask
+		var ranged_collision_mask : int = DEFAULT_RANGE_MASK setget _set_ranged_collision_mask
 
 ## Throw impulse factor
 export var impulse_factor : float = 1.0

--- a/addons/godot-xr-tools/functions/function_pointer.gd
+++ b/addons/godot-xr-tools/functions/function_pointer.gd
@@ -27,6 +27,10 @@ enum LaserLength {
 }
 
 
+# Default pointer collision mask of 21:pointable
+const DEFAULT_MASK := 0b0000_0000_0001_0000_0000_0000_0000_0000
+
+
 ## Pointer enabled property
 export var enabled : bool = true setget set_enabled
 
@@ -46,7 +50,7 @@ export var y_offset : float = -0.05 setget set_y_offset
 export var distance : float = 10 setget set_distance
 
 ## Pointer collision mask
-export (int, LAYERS_3D_PHYSICS) var collision_mask : int = 15 setget set_collision_mask
+export (int, LAYERS_3D_PHYSICS) var collision_mask : int = DEFAULT_MASK setget set_collision_mask
 
 ## Enable pointer collision with bodies
 export var collide_with_bodies : bool = true setget set_collide_with_bodies

--- a/addons/godot-xr-tools/functions/function_pointer.tscn
+++ b/addons/godot-xr-tools/functions/function_pointer.tscn
@@ -16,13 +16,12 @@ rings = 8
 
 [node name="FunctionPointer" type="Spatial"]
 script = ExtResource( 2 )
-collision_mask = 524287
 
 [node name="RayCast" type="RayCast" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0 )
 enabled = true
 cast_to = Vector3( 0, 0, -10 )
-collision_mask = 524287
+collision_mask = 1048576
 
 [node name="Laser" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, -5 )

--- a/addons/godot-xr-tools/functions/function_pose_detector.gd
+++ b/addons/godot-xr-tools/functions/function_pose_detector.gd
@@ -8,8 +8,12 @@ extends Spatial
 ## of the VR hands.
 
 
+# Default pose detector collision mask of 22:pose-area
+const DEFAULT_MASK := 0b0000_0000_0010_0000_0000_0000_0000_0000
+
+
 ## Collision mask to detect hand pose areas
-export (int, LAYERS_3D_PHYSICS) var collision_mask : int = 1 << 21 setget set_collision_mask
+export (int, LAYERS_3D_PHYSICS) var collision_mask : int = DEFAULT_MASK setget set_collision_mask
 
 
 ## Hand controller

--- a/addons/godot-xr-tools/functions/function_teleport.gd
+++ b/addons/godot-xr-tools/functions/function_teleport.gd
@@ -12,6 +12,10 @@ extends KinematicBody
 ## a teleport function on that controller.
 
 
+# Default teleport collision mask of all
+const DEFAULT_MASK := 0b1111_1111_1111_1111_1111_1111_1111_1111
+
+
 ## If true, teleporting is enabled
 export var enabled : bool = true setget set_enabled
 
@@ -37,7 +41,7 @@ export var strength : float = 5.0
 export var max_slope : float = 20.0
 
 ## Valid teleport layer mask
-export (int, LAYERS_3D_PHYSICS) var valid_teleport_mask : int = ~0
+export (int, LAYERS_3D_PHYSICS) var valid_teleport_mask : int = DEFAULT_MASK
 
 # once this is no longer a kinematic body, we'll need this..
 # export (int, LAYERS_3D_PHYSICS) var collision_mask = 1

--- a/addons/godot-xr-tools/functions/movement_grapple.gd
+++ b/addons/godot-xr-tools/functions/movement_grapple.gd
@@ -26,6 +26,10 @@ enum GrappleState {
 }
 
 
+# Default grapple collision mask of 1:static-world
+const DEFAULT_MASK := 0b0000_0000_0000_0000_0000_0000_0000_0001
+
+
 ## Movement provider order
 export var order : int = 20
 
@@ -34,7 +38,7 @@ export var grapple_length : float = 15.0
 
 ## Grapple collision mask
 export (int, LAYERS_3D_PHYSICS) \
-		var grapple_collision_mask : int = 1 setget _set_grapple_collision_mask
+		var grapple_collision_mask : int = DEFAULT_MASK setget _set_grapple_collision_mask
 
 ## Impulse speed applied to the player on first grapple
 export var impulse_speed : float = 10.0

--- a/addons/godot-xr-tools/functions/movement_wall_walk.gd
+++ b/addons/godot-xr-tools/functions/movement_wall_walk.gd
@@ -3,11 +3,15 @@ class_name XRToolsMovementWallWalk
 extends XRToolsMovementProvider
 
 
+# Default wall-walk mask of 4:wall-walk
+const DEFAULT_MASK := 0b0000_0000_0000_0000_0000_0000_0000_1000
+
+
 ## Wall walking provider order
 export var order : int = 25
 
 ## Set our follow layer mask
-export (int, LAYERS_3D_PHYSICS) var follow_mask : int = 8
+export (int, LAYERS_3D_PHYSICS) var follow_mask : int = DEFAULT_MASK
 
 ## Wall stick distance
 export var stick_distance : float = 1.0

--- a/addons/godot-xr-tools/functions/movement_wind.gd
+++ b/addons/godot-xr-tools/functions/movement_wind.gd
@@ -16,6 +16,10 @@ extends XRToolsMovementProvider
 signal wind_area_changed(active_wind_area)
 
 
+# Default wind area collision mask of 20:player-body
+const DEFAULT_MASK := 0b0000_0000_0000_1000_0000_0000_0000_0000
+
+
 ## Movement provider order
 export var order : int = 25
 
@@ -23,7 +27,7 @@ export var order : int = 25
 export var drag_multiplier : float = 1.0
 
 # Set our collision mask
-export (int, LAYERS_3D_PHYSICS) var collision_mask : int = 524288 setget set_collision_mask
+export (int, LAYERS_3D_PHYSICS) var collision_mask : int = DEFAULT_MASK setget set_collision_mask
 
 
 # Wind detection area

--- a/addons/godot-xr-tools/hands/physics_hand.gd
+++ b/addons/godot-xr-tools/hands/physics_hand.gd
@@ -10,13 +10,17 @@ extends XRToolsHand
 ## attached to the hand.
 
 
+# Default hand bone layer of 18:player-hand
+const DEFAULT_LAYER := 0b0000_0000_0000_0010_0000_0000_0000_0000
+
+
 ## Collision layer applied to all [XRToolsHandPhysicsBone] children.
 ##
 ## This is used to set physics collision layers for every bone in a hand.
 ## Additionally [XRToolsHandPhysicsBone] nodes can specify additional
 ## bone-specific collision layers - for example to give the fore-finger bone
 ## additional collision capabilities.
-export (int, LAYERS_3D_PHYSICS) var collision_layer : int = 1 << 17
+export (int, LAYERS_3D_PHYSICS) var collision_layer : int = DEFAULT_LAYER
 
 ## Bone collision margin applied to all [XRToolsHandPhysicsBone] children.
 ##

--- a/addons/godot-xr-tools/interactables/interactable_area_button.tscn
+++ b/addons/godot-xr-tools/interactables/interactable_area_button.tscn
@@ -3,4 +3,6 @@
 [ext_resource path="res://addons/godot-xr-tools/interactables/interactable_area_button.gd" type="Script" id=1]
 
 [node name="InteractableAreaButton" type="Area"]
+collision_layer = 0
+collision_mask = 131072
 script = ExtResource( 1 )

--- a/addons/godot-xr-tools/interactables/interactable_handle.tscn
+++ b/addons/godot-xr-tools/interactables/interactable_handle.tscn
@@ -8,4 +8,4 @@ collision_mask = 0
 mode = 1
 gravity_scale = 0.0
 script = ExtResource( 1 )
-reset_transform_on_pickup = false
+picked_up_layer = 0

--- a/addons/godot-xr-tools/objects/climbable.tscn
+++ b/addons/godot-xr-tools/objects/climbable.tscn
@@ -3,6 +3,8 @@
 [ext_resource path="res://addons/godot-xr-tools/objects/climbable.gd" type="Script" id=1]
 
 [node name="Climbable" type="StaticBody"]
+collision_layer = 262145
+collision_mask = 0
 script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]

--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -55,6 +55,9 @@ enum ReleaseMode {
 }
 
 
+# Default layer for held objects is 17:held-object
+const DEFAULT_LAYER := 0b0000_0000_0000_0001_0000_0000_0000_0000
+
 ## Priority for grip poses
 const GRIP_POSE_PRIORITY = 100
 
@@ -66,7 +69,7 @@ export var enabled : bool = true
 export var press_to_hold : bool = true
 
 ## Layer for this object while picked up
-export (int, LAYERS_3D_PHYSICS) var picked_up_layer = 0
+export (int, LAYERS_3D_PHYSICS) var picked_up_layer = DEFAULT_LAYER
 
 ## Method used to hold an object
 export (HoldMethod) var hold_method = HoldMethod.REMOTE_TRANSFORM

--- a/addons/godot-xr-tools/objects/pickable.tscn
+++ b/addons/godot-xr-tools/objects/pickable.tscn
@@ -3,6 +3,8 @@
 [ext_resource path="res://addons/godot-xr-tools/objects/pickable.gd" type="Script" id=1]
 
 [node name="Pickable" type="RigidBody"]
+collision_layer = 4
+collision_mask = 196615
 script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]

--- a/addons/godot-xr-tools/objects/snap_zone.tscn
+++ b/addons/godot-xr-tools/objects/snap_zone.tscn
@@ -5,6 +5,8 @@
 [sub_resource type="SphereShape" id=1]
 
 [node name="SnapZone" type="Area"]
+collision_layer = 4
+collision_mask = 65540
 script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -28,6 +28,10 @@ enum UpdateMode {
 }
 
 
+# Default layer of 1:static-world and 21:pointable
+const DEFAULT_LAYER := 0b0000_0000_0001_0000_0000_0000_0000_0001
+
+
 ## Viewport enabled property
 export var enabled : bool = true setget set_enabled
 
@@ -60,7 +64,8 @@ export (UpdateMode) var update_mode = UpdateMode.UPDATE_ALWAYS setget set_update
 export var throttle_fps : float = 30.0
 
 ## Collision layer
-export (int, LAYERS_3D_PHYSICS) var collision_layer : int = 15 setget set_collision_layer
+export (int, LAYERS_3D_PHYSICS) \
+		var collision_layer : int = DEFAULT_LAYER setget set_collision_layer
 
 
 var is_ready : bool = false

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.tscn
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.tscn
@@ -8,11 +8,10 @@ resource_local_to_scene = true
 size = Vector2( 3, 2 )
 
 [sub_resource type="ViewportTexture" id=5]
+flags = 4
 
-[sub_resource type="SpatialMaterial" id=3]
-resource_local_to_scene = true
+[sub_resource type="SpatialMaterial" id=6]
 flags_transparent = true
-flags_unshaded = true
 params_cull_mode = 2
 albedo_texture = SubResource( 5 )
 
@@ -22,7 +21,6 @@ extents = Vector3( 1.5, 1, 0.01 )
 
 [node name="Viewport2Din3D" type="Spatial"]
 script = ExtResource( 2 )
-collision_layer = 1023
 
 [node name="Viewport" type="Viewport" parent="."]
 size = Vector2( 300, 200 )
@@ -30,14 +28,14 @@ transparent_bg = true
 disable_3d = true
 usage = 0
 render_target_v_flip = true
-render_target_update_mode = 3
+render_target_update_mode = 1
 
 [node name="Screen" type="MeshInstance" parent="."]
 mesh = SubResource( 1 )
-material/0 = SubResource( 3 )
+material/0 = SubResource( 6 )
 
 [node name="StaticBody" type="StaticBody" parent="."]
-collision_layer = 1023
+collision_layer = 1048577
 collision_mask = 0
 script = ExtResource( 1 )
 viewport_size = Vector2( 300, 200 )

--- a/addons/godot-xr-tools/objects/wind_area.tscn
+++ b/addons/godot-xr-tools/objects/wind_area.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://addons/godot-xr-tools/objects/wind_area.gd" type="Script" id=1]
 
 [node name="WindArea" type="Area"]
-collision_layer = 65536
+collision_layer = 524288
 collision_mask = 0
 monitoring = false
 script = ExtResource( 1 )

--- a/addons/godot-xr-tools/player/poke/poke.tscn
+++ b/addons/godot-xr-tools/player/poke/poke.tscn
@@ -30,6 +30,7 @@ custom_integrator = true
 contacts_reported = 1
 contact_monitor = true
 script = ExtResource( 2 )
+teleport_distance = 0.1
 
 [node name="CollisionShape" type="CollisionShape" parent="PokeBody"]
 shape = SubResource( 1 )

--- a/assets/meshes/interactables/joystick_smooth.tscn
+++ b/assets/meshes/interactables/joystick_smooth.tscn
@@ -77,7 +77,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 4 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )

--- a/assets/meshes/interactables/joystick_snap.tscn
+++ b/assets/meshes/interactables/joystick_snap.tscn
@@ -83,7 +83,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 4 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )

--- a/assets/meshes/interactables/joystick_zero.tscn
+++ b/assets/meshes/interactables/joystick_zero.tscn
@@ -82,7 +82,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 4 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="JoystickOrigin/InteractableJoystick/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )

--- a/assets/meshes/interactables/lever_smooth.tscn
+++ b/assets/meshes/interactables/lever_smooth.tscn
@@ -81,7 +81,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 4 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )

--- a/assets/meshes/interactables/lever_snap.tscn
+++ b/assets/meshes/interactables/lever_snap.tscn
@@ -82,7 +82,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 4 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )

--- a/assets/meshes/interactables/lever_zero.tscn
+++ b/assets/meshes/interactables/lever_zero.tscn
@@ -82,7 +82,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 4 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="LeverOrigin/InteractableLever/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )

--- a/assets/meshes/interactables/slider_smooth.tscn
+++ b/assets/meshes/interactables/slider_smooth.tscn
@@ -84,7 +84,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 4 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )

--- a/assets/meshes/interactables/slider_snap.tscn
+++ b/assets/meshes/interactables/slider_snap.tscn
@@ -85,7 +85,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 4 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )

--- a/assets/meshes/interactables/slider_zero.tscn
+++ b/assets/meshes/interactables/slider_zero.tscn
@@ -85,7 +85,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 4 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="SliderOrigin/InteractableSlider/HandleOrigin/InteractableHandle"]
 shape = SubResource( 7 )

--- a/assets/meshes/interactables/wheel_smooth.tscn
+++ b/assets/meshes/interactables/wheel_smooth.tscn
@@ -54,7 +54,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 3 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="HingeOrigin/InteractableHinge/Handle1/InteractableHandle"]
 shape = SubResource( 3 )
@@ -67,7 +67,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 3 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="HingeOrigin/InteractableHinge/Handle2/InteractableHandle"]
 shape = SubResource( 3 )
@@ -80,7 +80,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 3 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="HingeOrigin/InteractableHinge/Handle3/InteractableHandle"]
 shape = SubResource( 3 )
@@ -93,7 +93,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 3 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="HingeOrigin/InteractableHinge/Handle4/InteractableHandle"]
 shape = SubResource( 3 )
@@ -106,7 +106,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 3 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="HingeOrigin/InteractableHinge/Handle5/InteractableHandle"]
 shape = SubResource( 3 )
@@ -119,7 +119,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 3 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="HingeOrigin/InteractableHinge/Handle6/InteractableHandle"]
 shape = SubResource( 3 )
@@ -132,7 +132,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 3 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="HingeOrigin/InteractableHinge/Handle7/InteractableHandle"]
 shape = SubResource( 3 )
@@ -145,7 +145,7 @@ collision_layer = 262144
 collision_mask = 0
 mode = 1
 script = ExtResource( 3 )
-reset_transform_on_pickup = false
+picked_up_layer = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="HingeOrigin/InteractableHinge/Handle8/InteractableHandle"]
 shape = SubResource( 3 )

--- a/project.godot
+++ b/project.godot
@@ -408,6 +408,7 @@ common/drop_mouse_on_gui_input_disabled=true
 3d_physics/layer_4="orientable_ground"
 3d_physics/layer_17="held_object"
 3d_physics/layer_18="player_hand"
+3d_physics/layer_19="handle"
 3d_physics/layer_20="player_body"
 3d_physics/layer_21="pointable"
 3d_physics/layer_22="pose_area"

--- a/scenes/grappling_demo/grappling_demo.tscn
+++ b/scenes/grappling_demo/grappling_demo.tscn
@@ -35,7 +35,6 @@ strafe = true
 jump_button_id = 7
 
 [node name="FunctionPickup" parent="ARVROrigin/LeftHand" index="3" instance=ExtResource( 8 )]
-grab_collision_mask = 3
 ranged_enable = false
 
 [node name="RightHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 10 )]
@@ -52,10 +51,8 @@ strafe = false
 jump_button_id = 7
 
 [node name="MovementGrapple" parent="ARVROrigin/RightHand" index="4" instance=ExtResource( 2 )]
-grapple_collision_mask = 2
 
 [node name="FunctionPickup" parent="ARVROrigin/RightHand" index="5" instance=ExtResource( 8 )]
-grab_collision_mask = 3
 ranged_enable = false
 
 [node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 11 )]

--- a/scenes/grappling_demo/objects/platform.tscn
+++ b/scenes/grappling_demo/objects/platform.tscn
@@ -10,7 +10,7 @@ size = Vector3( 5, 1, 5 )
 extents = Vector3( 2.5, 0.5, 2.5 )
 
 [node name="Platform" type="StaticBody"]
-collision_layer = 2
+collision_layer = 262145
 collision_mask = 0
 script = ExtResource( 1 )
 

--- a/scenes/grappling_demo/objects/tower.tscn
+++ b/scenes/grappling_demo/objects/tower.tscn
@@ -10,8 +10,6 @@ extents = Vector3( 1.5, 4, 1.5 )
 size = Vector3( 3, 8, 3 )
 
 [node name="Tower" instance=ExtResource( 1 )]
-collision_layer = 2
-collision_mask = 0
 
 [node name="CollisionShape" parent="." index="0"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, 0 )

--- a/scenes/interactables_demo/interactables_demo.tscn
+++ b/scenes/interactables_demo/interactables_demo.tscn
@@ -37,9 +37,7 @@ max_speed = 3.0
 strafe = true
 
 [node name="FunctionPickup" parent="ARVROrigin/LeftHand" index="3" instance=ExtResource( 7 )]
-grab_collision_mask = 262144
 ranged_enable = false
-ranged_collision_mask = 0
 
 [node name="RightPhysicsHand" parent="ARVROrigin/RightHand" index="0" instance=ExtResource( 11 )]
 
@@ -54,9 +52,7 @@ strafe = false
 [node name="MovementTurn" parent="ARVROrigin/RightHand" index="3" instance=ExtResource( 10 )]
 
 [node name="FunctionPickup" parent="ARVROrigin/RightHand" index="4" instance=ExtResource( 7 )]
-grab_collision_mask = 262144
 ranged_enable = false
-ranged_collision_mask = 0
 
 [node name="PlayerBody" parent="ARVROrigin" index="3" instance=ExtResource( 9 )]
 

--- a/scenes/pickable_demo/objects/BeltSnapZone.tscn
+++ b/scenes/pickable_demo/objects/BeltSnapZone.tscn
@@ -16,8 +16,6 @@ radial_segments = 32
 rings = 16
 
 [node name="BeltSnapZone" instance=ExtResource( 2 )]
-collision_layer = 4
-collision_mask = 65540
 grab_distance = 0.1
 
 [node name="Sphere" type="MeshInstance" parent="." index="1"]

--- a/scenes/pickable_demo/objects/grab_ball.tscn
+++ b/scenes/pickable_demo/objects/grab_ball.tscn
@@ -28,9 +28,7 @@ flags_unshaded = true
 albedo_color = Color( 1, 1, 0, 1 )
 
 [node name="GrabBall" instance=ExtResource( 1 )]
-collision_layer = 4
 collision_mask = 720903
-picked_up_layer = 65536
 ranged_grab_method = 2
 
 [node name="GrabPointHandLeft" parent="." index="0" instance=ExtResource( 4 )]

--- a/scenes/pickable_demo/objects/grab_cube.tscn
+++ b/scenes/pickable_demo/objects/grab_cube.tscn
@@ -12,9 +12,6 @@ extents = Vector3( 0.05, 0.05, 0.05 )
 size = Vector3( 0.1, 0.1, 0.1 )
 
 [node name="GrabCube" instance=ExtResource( 1 )]
-collision_layer = 4
-collision_mask = 196615
-picked_up_layer = 65536
 ranged_grab_method = 0
 
 [node name="CollisionShape" parent="." index="0"]

--- a/scenes/pickable_demo/objects/hammer.tscn
+++ b/scenes/pickable_demo/objects/hammer.tscn
@@ -27,9 +27,7 @@ rings = 0
 size = Vector3( 0.1, 0.1, 0.2 )
 
 [node name="Hammer" instance=ExtResource( 1 )]
-collision_layer = 4
 collision_mask = 7
-picked_up_layer = 65536
 ranged_grab_method = 0
 
 [node name="GrabPointHandLeft" parent="." index="0" instance=ExtResource( 5 )]

--- a/scenes/pickable_demo/objects/saucer.tscn
+++ b/scenes/pickable_demo/objects/saucer.tscn
@@ -30,7 +30,5 @@ mesh = SubResource( 1 )
 shape = SubResource( 2 )
 
 [node name="SnapZoneTeacup" parent="." instance=ExtResource( 1 )]
-collision_layer = 4
-collision_mask = 65540
 snap_mode = 1
 snap_require = "Teacup"

--- a/scenes/pickable_demo/objects/snap_toy_red.tscn
+++ b/scenes/pickable_demo/objects/snap_toy_red.tscn
@@ -18,9 +18,7 @@ rings = 0
 albedo_color = Color( 1, 0, 0, 1 )
 
 [node name="SnapToyRed" groups=["SnapToy", "SnapToyRed"] instance=ExtResource( 1 )]
-collision_layer = 4
 collision_mask = 65543
-picked_up_layer = 65536
 ranged_grab_method = 0
 
 [node name="CollisionShape" parent="." index="0"]

--- a/scenes/pickable_demo/objects/teacup.tscn
+++ b/scenes/pickable_demo/objects/teacup.tscn
@@ -42,7 +42,6 @@ closed_pose = ExtResource( 7 )
 collision_layer = 4
 collision_mask = 196615
 script = ExtResource( 1 )
-picked_up_layer = 65536
 
 [node name="Teacup" type="MeshInstance" parent="."]
 mesh = SubResource( 1 )


### PR DESCRIPTION
This pull request contains the following changes:
 - Added standard layer 19 for interactable handles.
 - Modified godot-xr-tools scripts and scenes to use all recommended layers for defaults.
 - Modified layer defaults to be binary constants.

Specifically the list of changes are:
 - FunctionPickup grab mask is 3:pickable and 19:handle
 - FunctionPickup ranged mask is 3:pickable
 - FunctionPointer mask is 21:pointable
 - FunctionPoseDetector mask is 22:pose-area
 - FunctionTeleport mask is 0xFFFFFFFF-all
 - MovementGrapple mask is 1:static-world
 - MovementWallWalk mask is 4:wall-walk
 - MovementWind mask is 20:player-body
 - PhysicsHand collision-layer is 18:player-hand
 - InteractableAreaButton collision-mask is 18:player-hand
 - InteractableHandle collision-layer is 19:handle
 - InteractableHandle picked-up-layer is 0:none
 - Climbable collision-layer is 1:static-world and 19:handle
 - Pickable picked-up-layer is 17:held-object
 - Pickable collision-layer is 3:pickable
 - Pickable collision-mask is 1:static-world, 2:dynamic-world, 3:pickable, 17:held-object, 18:player-hand
 - SnapZone collision-layer is 3:pickable
 - SnapZone collision-mask is 3:pickable, 17:held-object
 - Viewport2Din3D collision-layer is 1:static-world and 21:pointable
 - WindArea collision-layer is 20:player-body
 
NOTE: Updated to reflect climbable is now 19:handle so climbable objects can be grabbed