### PR TITLE
Fixed main menu level having to load all other levels

### DIFF
--- a/assets/meshes/teleport/teleport.gd
+++ b/assets/meshes/teleport/teleport.gd
@@ -6,8 +6,8 @@ extends Node3D
 ## Scene base for the current scene
 @export var scene_base: NodePath
 
-## Scene to teleport to, or none for main menu
-@export var scene: PackedScene
+## Main scene file
+@export_file('*.tscn') var scene : String
 
 ## Title texture
 @export var title: Texture2D: set = _set_title
@@ -39,8 +39,8 @@ func _on_TeleportArea_body_entered(body: Node3D):
 		return
 
 	# Teleport
-	if scene:
-		_scene_base.load_scene(scene.resource_path)
+	if scene != "":
+		_scene_base.load_scene(scene)
 	else:
 		_scene_base.exit_to_main_menu()
 

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=50 format=3 uid="uid://utga61rlgb3t"]
+[gd_scene load_steps=38 format=3 uid="uid://utga61rlgb3t"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="Script" path="res://scenes/main_menu/main_menu_level.gd" id="2_taoax"]
@@ -7,96 +7,84 @@
 [ext_resource type="PackedScene" uid="uid://b6bk2pj8vbj28" path="res://addons/godot-xr-tools/functions/movement_turn.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://bft3xyxs31ci3" path="res://addons/godot-xr-tools/functions/function_pose_detector.tscn" id="5_xgcrx"]
 [ext_resource type="PackedScene" uid="uid://bl2nuu3qhlb5k" path="res://addons/godot-xr-tools/functions/movement_direct.tscn" id="6"]
-[ext_resource type="PackedScene" uid="uid://c3pffsm74as2t" path="res://scenes/basic_movement_demo/basic_movement_demo.tscn" id="7"]
 [ext_resource type="PackedScene" uid="uid://diyu06cw06syv" path="res://addons/godot-xr-tools/player/player_body.tscn" id="8"]
 [ext_resource type="PackedScene" uid="uid://3a6wjr3a13vd" path="res://assets/meshes/teleport/teleport.tscn" id="9"]
 [ext_resource type="Texture2D" uid="uid://8jxrr3gqnxck" path="res://scenes/basic_movement_demo/basic movement demo.png" id="10"]
-[ext_resource type="PackedScene" path="res://scenes/teleport_demo/teleport_demo.tscn" id="11"]
 [ext_resource type="Texture2D" uid="uid://c8qc5ja60n3u8" path="res://scenes/teleport_demo/teleport movement demo.png" id="12"]
 [ext_resource type="Texture2D" uid="uid://d3epm85d4s28f" path="res://scenes/climbing_gliding_demo/climbing_gliding_demo.png" id="13"]
-[ext_resource type="PackedScene" uid="uid://c7ebkdn7ryqrp" path="res://scenes/climbing_gliding_demo/climbing_gliding_demo.tscn" id="14"]
-[ext_resource type="PackedScene" uid="uid://cvnl210i6nydl" path="res://scenes/grappling_demo/grappling_demo.tscn" id="15"]
-[ext_resource type="PackedScene" uid="uid://di3m8og7wdtw7" path="res://scenes/footstep_movement_demo/footstep_movement_demo.tscn" id="15_3b6cs"]
 [ext_resource type="Texture2D" uid="uid://dwryn8mjdj86m" path="res://scenes/footstep_movement_demo/footstep movement demo.png" id="15_k6bhw"]
 [ext_resource type="Texture2D" uid="uid://bwkm0t73t80cs" path="res://scenes/grappling_demo/grappling_demo.png" id="16"]
 [ext_resource type="Texture2D" uid="uid://bv0r0klv2u7tl" path="res://scenes/interactables_demo/interactables_demo.png" id="17"]
-[ext_resource type="PackedScene" uid="uid://hv3is88xy8k4" path="res://scenes/interactables_demo/interactables_demo.tscn" id="18"]
-[ext_resource type="PackedScene" uid="uid://deq6satll2p5x" path="res://scenes/pointer_demo/pointer_demo.tscn" id="19"]
 [ext_resource type="Texture2D" uid="uid://bh5j2q7vpmr0b" path="res://scenes/pointer_demo/pointer_demo.png" id="20"]
-[ext_resource type="PackedScene" uid="uid://j53121pbwpsw" path="res://scenes/pickable_demo/pickable_demo.tscn" id="21"]
 [ext_resource type="Texture2D" uid="uid://ny4n43p3e3du" path="res://scenes/pickable_demo/pickable_demo.png" id="22"]
 [ext_resource type="PackedScene" uid="uid://bq86r4yll8po" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/left_fullglove_low.tscn" id="23_pr05t"]
-[ext_resource type="PackedScene" uid="uid://b4fy6i3e7s08u" path="res://scenes/poke_demo/poke_demo.tscn" id="24_qtcxq"]
 [ext_resource type="PackedScene" uid="uid://xqimcf20s2jp" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/right_fullglove_low.tscn" id="25_2b81d"]
 [ext_resource type="Texture2D" uid="uid://bbe7o7pdq38m2" path="res://scenes/poke_demo/poke_demo.png" id="25_rg3rn"]
 [ext_resource type="PackedScene" uid="uid://3bsyhd7ehoa1" path="res://scenes/main_menu/objects/settings_ui.tscn" id="26_0uyxa"]
 [ext_resource type="Material" uid="uid://bhiiya7ow6h8v" path="res://addons/godot-xr-tools/hands/materials/labglove.material" id="26_id1x7"]
-[ext_resource type="PackedScene" path="res://scenes/sprinting_demo/sprinting_demo.tscn" id="28_u37cd"]
 [ext_resource type="Texture2D" uid="uid://v4807nasx1dc" path="res://scenes/sprinting_demo/sprinting_demo.png" id="29_h1jn0"]
-[ext_resource type="PackedScene" uid="uid://dyfx10nwe0oil" path="res://scenes/origin_gravity_demo/origin_gravity_demo.tscn" id="31_18nh2"]
 [ext_resource type="Texture2D" uid="uid://cr1l4g7btdyht" path="res://scenes/origin_gravity_demo/origin_gravity_demo.png" id="32_c4n1q"]
-[ext_resource type="PackedScene" uid="uid://b5o25nkvyv8ho" path="res://scenes/sphere_world_demo/sphere_world_demo.tscn" id="33_ews5s"]
 [ext_resource type="Texture2D" uid="uid://dhd30j0xpcxoi" path="res://scenes/sphere_world_demo/sphere_world_demo.png" id="34_xw8ig"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_b71j7"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_a53jr"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ex44k"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_no2j2"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_umfkq"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_pj3so"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_wrckm"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_3d11p"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_856ri"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_qaknm"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_1xdjf"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_ougf0"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_b71j7")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_a53jr")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_ex44k")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_no2j2")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_umfkq")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_pj3so")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_wrckm")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_3d11p")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_856ri")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_qaknm")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_wbi3t"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_f3eia"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_se43b"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_kg04j"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_5cf5w"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ubtjw"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_qxqxf"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_gi1hy"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_vkcg5"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_snhct"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_3ea7w"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_8tjfy"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_wbi3t")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_f3eia")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_se43b")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_kg04j")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_5cf5w")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_ubtjw")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_qxqxf")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_gi1hy")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_vkcg5")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_snhct")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
@@ -135,7 +123,7 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_1xdjf")
+tree_root = SubResource("AnimationNodeBlendTree_ougf0")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("5_xgcrx")]
 
@@ -178,7 +166,7 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_3ea7w")
+tree_root = SubResource("AnimationNodeBlendTree_8tjfy")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5_xgcrx")]
 
@@ -188,8 +176,6 @@ max_speed = 3.0
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("5")]
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("8")]
-top_level = true
-body_forward_mix = 0.75
 
 [node name="BasicMap" parent="." index="1" instance=ExtResource("4")]
 
@@ -198,73 +184,73 @@ body_forward_mix = 0.75
 [node name="ToBasicMovementDemo" parent="Demos" index="0" instance=ExtResource("9")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10)
 scene_base = NodePath("../..")
-scene = ExtResource("7")
+scene = "res://scenes/basic_movement_demo/basic_movement_demo.tscn"
 title = ExtResource("10")
 
 [node name="ToFootstepDemo" parent="Demos" index="1" instance=ExtResource("9")]
 transform = Transform3D(0.866025, 0, 0.5, 0, 1, 0, -0.5, 0, 0.866025, -5, 0, -8.66025)
 scene_base = NodePath("../..")
-scene = ExtResource("15_3b6cs")
+scene = "res://scenes/footstep_movement_demo/footstep_movement_demo.tscn"
 title = ExtResource("15_k6bhw")
 
 [node name="ToTeleportDemo" parent="Demos" index="2" instance=ExtResource("9")]
 transform = Transform3D(0.5, 0, 0.866025, 0, 1, 0, -0.866025, 0, 0.5, -8.66025, 0, -5)
 scene_base = NodePath("../..")
-scene = ExtResource("11")
+scene = "res://scenes/teleport_demo/teleport_demo.tscn"
 title = ExtResource("12")
 
 [node name="ToClimbingGlidingDemo" parent="Demos" index="3" instance=ExtResource("9")]
 transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -10, 0, 4.37114e-07)
 scene_base = NodePath("../..")
-scene = ExtResource("14")
+scene = "res://scenes/climbing_gliding_demo/climbing_gliding_demo.tscn"
 title = ExtResource("13")
 
 [node name="ToGrapplingDemo" parent="Demos" index="4" instance=ExtResource("9")]
 transform = Transform3D(-0.5, 0, 0.866025, 0, 1, 0, -0.866025, 0, -0.5, -8.66025, 0, 5)
 scene_base = NodePath("../..")
-scene = ExtResource("15")
+scene = "res://scenes/grappling_demo/grappling_demo.tscn"
 title = ExtResource("16")
 
 [node name="ToInteractablesDemo" parent="Demos" index="5" instance=ExtResource("9")]
 transform = Transform3D(-0.866025, 0, 0.5, 0, 1, 0, -0.5, 0, -0.866025, -5, 0, 8.66025)
 scene_base = NodePath("../..")
-scene = ExtResource("18")
+scene = "res://scenes/interactables_demo/interactables_demo.tscn"
 title = ExtResource("17")
 
 [node name="ToPointerDemo" parent="Demos" index="6" instance=ExtResource("9")]
 transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 8.74228e-07, 0, 10)
 scene_base = NodePath("../..")
-scene = ExtResource("19")
+scene = "res://scenes/interactables_demo/interactables_demo.tscn"
 title = ExtResource("20")
 
 [node name="ToPickableDemo" parent="Demos" index="7" instance=ExtResource("9")]
 transform = Transform3D(-0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, -0.866025, 5, 0, 8.66025)
 scene_base = NodePath("../..")
-scene = ExtResource("21")
+scene = "res://scenes/pickable_demo/pickable_demo.tscn"
 title = ExtResource("22")
 
 [node name="ToPokeDemo" parent="Demos" index="8" instance=ExtResource("9")]
 transform = Transform3D(-0.5, 0, -0.866025, 0, 1, 0, 0.866025, 0, -0.5, 8.66025, 0, 5)
 scene_base = NodePath("../..")
-scene = ExtResource("24_qtcxq")
+scene = "res://scenes/poke_demo/poke_demo.tscn"
 title = ExtResource("25_rg3rn")
 
 [node name="ToSprintDemo" parent="Demos" index="9" instance=ExtResource("9")]
 transform = Transform3D(1.19249e-08, 0, -1, 0, 1, 0, 1, 0, 1.19249e-08, 10, 0, -1.19249e-07)
 scene_base = NodePath("../..")
-scene = ExtResource("28_u37cd")
+scene = "res://scenes/sprinting_demo/sprinting_demo.tscn"
 title = ExtResource("29_h1jn0")
 
 [node name="ToOriginGravityDemo" parent="Demos" index="10" instance=ExtResource("9")]
 transform = Transform3D(0.5, 0, -0.866025, 0, 1, 0, 0.866025, 0, 0.5, 8.66025, 0, -5)
 scene_base = NodePath("../..")
-scene = ExtResource("31_18nh2")
+scene = "res://scenes/origin_gravity_demo/origin_gravity_demo.tscn"
 title = ExtResource("32_c4n1q")
 
 [node name="ToSphereWorldDemo" parent="Demos" index="11" instance=ExtResource("9")]
 transform = Transform3D(0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, 0.866025, 5, 0, -8.66025)
 scene_base = NodePath("../..")
-scene = ExtResource("33_ews5s")
+scene = "res://scenes/sphere_world_demo/sphere_world_demo.tscn"
 title = ExtResource("34_xw8ig")
 
 [node name="SettingsUI" parent="." index="3" instance=ExtResource("26_0uyxa")]


### PR DESCRIPTION
The teleport object originally used a PackedScene to let the developer specify which scene to teleport to. This was wasteful as it resulted in the main menu having to import all other scenes. This pull request replaces the PackedScene with just a file-path string to the tscn file.