### PR TITLE
flapping improvements: add altitude limit and allow roll-turning while flapping

### DIFF
--- a/addons/godot-xr-tools/functions/movement_glide.gd
+++ b/addons/godot-xr-tools/functions/movement_glide.gd
@@ -128,7 +128,8 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	var allowed_flapping_altitude = false
 	if wings_impulse:
 		if is_sphere_planet:
-			allowed_flapping_altitude = sphere_planet_center.distance_to(player_body.translation) < max_flapping_altitude
+			var altitude = sphere_planet_center.distance_to(player_body.translation)
+			allowed_flapping_altitude = altitude < max_flapping_altitude
 		else:
 			allowed_flapping_altitude = player_body.translation.y < max_flapping_altitude
 

--- a/addons/godot-xr-tools/functions/movement_glide.gd
+++ b/addons/godot-xr-tools/functions/movement_glide.gd
@@ -58,6 +58,9 @@ export var roll_turn_speed : float = 1
 ## Add vertical impulse by flapping controllers
 export var wings_impulse : bool = false
 
+## Altitude limit when flapping
+export var max_flapping_altitude : float = 250
+
 ## Minimum velocity for flapping
 export var flap_min_speed : float = 0.3
 
@@ -116,7 +119,7 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	var wings_impulse_velocity := 0.0
 
 	# If wings impulse is active, calculate flapping impulse
-	if wings_impulse:
+	if wings_impulse && player_body.translation.y < max_flapping_altitude:
 		# Get head position
 		var camera_position := _camera_node.global_transform.origin
 
@@ -156,19 +159,19 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 			last_local_left_position = local_left_position
 			last_local_right_position = local_right_position
 
-	# If not falling, then not gliding
-	var vertical_velocity := player_body.velocity.dot(player_body.up_gravity_vector)
-	vertical_velocity += wings_impulse_velocity
-	if vertical_velocity >= glide_min_fall_speed && wings_impulse_velocity == 0.0:
-		_set_gliding(false)
-		return
-
 	# Calculate global left to right controller vector
 	var left_to_right := right_position - left_position
 
 	if turn_with_roll:
 		var angle = -left_to_right.dot(player_body.up_player_vector)
 		player_body.rotate_player(roll_turn_speed * delta * angle)
+
+	# If not falling, then not gliding
+	var vertical_velocity := player_body.velocity.dot(player_body.up_gravity_vector)
+	vertical_velocity += wings_impulse_velocity
+	if vertical_velocity >= glide_min_fall_speed && wings_impulse_velocity == 0.0:
+		_set_gliding(false)
+		return
 
 	# Set gliding based on hand separation
 	var separation := left_to_right.length() / ARVRServer.world_scale

--- a/addons/godot-xr-tools/functions/movement_glide.gd
+++ b/addons/godot-xr-tools/functions/movement_glide.gd
@@ -68,17 +68,6 @@ export var wings_force : float = 1.0
 ## if set to 0, you need to reach head level with hands to rearm flaps
 export var rearm_distance_offset : float = 0.2
 
-## Altitude limit to allow flapping
-## please note this doesn´t prevent the player to go beyond this limit
-## if enought force is applied
-export var max_flapping_altitude : float = 100
-
-## set to true to calculate altitude limit on spherical world
-export var is_sphere_planet : bool = false
-
-## Set the origin of the spherical world gravity
-export var sphere_planet_center : Vector3 = Vector3.ZERO
-
 ## Flap activated (when both controllers are near the ARVRCamera height)
 var flap_armed : bool = false
 
@@ -125,16 +114,8 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	# Set default wings impulse to zero
 	var wings_impulse_velocity := 0.0
 
-	var allowed_flapping_altitude = false
-	if wings_impulse:
-		if is_sphere_planet:
-			var altitude = sphere_planet_center.distance_to(player_body.translation)
-			allowed_flapping_altitude = altitude < max_flapping_altitude
-		else:
-			allowed_flapping_altitude = player_body.translation.y < max_flapping_altitude
-
 	# If wings impulse is active, calculate flapping impulse
-	if wings_impulse && allowed_flapping_altitude:
+	if wings_impulse:
 		# Get head position
 		var camera_position := _camera_node.global_transform.origin
 

--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -72,7 +72,6 @@ jump_button_id = 7
 [node name="MovementGlide" parent="ARVROrigin" index="5" instance=ExtResource( 7 )]
 turn_with_roll = true
 wings_impulse = true
-max_flapping_altitude = 250.0
 
 [node name="MovementWind" parent="ARVROrigin" index="6" instance=ExtResource( 22 )]
 

--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -72,6 +72,7 @@ jump_button_id = 7
 [node name="MovementGlide" parent="ARVROrigin" index="5" instance=ExtResource( 7 )]
 turn_with_roll = true
 wings_impulse = true
+max_flapping_altitude = 250.0
 
 [node name="MovementWind" parent="ARVROrigin" index="6" instance=ExtResource( 22 )]
 

--- a/scenes/sphere_world_demo/sphere_world_demo.tscn
+++ b/scenes/sphere_world_demo/sphere_world_demo.tscn
@@ -33,7 +33,7 @@ height = 100.0
 radius = 50.0
 
 [sub_resource type="SphereShape" id=3]
-radius = 80.0
+radius = 200.0
 
 [node name="SphereWorldDemo" instance=ExtResource( 1 )]
 environment = ExtResource( 19 )
@@ -89,6 +89,9 @@ grapple_collision_mask = 3
 [node name="MovementWind" parent="ARVROrigin" index="5" instance=ExtResource( 13 )]
 
 [node name="MovementGlide" parent="ARVROrigin" index="6" instance=ExtResource( 17 )]
+turn_with_roll = true
+wings_impulse = true
+is_sphere_planet = true
 
 [node name="MovementWallWalk" parent="ARVROrigin" index="7" instance=ExtResource( 12 )]
 


### PR DESCRIPTION
I added an altitude limit when flapping

Also changed the order of the roll-turning calculation and the falling check that was preventing to turn while gaining altitude after flapping.