### PR TITLE
Held objects can now detect release of action button

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,6 +3,7 @@
 - Fixed snap-zones stealing objects picked out of other near-by snap-zones
 - Improved player body so it can be used to child objects to
 - Updated scene/script default physics layers to match recommendations on website
+- Added action_released signal to held objects
 
 # 3.2.0
 - Minimum supported Godot version set to 3.5

--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -408,13 +408,17 @@ func _pick_up_object(target: Spatial) -> void:
 
 
 func _on_button_pressed(p_button) -> void:
-	if p_button == action_button_id:
-		if is_instance_valid(picked_up_object) and picked_up_object.has_method("action"):
+	if p_button == action_button_id and is_instance_valid(picked_up_object):
+		if picked_up_object.has_method("action"):
 			picked_up_object.action()
+		if picked_up_object.has_method("action_button"):
+			picked_up_object.action_button(true)
 
 
-func _on_button_release(_p_button) -> void:
-	pass
+func _on_button_release(p_button) -> void:
+	if p_button == action_button_id and is_instance_valid(picked_up_object):
+		if picked_up_object.has_method("action_button"):
+			picked_up_object.action_button(false)
 
 
 func _on_grip_pressed() -> void:

--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -24,6 +24,9 @@ signal dropped(pickable)
 # Signal emitted when the user presses the action button while holding this object
 signal action_pressed(pickable)
 
+# Signal emitted when the user releases the action button while holding this object
+signal action_released(pickable)
+
 # Signal emitted when the highlight state changes
 signal highlight_updated(pickable, enable)
 
@@ -155,9 +158,12 @@ func is_picked_up():
 
 
 # action is called when user presses the action button while holding this object
-func action():
+func action_button(p_pressed : bool) -> void:
 	# let interested parties know
-	emit_signal("action_pressed", self)
+	if p_pressed:
+		emit_signal("action_pressed", self)
+	else:
+		emit_signal("action_released", self)
 
 
 # This method is invoked when it becomes the closest pickable object to one of

--- a/scenes/pickable_demo/objects/grab_cube.gd
+++ b/scenes/pickable_demo/objects/grab_cube.gd
@@ -1,0 +1,35 @@
+extends XRToolsPickable
+
+
+## Material to show when active
+export var active_material : Material
+
+
+# Default material shown when inactive
+var _default_material : Material
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	_default_material = $MeshInstance.get_active_material(0)
+
+	# Listen for events
+	connect("action_pressed", self, "_on_action_pressed")
+	connect("action_released", self, "_on_action_released")
+	connect("dropped", self, "_on_dropped")
+
+
+# Called when the user presses the action button while holding this object
+func _on_action_pressed(_pickable : XRToolsPickable) -> void:
+	if active_material:
+		$MeshInstance.set_surface_material(0, active_material)
+
+
+# Called when the user releases the action button while holding this object
+func _on_action_released(_pickable : XRToolsPickable) -> void:
+	$MeshInstance.set_surface_material(0, _default_material)
+
+
+# Called when this object is dropped
+func _on_dropped(_pickable : XRToolsPickable) -> void:
+	$MeshInstance.set_surface_material(0, _default_material)

--- a/scenes/pickable_demo/objects/grab_cube.tscn
+++ b/scenes/pickable_demo/objects/grab_cube.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/objects/pickable.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-xr-tools/objects/highlight/highlight_ring.tscn" type="PackedScene" id=2]
 [ext_resource path="res://assets/wahooney.itch.io/green_grid_triplanar.tres" type="Material" id=3]
+[ext_resource path="res://scenes/pickable_demo/objects/grab_cube.gd" type="Script" id=4]
+[ext_resource path="res://assets/wahooney.itch.io/blue_grid.tres" type="Material" id=5]
 
 [sub_resource type="BoxShape" id=7]
 margin = 0.01
@@ -12,7 +14,8 @@ extents = Vector3( 0.05, 0.05, 0.05 )
 size = Vector3( 0.1, 0.1, 0.1 )
 
 [node name="GrabCube" instance=ExtResource( 1 )]
-ranged_grab_method = 0
+script = ExtResource( 4 )
+active_material = ExtResource( 5 )
 
 [node name="CollisionShape" parent="." index="0"]
 shape = SubResource( 7 )


### PR DESCRIPTION
This pull request lets held objects know when the action button is released by:
 - Adding optional action_button() method for held objects.
 - Adding action_released signal on pickable objects.

This feature is demonstrated in the pickable demo scene by the green "grab cube" objects changing color while the action button is held down.