### PR TITLE
Disable vsync when entering XR mode

### DIFF
--- a/addons/godot-xr-tools/xr/start_xr.gd
+++ b/addons/godot-xr-tools/xr/start_xr.gd
@@ -128,6 +128,9 @@ func _setup_for_openxr() -> bool:
 	if enable_passthrough and _openxr_is_passthrough_supported():
 		enable_passthrough = _openxr_start_passthrough()
 
+	# Disable vsync
+	OS.vsync_enabled = false
+
 	# Switch the viewport to XR
 	get_viewport().arvr = true
 


### PR DESCRIPTION
This pull request disables vsync when entering XR mode for OpenXR. I'm not sure whether we should do the same thing in WebXR.