### PR TITLE
Added return-to-snap-zone script

### DIFF
--- a/addons/godot-xr-tools/objects/return_to_snap_zone.gd
+++ b/addons/godot-xr-tools/objects/return_to_snap_zone.gd
@@ -1,0 +1,104 @@
+tool
+class_name XRToolsReturnToSnapZone, "res://addons/godot-xr-tools/editor/icons/hand.svg"
+extends Node
+
+
+## XR Tools Return to Snap Zone
+##
+## This node can be added to an XRToolsPickable to make it return to a specified
+## snap-zone when the object is dropped.
+
+
+## Snap zone path
+export var snap_zone_path : NodePath
+
+## Return delay
+export var return_delay : float = 1.0
+
+
+# Pickable object to control
+var _pickable : XRToolsPickable
+
+# Snap zone to return to
+var _snap_zone : XRToolsSnapZone
+
+# Return counter
+var _return_counter : float = 0.0
+
+# Is the pickable held
+var _held := false
+
+
+# Add support for is_class on XRTools classes
+func is_class(name : String) -> bool:
+	return name == "XRToolsReturnToSnapZone" or .is_class(name)
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	# Get the pickable (parent of this node)
+	_pickable = get_parent() as XRToolsPickable
+	if _pickable:
+		_pickable.connect("picked_up", self, "_on_picked_up")
+		_pickable.connect("dropped", self, "_on_dropped")
+
+	# Get the optional snap-zone
+	_snap_zone = get_node_or_null(snap_zone_path)
+	if not _snap_zone:
+		set_process(false)
+
+
+# Handle the return counter
+func _process(delta : float) -> void:
+	# Update return time and skip if still waiting
+	_return_counter += delta
+	if _return_counter < return_delay:
+		return
+
+	# Stop counting
+	set_process(false)
+
+	# If the snap-zone is empty then snap to it
+	if not _snap_zone.has_snapped_object():
+		_snap_zone.pick_up_object(_pickable)
+
+
+# Set the snap-zone
+func set_snap_zone(snap_zone : XRToolsSnapZone) -> void:
+	# Set the snap zone
+	_snap_zone = snap_zone
+	_return_counter = 0.0
+
+	# Control counting
+	if _snap_zone and not _held:
+		set_process(true)
+	else:
+		set_process(false)
+
+
+# Handle the object being picked up
+func _on_picked_up(_pickable) -> void:
+	# Set held and stop counting
+	_held = true
+	set_process(false)
+
+
+# Handle the object being dropped
+func _on_dropped(_pickable) -> void:
+	# Clear held and reset counter
+	_held = false
+	_return_counter = 0.0
+
+	# Start counter if snap-zone specified
+	if _snap_zone:
+		set_process(true)
+
+
+# This method verifies the pose area has a valid configuration.
+func _get_configuration_warning():
+	# Verify this node is a child of a pickable
+	if not get_parent() is XRToolsPickable:
+		return "Must be a child of a pickable"
+
+	# Pass basic validation
+	return ""

--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -94,7 +94,7 @@ func _process(_delta):
 			continue
 
 		# pick up our target
-		_pick_up_object(o)
+		pick_up_object(o)
 		return
 
 
@@ -167,7 +167,7 @@ func _initial_object_check() -> void:
 	# Check for an initial object
 	if initial_object:
 		# Force pick-up the initial object
-		_pick_up_object(get_node(initial_object))
+		pick_up_object(get_node(initial_object))
 	else:
 		# Show highlight when empty
 		emit_signal("highlight_updated", self, true)
@@ -222,8 +222,13 @@ func _on_snap_zone_body_exited(target: Spatial) -> void:
 		emit_signal("close_highlight_updated", self, false)
 
 
+# Test if this snap zone has a picked up object
+func has_snapped_object() -> bool:
+	return is_instance_valid(picked_up_object)
+
+
 # Pick up the specified object
-func _pick_up_object(target: Spatial) -> void:
+func pick_up_object(target: Spatial) -> void:
 	# check if already holding an object
 	if is_instance_valid(picked_up_object):
 		# skip if holding the target object
@@ -296,4 +301,4 @@ func _on_target_dropped(target: Spatial) -> void:
 
 	# Pick up the target if we can
 	if target.can_pick_up(self):
-		_pick_up_object(target)
+		pick_up_object(target)

--- a/project.godot
+++ b/project.godot
@@ -259,6 +259,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godot-xr-tools/assets/resource_queue/resource_queue.gd"
 }, {
+"base": "Node",
+"class": "XRToolsReturnToSnapZone",
+"language": "GDScript",
+"path": "res://addons/godot-xr-tools/objects/return_to_snap_zone.gd"
+}, {
 "base": "Spatial",
 "class": "XRToolsSceneBase",
 "language": "GDScript",
@@ -365,6 +370,7 @@ _global_script_class_icons={
 "XRToolsPlayerBody": "res://addons/godot-xr-tools/editor/icons/body.svg",
 "XRToolsPoke": "",
 "XRToolsResourceQueue": "",
+"XRToolsReturnToSnapZone": "res://addons/godot-xr-tools/editor/icons/hand.svg",
 "XRToolsSceneBase": "",
 "XRToolsSnapZone": "",
 "XRToolsStaging": "",

--- a/scenes/pickable_demo/pickable_demo.tscn
+++ b/scenes/pickable_demo/pickable_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=2]
+[gd_scene load_steps=26 format=2]
 
 [ext_resource path="res://addons/godot-xr-tools/staging/scene_base.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/maps/basic_map.tscn" type="PackedScene" id=2]
@@ -24,6 +24,7 @@
 [ext_resource path="res://scenes/pickable_demo/objects/instructions.tscn" type="PackedScene" id=22]
 [ext_resource path="res://scenes/pickable_demo/objects/BeltSnapZone.tscn" type="PackedScene" id=23]
 [ext_resource path="res://scenes/pickable_demo/objects/knife.tscn" type="PackedScene" id=24]
+[ext_resource path="res://addons/godot-xr-tools/objects/return_to_snap_zone.gd" type="Script" id=25]
 
 [node name="PickableDemo" instance=ExtResource( 1 )]
 
@@ -103,6 +104,10 @@ initial_object = NodePath("../Teacup")
 
 [node name="Teacup" parent="Table1/TeacupStand" index="8" instance=ExtResource( 19 )]
 transform = Transform( -4.37114e-08, 0, -1, 1, -4.37114e-08, -4.37114e-08, -4.37114e-08, -1, 1.91069e-15, 0.08, 0.204674, 0.0395086 )
+
+[node name="XRToolsReturnToSnapZone" type="Node" parent="Table1/TeacupStand/Teacup" index="6"]
+script = ExtResource( 25 )
+snap_zone_path = NodePath("../../SnapZone1")
 
 [node name="Teacup" parent="Table1" index="12" instance=ExtResource( 19 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.234713, 0.824552, 0.266177 )


### PR DESCRIPTION
This pull request adds an XRToolsReturnToSnapZone script which returns an XRToolsPickable object to a snap-zone if dropped for longer than a specified duration. Additionally this pull request implements feature #400.
