### PR TITLE
Remove old reference to player kinematic body

### DIFF
--- a/addons/godot-xr-tools/functions/movement_climb.gd
+++ b/addons/godot-xr-tools/functions/movement_climb.gd
@@ -123,7 +123,7 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 
 	# Move the player by the offset
 	var old_position := player_body.global_transform.origin
-	player_body.kinematic_node.move_and_collide(-offset)
+	player_body.move_and_collide(-offset)
 	player_body.velocity = Vector3.ZERO
 
 	# Update the players average-velocity data


### PR DESCRIPTION
This pull request fixes issue #389 by removing the unnecessary `.kinematic_body` when accessing the PlayerBody kinematic-body.