### PR TITLE
added tool annotation to snap_zone.gd

### DIFF
--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -1,3 +1,4 @@
+tool
 class_name XRToolsSnapZone
 extends Area
 


### PR DESCRIPTION
 added tool annotation to snap_zone.gd
this fixes the rendering artifact that occurs in editor

without it, the radius of the snapzone is shown to be 1 meter

this PR fixes #404 