### PR TITLE
Fix staging fade shader so it works on both Vulkan and GL renderers

### DIFF
--- a/addons/godot-xr-tools/staging/fade.gdshader
+++ b/addons/godot-xr-tools/staging/fade.gdshader
@@ -1,5 +1,5 @@
 shader_type spatial;
-render_mode depth_test_disabled, skip_vertex_transform, unshaded;
+render_mode depth_test_disabled, skip_vertex_transform, unshaded, cull_disabled;
 
 uniform float alpha = 0.0;
 


### PR DESCRIPTION
This pull request adds `cull_disabled` to the fade shader so it works with the handedness difference between Vulkan and GL.