### PR TITLE
Fixed physics hand bone groups

### DIFF
--- a/addons/godot-xr-tools/hands/scenes/highpoly/left_fullglove_physics_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/left_fullglove_physics_hand.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Material" uid="uid://bhiiya7ow6h8v" path="res://addons/godot-xr-tools/hands/materials/labglove.material" id="5"]
 [ext_resource type="AnimationNodeBlendTree" uid="uid://dl8yf7ipqotd1" path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" id="9"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_u4nb4"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_2frkw"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_7blad"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_2xka1"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_dcp65"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ru86n"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_jjpal"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_g5ps2"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_djjo6"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_v8isy"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_nwkwa"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_yv3c8"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_u4nb4")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_2frkw")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_7blad")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_2xka1")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_dcp65")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_ru86n")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_jjpal")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_g5ps2")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_djjo6")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_v8isy")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="LeftPhysicsHand" type="Node3D"]
 script = ExtResource("3")
+bone_group = "LeftHand"
 hand_blend_tree = ExtResource("9")
 default_pose = ExtResource("3_0aa1r")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
 [node name="mesh_Hand_L" parent="Hand_L/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("5")
 
-[node name="Hand_L@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, -1.83077e-05, 1.52659e-08, 1.52668e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_L"
 bone_idx = 0
 script = ExtResource("4")
 width_ratio = 0.8
 
-[node name="Hand_L@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, 0.0514604, -0.0176509, -0.017651, 0.613335, 0.789626, 0.0514604, -0.788145, 0.613335, 0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_L"
 bone_idx = 1
 script = ExtResource("4")
 length = 0.05
 
-[node name="Hand_L@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, 0.383958, -0.0587628, -0.124052, 0.434264, 0.892203, 0.368087, -0.814856, 0.447796, 0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_L"
 bone_idx = 2
 script = ExtResource("4")
 
-[node name="Hand_L@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, 0.366844, 0.0151708, -0.154037, 0.352396, 0.923087, 0.333283, -0.860954, 0.384292, 0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_L"
 bone_idx = 3
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_L@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, 0.0336562, -0.0231681, 0.0231985, -0.00051113, 0.999731, 0.0336353, -0.999433, -0.00129147, -0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_L"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_L@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, 0.0419384, -0.0509326, 0.0413169, 0.204661, 0.97796, 0.0514381, -0.977934, 0.202483, -0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_L"
 bone_idx = 6
 script = ExtResource("4")
 
-[node name="Hand_L@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, 0.644453, -0.0854741, -0.040588, 0.178251, 0.983148, 0.648829, -0.743577, 0.161601, -0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_L"
 bone_idx = 7
 script = ExtResource("4")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_L@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356468, 0.927111, -0.115741, -0.109286, 0.164404, 0.98032, 0.927894, -0.336804, 0.159925, 0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_L"
 bone_idx = 8
 script = ExtResource("4")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_L@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, -0.0127165, -0.00125617, 0.000365489, -0.0698022, 0.997561, -0.0127732, -0.99748, -0.0697919, -0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_L"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_L@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, 0.237654, -0.00293004, 0.0207339, -0.0724503, 0.997156, 0.236766, -0.968644, -0.0753018, -0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_L"
 bone_idx = 11
 script = ExtResource("4")
 
-[node name="Hand_L@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, 0.643161, -0.0351718, 0.0290327, 0.0201225, 0.999376, 0.643468, -0.765466, -0.00328059, -0.000328456, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_L"
 bone_idx = 12
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_L@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, 0.95453, -0.0243818, 0.0374454, 0.0138673, 0.999202, 0.954107, -0.297791, -0.0316226, 0.0205207, -0.00467056, -0.148631)
 bone_name = "Middle_Distal_L"
 bone_idx = 13
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_L@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, 0.047074, 0.0237409, -0.0169882, -0.138981, 0.990149, 0.0499098, -0.989175, -0.137988, -0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_L"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_L@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, 0.181854, 0.0266582, 0.0109494, -0.202722, 0.979175, 0.183471, -0.962202, -0.20126, -0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_L"
 bone_idx = 16
 script = ExtResource("4")
 length = 0.028
 
-[node name="Hand_L@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778393, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_L"
 bone_idx = 17
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_L@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381387, 0.924068, 0.025339, 0.114105, -0.0742599, 0.990689, 0.917346, -0.374945, -0.133762, 0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_L"
 bone_idx = 18
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_L@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, 0.0165318, 0.0422887, -0.0385953, -0.181426, 0.982647, 0.0239172, -0.983265, -0.180601, -4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_L"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_L@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, 0.239304, 0.0579745, 0.0185535, -0.305761, 0.951928, 0.245527, -0.921544, -0.300787, 0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_L"
 bone_idx = 21
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_L@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, 0.713816, 0.0374602, 0.103947, -0.153407, 0.982681, 0.707199, -0.683325, -0.181481, 0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_L"
 bone_idx = 22
 script = ExtResource("4")
 length = 0.015
 
-[node name="Hand_L@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_L/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, 0.939844, 0.0220291, 0.162162, -0.081867, 0.983362, 0.926011, -0.331647, -0.180315, 0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_L"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_L" instance=ExtResource("2")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_nwkwa")
+tree_root = SubResource("AnimationNodeBlendTree_yv3c8")
 anim_player = NodePath("../Hand_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0

--- a/addons/godot-xr-tools/hands/scenes/highpoly/left_physics_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/left_physics_hand.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Material" uid="uid://dbvge3quu3bju" path="res://addons/godot-xr-tools/hands/materials/caucasian_hand.material" id="5"]
 [ext_resource type="AnimationNodeBlendTree" uid="uid://dl8yf7ipqotd1" path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" id="9"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_qo0kg"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_5nt68"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_j4paf"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_04hby"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_07l6n"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_dvduk"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vwqya"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_40ncn"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_5tj4h"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_fjpy6"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_w000o"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_xtig3"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_qo0kg")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_5nt68")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_j4paf")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_04hby")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_07l6n")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_dvduk")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_vwqya")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_40ncn")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_5tj4h")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_fjpy6")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="LeftPhysicsHand" type="Node3D"]
 script = ExtResource("3")
+bone_group = "LeftHand"
 hand_blend_tree = ExtResource("9")
 default_pose = ExtResource("3_fye1l")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
 [node name="mesh_Hand_Nails_L" parent="Hand_Nails_L/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("5")
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, -1.83077e-05, 1.52659e-08, 1.52668e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_L"
 bone_idx = 0
 script = ExtResource("4")
 width_ratio = 0.8
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, 0.0514604, -0.0176509, -0.017651, 0.613335, 0.789626, 0.0514604, -0.788145, 0.613335, 0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_L"
 bone_idx = 1
 script = ExtResource("4")
 length = 0.05
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, 0.383958, -0.0587628, -0.124052, 0.434264, 0.892203, 0.368087, -0.814856, 0.447796, 0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_L"
 bone_idx = 2
 script = ExtResource("4")
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, 0.366844, 0.0151708, -0.154037, 0.352396, 0.923087, 0.333283, -0.860954, 0.384292, 0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_L"
 bone_idx = 3
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, 0.0336562, -0.0231681, 0.0231985, -0.00051113, 0.999731, 0.0336353, -0.999433, -0.00129147, -0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_L"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, 0.0419384, -0.0509326, 0.0413169, 0.204661, 0.97796, 0.0514381, -0.977934, 0.202483, -0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_L"
 bone_idx = 6
 script = ExtResource("4")
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, 0.644453, -0.0854741, -0.040588, 0.178251, 0.983148, 0.648829, -0.743577, 0.161601, -0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_L"
 bone_idx = 7
 script = ExtResource("4")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356468, 0.927111, -0.115741, -0.109286, 0.164404, 0.98032, 0.927894, -0.336804, 0.159925, 0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_L"
 bone_idx = 8
 script = ExtResource("4")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, -0.0127165, -0.00125617, 0.000365489, -0.0698022, 0.997561, -0.0127732, -0.99748, -0.0697919, -0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_L"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, 0.237654, -0.00293004, 0.0207339, -0.0724503, 0.997156, 0.236766, -0.968644, -0.0753018, -0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_L"
 bone_idx = 11
 script = ExtResource("4")
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, 0.643161, -0.0351718, 0.0290327, 0.0201225, 0.999376, 0.643468, -0.765466, -0.00328059, -0.000328456, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_L"
 bone_idx = 12
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, 0.95453, -0.0243818, 0.0374454, 0.0138673, 0.999202, 0.954107, -0.297791, -0.0316226, 0.0205207, -0.00467056, -0.148631)
 bone_name = "Middle_Distal_L"
 bone_idx = 13
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, 0.047074, 0.0237409, -0.0169882, -0.138981, 0.990149, 0.0499098, -0.989175, -0.137988, -0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_L"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, 0.181854, 0.0266582, 0.0109494, -0.202722, 0.979175, 0.183471, -0.962202, -0.20126, -0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_L"
 bone_idx = 16
 script = ExtResource("4")
 length = 0.028
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778393, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_L"
 bone_idx = 17
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_Nails_L@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381387, 0.924068, 0.025339, 0.114105, -0.0742599, 0.990689, 0.917346, -0.374945, -0.133762, 0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_L"
 bone_idx = 18
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_L@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, 0.0165318, 0.0422887, -0.0385953, -0.181426, 0.982647, 0.0239172, -0.983265, -0.180601, -4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_L"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_Nails_L@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, 0.239304, 0.0579745, 0.0185535, -0.305761, 0.951928, 0.245527, -0.921544, -0.300787, 0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_L"
 bone_idx = 21
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_L@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, 0.713816, 0.0374602, 0.103947, -0.153407, 0.982681, 0.707199, -0.683325, -0.181481, 0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_L"
 bone_idx = 22
 script = ExtResource("4")
 length = 0.015
 
-[node name="Hand_Nails_L@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Nails_L/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, 0.939844, 0.0220291, 0.162162, -0.081867, 0.983362, 0.926011, -0.331647, -0.180315, 0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_L"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_Nails_L" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_w000o")
+tree_root = SubResource("AnimationNodeBlendTree_xtig3")
 anim_player = NodePath("../Hand_Nails_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0

--- a/addons/godot-xr-tools/hands/scenes/highpoly/left_physics_tac_glove.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/left_physics_tac_glove.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Script" path="res://addons/godot-xr-tools/hands/hand_physics_bone.gd" id="5"]
 [ext_resource type="Script" path="res://addons/godot-xr-tools/hands/physics_hand.gd" id="6"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_t6qch"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_mq2ds"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_4dkr2"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_yqx3r"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_y0e2n"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_o3ato"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_idffn"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_2ih7n"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_g64cp"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_02eq5"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_6y0fw"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_yo480"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_t6qch")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_mq2ds")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_4dkr2")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_yqx3r")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_y0e2n")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_o3ato")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_idffn")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_2ih7n")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_g64cp")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_02eq5")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="LeftPhysicsHand" type="Node3D"]
 script = ExtResource("6")
+bone_group = "LeftHand"
 hand_blend_tree = ExtResource("3")
 default_pose = ExtResource("3_rnhp7")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
 [node name="mesh_Glove_L" parent="Hand_Glove_L/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("4")
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, -1.83077e-05, 1.52659e-08, 1.52668e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_L"
 bone_idx = 0
 script = ExtResource("5")
 width_ratio = 0.8
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, 0.0514604, -0.0176509, -0.017651, 0.613335, 0.789626, 0.0514604, -0.788145, 0.613335, 0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_L"
 bone_idx = 1
 script = ExtResource("5")
 length = 0.05
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, 0.383958, -0.0587628, -0.124052, 0.434264, 0.892203, 0.368087, -0.814856, 0.447796, 0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_L"
 bone_idx = 2
 script = ExtResource("5")
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, 0.366844, 0.0151708, -0.154037, 0.352396, 0.923087, 0.333283, -0.860954, 0.384292, 0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_L"
 bone_idx = 3
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, 0.0336562, -0.0231681, 0.0231985, -0.00051113, 0.999731, 0.0336353, -0.999433, -0.00129147, -0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_L"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("5")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, 0.0419384, -0.0509326, 0.0413169, 0.204661, 0.97796, 0.0514381, -0.977934, 0.202483, -0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_L"
 bone_idx = 6
 script = ExtResource("5")
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, 0.644453, -0.0854741, -0.040588, 0.178251, 0.983148, 0.648829, -0.743577, 0.161601, -0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_L"
 bone_idx = 7
 script = ExtResource("5")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356468, 0.927111, -0.115741, -0.109286, 0.164404, 0.98032, 0.927894, -0.336804, 0.159925, 0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_L"
 bone_idx = 8
 script = ExtResource("5")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, -0.0127165, -0.00125617, 0.000365489, -0.0698022, 0.997561, -0.0127732, -0.99748, -0.0697919, -0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_L"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("5")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, 0.237654, -0.00293004, 0.0207339, -0.0724503, 0.997156, 0.236766, -0.968644, -0.0753018, -0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_L"
 bone_idx = 11
 script = ExtResource("5")
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, 0.643161, -0.0351718, 0.0290327, 0.0201225, 0.999376, 0.643468, -0.765466, -0.00328059, -0.000328456, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_L"
 bone_idx = 12
 script = ExtResource("5")
 length = 0.025
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, 0.95453, -0.0243818, 0.0374454, 0.0138673, 0.999202, 0.954107, -0.297791, -0.0316226, 0.0205207, -0.00467056, -0.148631)
 bone_name = "Middle_Distal_L"
 bone_idx = 13
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, 0.047074, 0.0237409, -0.0169882, -0.138981, 0.990149, 0.0499098, -0.989175, -0.137988, -0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_L"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("5")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, 0.181854, 0.0266582, 0.0109494, -0.202722, 0.979175, 0.183471, -0.962202, -0.20126, -0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_L"
 bone_idx = 16
 script = ExtResource("5")
 length = 0.028
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778393, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_L"
 bone_idx = 17
 script = ExtResource("5")
 length = 0.025
 
-[node name="Hand_Glove_L@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381387, 0.924068, 0.025339, 0.114105, -0.0742599, 0.990689, 0.917346, -0.374945, -0.133762, 0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_L"
 bone_idx = 18
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_L@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, 0.0165318, 0.0422887, -0.0385953, -0.181426, 0.982647, 0.0239172, -0.983265, -0.180601, -4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_L"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("5")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_Glove_L@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, 0.239304, 0.0579745, 0.0185535, -0.305761, 0.951928, 0.245527, -0.921544, -0.300787, 0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_L"
 bone_idx = 21
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_L@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, 0.713816, 0.0374602, 0.103947, -0.153407, 0.982681, 0.707199, -0.683325, -0.181481, 0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_L"
 bone_idx = 22
 script = ExtResource("5")
 length = 0.015
 
-[node name="Hand_Glove_L@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Glove_L/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, 0.939844, 0.0220291, 0.162162, -0.081867, 0.983362, 0.926011, -0.331647, -0.180315, 0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_L"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_Glove_L" instance=ExtResource("2")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_6y0fw")
+tree_root = SubResource("AnimationNodeBlendTree_yo480")
 anim_player = NodePath("../Hand_Glove_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0

--- a/addons/godot-xr-tools/hands/scenes/highpoly/right_fullglove_physics_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/right_fullglove_physics_hand.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Material" uid="uid://bhiiya7ow6h8v" path="res://addons/godot-xr-tools/hands/materials/labglove.material" id="5"]
 [ext_resource type="AnimationNodeBlendTree" uid="uid://m85b1gogdums" path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" id="7"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vuxsk"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_sbg56"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_5q5w8"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_cmqjo"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_bh13w"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_giuei"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ntfdl"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_4mwbe"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_bsbib"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_x7ees"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_tchuk"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_s5hy4"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_vuxsk")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_sbg56")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_5q5w8")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_cmqjo")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_bh13w")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_giuei")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_ntfdl")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_4mwbe")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_bsbib")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_x7ees")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="RightPhysicsHand" type="Node3D"]
 script = ExtResource("3")
+bone_group = "RightHand"
 hand_blend_tree = ExtResource("7")
 default_pose = ExtResource("3_23oai")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 [node name="mesh_Hand_R" parent="Hand_R/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("5")
 
-[node name="Hand_R@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, 1.83077e-05, -1.52659e-08, -1.52668e-08, 0.00166774, 0.999999, 1.83077e-05, -0.999999, 0.00166774, -3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_R"
 bone_idx = 0
 script = ExtResource("4")
 width_ratio = 0.8
 
-[node name="Hand_R@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, -0.0514604, 0.0176509, 0.017651, 0.613335, 0.789626, -0.0514604, -0.788145, 0.613335, -0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_R"
 bone_idx = 1
 script = ExtResource("4")
 length = 0.05
 
-[node name="Hand_R@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, -0.383958, 0.0587628, 0.124052, 0.434264, 0.892203, -0.368087, -0.814856, 0.447796, -0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_R"
 bone_idx = 2
 script = ExtResource("4")
 
-[node name="Hand_R@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, -0.366844, -0.0151708, 0.154037, 0.352396, 0.923087, -0.333283, -0.860954, 0.384292, -0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_R"
 bone_idx = 3
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_R@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, -0.0336562, 0.0231681, -0.0231985, -0.00051113, 0.999731, -0.0336353, -0.999433, -0.00129147, 0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_R"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_R@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, -0.0419385, 0.0509327, -0.0413169, 0.204661, 0.97796, -0.0514381, -0.977934, 0.202483, 0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_R"
 bone_idx = 6
 script = ExtResource("4")
 
-[node name="Hand_R@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, -0.644453, 0.0854741, 0.0405881, 0.178251, 0.983148, -0.648829, -0.743577, 0.161601, 0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_R"
 bone_idx = 7
 script = ExtResource("4")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_R@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356467, -0.927111, 0.115741, 0.109286, 0.164404, 0.98032, -0.927894, -0.336803, 0.159925, -0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_R"
 bone_idx = 8
 script = ExtResource("4")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IIndexFinger"
 
-[node name="Hand_R@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, 0.0127165, 0.00125617, -0.000365489, -0.0698022, 0.997561, 0.0127732, -0.99748, -0.0697919, 0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_R"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_R@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, -0.237654, 0.00293004, -0.0207339, -0.0724503, 0.997156, -0.236766, -0.968644, -0.0753018, 0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_R"
 bone_idx = 11
 script = ExtResource("4")
 
-[node name="Hand_R@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, -0.643162, 0.0351718, -0.0290327, 0.0201225, 0.999376, -0.643468, -0.765466, -0.00328059, 0.00032845, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_R"
 bone_idx = 12
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_R@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, -0.95453, 0.0243818, -0.0374454, 0.0138673, 0.999202, -0.954107, -0.297791, -0.0316226, -0.0205207, -0.00467055, -0.148631)
 bone_name = "Middle_Distal_R"
 bone_idx = 13
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_R@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, -0.047074, -0.0237409, 0.0169882, -0.138981, 0.990149, -0.0499098, -0.989175, -0.137988, 0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_R"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_R@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, -0.181854, -0.0266582, -0.0109494, -0.202722, 0.979175, -0.183471, -0.962202, -0.20126, 0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_R"
 bone_idx = 16
 script = ExtResource("4")
 length = 0.028
 
-[node name="Hand_R@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, -0.634603, -0.0200164, -0.0794844, -0.127948, 0.98859, -0.629924, -0.762173, -0.149291, -0.000778395, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_R"
 bone_idx = 17
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_R@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381388, -0.924068, -0.025339, -0.114105, -0.0742599, 0.990689, -0.917346, -0.374945, -0.133762, -0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_R"
 bone_idx = 18
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_R@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, -0.0165318, -0.0422887, 0.0385953, -0.181426, 0.982647, -0.0239172, -0.983265, -0.180601, 4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_R"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_R@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, -0.239304, -0.0579745, -0.0185535, -0.305761, 0.951928, -0.245527, -0.921544, -0.300787, -0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_R"
 bone_idx = 21
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_R@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, -0.713816, -0.0374602, -0.103947, -0.153407, 0.982681, -0.707199, -0.683325, -0.181481, -0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_R"
 bone_idx = 22
 script = ExtResource("4")
 length = 0.015
 
-[node name="Hand_R@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_R/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, -0.939844, -0.0220291, -0.162162, -0.081867, 0.983362, -0.926011, -0.331647, -0.180315, -0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_R"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_R" instance=ExtResource("2")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_tchuk")
+tree_root = SubResource("AnimationNodeBlendTree_s5hy4")
 anim_player = NodePath("../Hand_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0

--- a/addons/godot-xr-tools/hands/scenes/highpoly/right_physics_hand.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/right_physics_hand.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Material" uid="uid://dbvge3quu3bju" path="res://addons/godot-xr-tools/hands/materials/caucasian_hand.material" id="5"]
 [ext_resource type="AnimationNodeBlendTree" uid="uid://m85b1gogdums" path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" id="7"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_lgih3"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_y3mf2"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_wop42"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_8ifub"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ufkef"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_jh66p"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_o5b51"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_4bb4h"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_pdljy"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_b8ks0"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_8gtsg"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_xm2bm"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_lgih3")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_y3mf2")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_wop42")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_8ifub")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_ufkef")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_jh66p")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_o5b51")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_4bb4h")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_pdljy")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_b8ks0")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="RightPhysicsHand" type="Node3D"]
 script = ExtResource("3")
+bone_group = "RightHand"
 hand_blend_tree = ExtResource("7")
 default_pose = ExtResource("3_gqplw")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 [node name="mesh_Hand_Nails_R" parent="Hand_Nails_R/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("5")
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, 1.83077e-05, -1.52659e-08, -1.52668e-08, 0.00166774, 0.999999, 1.83077e-05, -0.999999, 0.00166774, -3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_R"
 bone_idx = 0
 script = ExtResource("4")
 width_ratio = 0.8
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, -0.0514604, 0.0176509, 0.017651, 0.613335, 0.789626, -0.0514604, -0.788145, 0.613335, -0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_R"
 bone_idx = 1
 script = ExtResource("4")
 length = 0.05
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, -0.383958, 0.0587628, 0.124052, 0.434264, 0.892203, -0.368087, -0.814856, 0.447796, -0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_R"
 bone_idx = 2
 script = ExtResource("4")
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, -0.366844, -0.0151708, 0.154037, 0.352396, 0.923087, -0.333283, -0.860954, 0.384292, -0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_R"
 bone_idx = 3
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, -0.0336562, 0.0231681, -0.0231985, -0.00051113, 0.999731, -0.0336353, -0.999433, -0.00129147, 0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_R"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, -0.0419385, 0.0509327, -0.0413169, 0.204661, 0.97796, -0.0514381, -0.977934, 0.202483, 0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_R"
 bone_idx = 6
 script = ExtResource("4")
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, -0.644453, 0.0854741, 0.0405881, 0.178251, 0.983148, -0.648829, -0.743577, 0.161601, 0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_R"
 bone_idx = 7
 script = ExtResource("4")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356467, -0.927111, 0.115741, 0.109286, 0.164404, 0.98032, -0.927894, -0.336803, 0.159925, -0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_R"
 bone_idx = 8
 script = ExtResource("4")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, 0.0127165, 0.00125617, -0.000365489, -0.0698022, 0.997561, 0.0127732, -0.99748, -0.0697919, 0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_R"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, -0.237654, 0.00293004, -0.0207339, -0.0724503, 0.997156, -0.236766, -0.968644, -0.0753018, 0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_R"
 bone_idx = 11
 script = ExtResource("4")
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, -0.643162, 0.0351718, -0.0290327, 0.0201225, 0.999376, -0.643468, -0.765466, -0.00328059, 0.00032845, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_R"
 bone_idx = 12
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, -0.95453, 0.0243818, -0.0374454, 0.0138673, 0.999202, -0.954107, -0.297791, -0.0316226, -0.0205207, -0.00467055, -0.148631)
 bone_name = "Middle_Distal_R"
 bone_idx = 13
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, -0.047074, -0.0237409, 0.0169882, -0.138981, 0.990149, -0.0499098, -0.989175, -0.137988, 0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_R"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, -0.181854, -0.0266582, -0.0109494, -0.202722, 0.979175, -0.183471, -0.962202, -0.20126, 0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_R"
 bone_idx = 16
 script = ExtResource("4")
 length = 0.028
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, -0.634603, -0.0200164, -0.0794844, -0.127948, 0.98859, -0.629924, -0.762173, -0.149291, -0.000778395, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_R"
 bone_idx = 17
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_Nails_R@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381388, -0.924068, -0.025339, -0.114105, -0.0742599, 0.990689, -0.917346, -0.374945, -0.133762, -0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_R"
 bone_idx = 18
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_R@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, -0.0165318, -0.0422887, 0.0385953, -0.181426, 0.982647, -0.0239172, -0.983265, -0.180601, 4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_R"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_Nails_R@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, -0.239304, -0.0579745, -0.0185535, -0.305761, 0.951928, -0.245527, -0.921544, -0.300787, -0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_R"
 bone_idx = 21
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_R@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, -0.713816, -0.0374602, -0.103947, -0.153407, 0.982681, -0.707199, -0.683325, -0.181481, -0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_R"
 bone_idx = 22
 script = ExtResource("4")
 length = 0.015
 
-[node name="Hand_Nails_R@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Nails_R/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, -0.939844, -0.0220291, -0.162162, -0.081867, 0.983362, -0.926011, -0.331647, -0.180315, -0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_R"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_Nails_R" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_8gtsg")
+tree_root = SubResource("AnimationNodeBlendTree_xm2bm")
 anim_player = NodePath("../Hand_Nails_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0

--- a/addons/godot-xr-tools/hands/scenes/highpoly/right_physics_tac_glove.tscn
+++ b/addons/godot-xr-tools/hands/scenes/highpoly/right_physics_tac_glove.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Script" path="res://addons/godot-xr-tools/hands/hand_physics_bone.gd" id="5"]
 [ext_resource type="Script" path="res://addons/godot-xr-tools/hands/physics_hand.gd" id="6"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_nsl06"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_eynss"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ocujq"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_udhgr"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_o4l8c"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_s7eng"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_p0302"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_dc0m1"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_umc4l"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_guoth"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_7jd3e"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_08oti"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_nsl06")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_eynss")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_ocujq")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_udhgr")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_o4l8c")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_s7eng")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_p0302")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_dc0m1")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_umc4l")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_guoth")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="RightPhysicsHand" type="Node3D"]
 script = ExtResource("6")
+bone_group = "RightHand"
 hand_blend_tree = ExtResource("3")
 default_pose = ExtResource("3_h0fv3")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 [node name="mesh_Glove_R" parent="Hand_Glove_R/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("4")
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, 1.83077e-05, -1.52659e-08, -1.52668e-08, 0.00166774, 0.999999, 1.83077e-05, -0.999999, 0.00166774, -3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_R"
 bone_idx = 0
 script = ExtResource("5")
 width_ratio = 0.8
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, -0.0514604, 0.0176509, 0.017651, 0.613335, 0.789626, -0.0514604, -0.788145, 0.613335, -0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_R"
 bone_idx = 1
 script = ExtResource("5")
 length = 0.05
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, -0.383958, 0.0587628, 0.124052, 0.434264, 0.892203, -0.368087, -0.814856, 0.447796, -0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_R"
 bone_idx = 2
 script = ExtResource("5")
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, -0.366844, -0.0151708, 0.154037, 0.352396, 0.923087, -0.333283, -0.860954, 0.384292, -0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_R"
 bone_idx = 3
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, -0.0336562, 0.0231681, -0.0231985, -0.00051113, 0.999731, -0.0336353, -0.999433, -0.00129147, 0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_R"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("5")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, -0.0419385, 0.0509327, -0.0413169, 0.204661, 0.97796, -0.0514381, -0.977934, 0.202483, 0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_R"
 bone_idx = 6
 script = ExtResource("5")
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, -0.644453, 0.0854741, 0.0405881, 0.178251, 0.983148, -0.648829, -0.743577, 0.161601, 0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_R"
 bone_idx = 7
 script = ExtResource("5")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356467, -0.927111, 0.115741, 0.109286, 0.164404, 0.98032, -0.927894, -0.336803, 0.159925, -0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_R"
 bone_idx = 8
 script = ExtResource("5")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, 0.0127165, 0.00125617, -0.000365489, -0.0698022, 0.997561, 0.0127732, -0.99748, -0.0697919, 0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_R"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("5")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, -0.237654, 0.00293004, -0.0207339, -0.0724503, 0.997156, -0.236766, -0.968644, -0.0753018, 0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_R"
 bone_idx = 11
 script = ExtResource("5")
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, -0.643162, 0.0351718, -0.0290327, 0.0201225, 0.999376, -0.643468, -0.765466, -0.00328059, 0.00032845, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_R"
 bone_idx = 12
 script = ExtResource("5")
 length = 0.025
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, -0.95453, 0.0243818, -0.0374454, 0.0138673, 0.999202, -0.954107, -0.297791, -0.0316226, -0.0205207, -0.00467055, -0.148631)
 bone_name = "Middle_Distal_R"
 bone_idx = 13
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, -0.047074, -0.0237409, 0.0169882, -0.138981, 0.990149, -0.0499098, -0.989175, -0.137988, 0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_R"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("5")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, -0.181854, -0.0266582, -0.0109494, -0.202722, 0.979175, -0.183471, -0.962202, -0.20126, 0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_R"
 bone_idx = 16
 script = ExtResource("5")
 length = 0.028
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, -0.634603, -0.0200164, -0.0794844, -0.127948, 0.98859, -0.629924, -0.762173, -0.149291, -0.000778395, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_R"
 bone_idx = 17
 script = ExtResource("5")
 length = 0.025
 
-[node name="Hand_Glove_R@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381388, -0.924068, -0.025339, -0.114105, -0.0742599, 0.990689, -0.917346, -0.374945, -0.133762, -0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_R"
 bone_idx = 18
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_R@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, -0.0165318, -0.0422887, 0.0385953, -0.181426, 0.982647, -0.0239172, -0.983265, -0.180601, 4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_R"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("5")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_Glove_R@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, -0.239304, -0.0579745, -0.0185535, -0.305761, 0.951928, -0.245527, -0.921544, -0.300787, -0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_R"
 bone_idx = 21
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_R@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, -0.713816, -0.0374602, -0.103947, -0.153407, 0.982681, -0.707199, -0.683325, -0.181481, -0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_R"
 bone_idx = 22
 script = ExtResource("5")
 length = 0.015
 
-[node name="Hand_Glove_R@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Glove_R/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, -0.939844, -0.0220291, -0.162162, -0.081867, 0.983362, -0.926011, -0.331647, -0.180315, -0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_R"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_Glove_R" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_7jd3e")
+tree_root = SubResource("AnimationNodeBlendTree_08oti")
 anim_player = NodePath("../Hand_Glove_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/left_physics_fullglove_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/left_physics_fullglove_low.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Material" uid="uid://bhiiya7ow6h8v" path="res://addons/godot-xr-tools/hands/materials/labglove.material" id="5"]
 [ext_resource type="AnimationNodeBlendTree" uid="uid://dl8yf7ipqotd1" path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" id="7"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_a581x"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_28vdf"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_si6rq"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_j2cie"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_jv1ag"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_tspja"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_3qeiu"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_fvmpw"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_4eh8j"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_a1c3t"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_vftdd"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_ga1br"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_a581x")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_28vdf")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_si6rq")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_j2cie")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_jv1ag")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_tspja")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_3qeiu")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_fvmpw")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_4eh8j")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_a1c3t")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="LeftPhysicsHand" type="Node3D"]
 script = ExtResource("3")
+bone_group = "LeftHand"
 hand_blend_tree = ExtResource("7")
 default_pose = ExtResource("3_4017m")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
 [node name="mesh_Hand_low_L" parent="Hand_low_L/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("5")
 
-[node name="Hand_low_L@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, -1.83077e-05, 1.52659e-08, 1.52668e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_L"
 bone_idx = 0
 script = ExtResource("4")
 width_ratio = 0.8
 
-[node name="Hand_low_L@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, 0.0514604, -0.0176509, -0.017651, 0.613335, 0.789626, 0.0514604, -0.788145, 0.613335, 0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_L"
 bone_idx = 1
 script = ExtResource("4")
 length = 0.05
 
-[node name="Hand_low_L@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, 0.383958, -0.0587628, -0.124052, 0.434264, 0.892203, 0.368087, -0.814856, 0.447796, 0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_L"
 bone_idx = 2
 script = ExtResource("4")
 
-[node name="Hand_low_L@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, 0.366844, 0.0151708, -0.154037, 0.352396, 0.923087, 0.333283, -0.860954, 0.384292, 0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_L"
 bone_idx = 3
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_low_L@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, 0.0336562, -0.0231681, 0.0231985, -0.00051113, 0.999731, 0.0336353, -0.999433, -0.00129147, -0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_L"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_low_L@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, 0.0419384, -0.0509326, 0.0413169, 0.204661, 0.97796, 0.0514381, -0.977934, 0.202483, -0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_L"
 bone_idx = 6
 script = ExtResource("4")
 
-[node name="Hand_low_L@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, 0.644453, -0.0854741, -0.040588, 0.178251, 0.983148, 0.648829, -0.743577, 0.161601, -0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_L"
 bone_idx = 7
 script = ExtResource("4")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_low_L@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356468, 0.927111, -0.115741, -0.109286, 0.164404, 0.98032, 0.927894, -0.336804, 0.159925, 0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_L"
 bone_idx = 8
 script = ExtResource("4")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_low_L@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, -0.0127165, -0.00125617, 0.000365489, -0.0698022, 0.997561, -0.0127732, -0.99748, -0.0697919, -0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_L"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_low_L@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, 0.237654, -0.00293004, 0.0207339, -0.0724503, 0.997156, 0.236766, -0.968644, -0.0753018, -0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_L"
 bone_idx = 11
 script = ExtResource("4")
 
-[node name="Hand_low_L@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, 0.643161, -0.0351718, 0.0290327, 0.0201225, 0.999376, 0.643468, -0.765466, -0.00328059, -0.000328456, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_L"
 bone_idx = 12
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_low_L@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, 0.95453, -0.0243818, 0.0374454, 0.0138673, 0.999202, 0.954107, -0.297791, -0.0316226, 0.0205207, -0.00467056, -0.148631)
 bone_name = "Middle_Distal_L"
 bone_idx = 13
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_low_L@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, 0.047074, 0.0237409, -0.0169882, -0.138981, 0.990149, 0.0499098, -0.989175, -0.137988, -0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_L"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_low_L@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, 0.181854, 0.0266582, 0.0109494, -0.202722, 0.979175, 0.183471, -0.962202, -0.20126, -0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_L"
 bone_idx = 16
 script = ExtResource("4")
 length = 0.028
 
-[node name="Hand_low_L@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778393, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_L"
 bone_idx = 17
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_low_L@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381387, 0.924068, 0.025339, 0.114105, -0.0742599, 0.990689, 0.917346, -0.374945, -0.133762, 0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_L"
 bone_idx = 18
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_low_L@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, 0.0165318, 0.0422887, -0.0385953, -0.181426, 0.982647, 0.0239172, -0.983265, -0.180601, -4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_L"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_low_L@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, 0.239304, 0.0579745, 0.0185535, -0.305761, 0.951928, 0.245527, -0.921544, -0.300787, 0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_L"
 bone_idx = 21
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_low_L@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, 0.713816, 0.0374602, 0.103947, -0.153407, 0.982681, 0.707199, -0.683325, -0.181481, 0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_L"
 bone_idx = 22
 script = ExtResource("4")
 length = 0.015
 
-[node name="Hand_low_L@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_low_L/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, 0.939844, 0.0220291, 0.162162, -0.081867, 0.983362, 0.926011, -0.331647, -0.180315, 0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_L"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_low_L" instance=ExtResource("2")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_vftdd")
+tree_root = SubResource("AnimationNodeBlendTree_ga1br")
 anim_player = NodePath("../Hand_low_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/left_physics_hand_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/left_physics_hand_low.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Material" uid="uid://dbvge3quu3bju" path="res://addons/godot-xr-tools/hands/materials/caucasian_hand.material" id="5"]
 [ext_resource type="AnimationNodeBlendTree" uid="uid://dl8yf7ipqotd1" path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" id="7"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_uqn4v"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_c4qn1"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_783qd"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_skgu7"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_uetxr"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_7pgcb"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_52cah"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_3l13i"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_4js8y"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ms3kw"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_8iblu"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_jcrf4"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_uqn4v")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_c4qn1")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_783qd")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_skgu7")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_uetxr")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_7pgcb")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_52cah")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_3l13i")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_4js8y")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_ms3kw")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="LeftPhysicsHand" type="Node3D"]
 script = ExtResource("3")
+bone_group = "LeftHand"
 hand_blend_tree = ExtResource("7")
 default_pose = ExtResource("3_t17lq")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
 [node name="mesh_Hand_Nails_low_L" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("5")
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, -1.83077e-05, 1.52659e-08, 1.52668e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_L"
 bone_idx = 0
 script = ExtResource("4")
 width_ratio = 0.8
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, 0.0514604, -0.0176509, -0.017651, 0.613335, 0.789626, 0.0514604, -0.788145, 0.613335, 0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_L"
 bone_idx = 1
 script = ExtResource("4")
 length = 0.05
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, 0.383958, -0.0587628, -0.124052, 0.434264, 0.892203, 0.368087, -0.814856, 0.447796, 0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_L"
 bone_idx = 2
 script = ExtResource("4")
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, 0.366844, 0.0151708, -0.154037, 0.352396, 0.923087, 0.333283, -0.860954, 0.384292, 0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_L"
 bone_idx = 3
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, 0.0336562, -0.0231681, 0.0231985, -0.00051113, 0.999731, 0.0336353, -0.999433, -0.00129147, -0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_L"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, 0.0419384, -0.0509326, 0.0413169, 0.204661, 0.97796, 0.0514381, -0.977934, 0.202483, -0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_L"
 bone_idx = 6
 script = ExtResource("4")
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, 0.644453, -0.0854741, -0.040588, 0.178251, 0.983148, 0.648829, -0.743577, 0.161601, -0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_L"
 bone_idx = 7
 script = ExtResource("4")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356468, 0.927111, -0.115741, -0.109286, 0.164404, 0.98032, 0.927894, -0.336804, 0.159925, 0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_L"
 bone_idx = 8
 script = ExtResource("4")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, -0.0127165, -0.00125617, 0.000365489, -0.0698022, 0.997561, -0.0127732, -0.99748, -0.0697919, -0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_L"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, 0.237654, -0.00293004, 0.0207339, -0.0724503, 0.997156, 0.236766, -0.968644, -0.0753018, -0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_L"
 bone_idx = 11
 script = ExtResource("4")
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, 0.643161, -0.0351718, 0.0290327, 0.0201225, 0.999376, 0.643468, -0.765466, -0.00328059, -0.000328456, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_L"
 bone_idx = 12
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, 0.95453, -0.0243818, 0.0374454, 0.0138673, 0.999202, 0.954107, -0.297791, -0.0316226, 0.0205207, -0.00467056, -0.148631)
 bone_name = "Middle_Distal_L"
 bone_idx = 13
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, 0.047074, 0.0237409, -0.0169882, -0.138981, 0.990149, 0.0499098, -0.989175, -0.137988, -0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_L"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, 0.181854, 0.0266582, 0.0109494, -0.202722, 0.979175, 0.183471, -0.962202, -0.20126, -0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_L"
 bone_idx = 16
 script = ExtResource("4")
 length = 0.028
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778393, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_L"
 bone_idx = 17
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381387, 0.924068, 0.025339, 0.114105, -0.0742599, 0.990689, 0.917346, -0.374945, -0.133762, 0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_L"
 bone_idx = 18
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, 0.0165318, 0.0422887, -0.0385953, -0.181426, 0.982647, 0.0239172, -0.983265, -0.180601, -4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_L"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, 0.239304, 0.0579745, 0.0185535, -0.305761, 0.951928, 0.245527, -0.921544, -0.300787, 0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_L"
 bone_idx = 21
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, 0.713816, 0.0374602, 0.103947, -0.153407, 0.982681, 0.707199, -0.683325, -0.181481, 0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_L"
 bone_idx = 22
 script = ExtResource("4")
 length = 0.015
 
-[node name="Hand_Nails_low_L@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Nails_low_L/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, 0.939844, 0.0220291, 0.162162, -0.081867, 0.983362, 0.926011, -0.331647, -0.180315, 0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_L"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_Nails_low_L" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_8iblu")
+tree_root = SubResource("AnimationNodeBlendTree_jcrf4")
 anim_player = NodePath("../Hand_Nails_low_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/left_physics_tac_glove_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/left_physics_tac_glove_low.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Script" path="res://addons/godot-xr-tools/hands/hand_physics_bone.gd" id="5"]
 [ext_resource type="Script" path="res://addons/godot-xr-tools/hands/physics_hand.gd" id="6"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_8ybkh"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_80h26"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_onyre"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_0pshr"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_y2hch"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_rgabh"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_33lkx"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vkt4w"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_yde33"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_1yhw8"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_gfg8a"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_kvyku"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_8ybkh")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_80h26")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_onyre")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_0pshr")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_y2hch")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_rgabh")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_33lkx")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_vkt4w")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_yde33")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_1yhw8")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="LeftPhysicsHand" type="Node3D"]
 script = ExtResource("6")
+bone_group = "LeftHand"
 hand_blend_tree = ExtResource("3")
 default_pose = ExtResource("3_oehre")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
 [node name="mesh_Glove_low_L" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("4")
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, -1.83077e-05, 1.52659e-08, 1.52668e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_L"
 bone_idx = 0
 script = ExtResource("5")
 width_ratio = 0.8
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, 0.0514604, -0.0176509, -0.017651, 0.613335, 0.789626, 0.0514604, -0.788145, 0.613335, 0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_L"
 bone_idx = 1
 script = ExtResource("5")
 length = 0.05
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, 0.383958, -0.0587628, -0.124052, 0.434264, 0.892203, 0.368087, -0.814856, 0.447796, 0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_L"
 bone_idx = 2
 script = ExtResource("5")
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, 0.366844, 0.0151708, -0.154037, 0.352396, 0.923087, 0.333283, -0.860954, 0.384292, 0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_L"
 bone_idx = 3
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, 0.0336562, -0.0231681, 0.0231985, -0.00051113, 0.999731, 0.0336353, -0.999433, -0.00129147, -0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_L"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("5")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, 0.0419384, -0.0509326, 0.0413169, 0.204661, 0.97796, 0.0514381, -0.977934, 0.202483, -0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_L"
 bone_idx = 6
 script = ExtResource("5")
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, 0.644453, -0.0854741, -0.040588, 0.178251, 0.983148, 0.648829, -0.743577, 0.161601, -0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_L"
 bone_idx = 7
 script = ExtResource("5")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356468, 0.927111, -0.115741, -0.109286, 0.164404, 0.98032, 0.927894, -0.336804, 0.159925, 0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_L"
 bone_idx = 8
 script = ExtResource("5")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, -0.0127165, -0.00125617, 0.000365489, -0.0698022, 0.997561, -0.0127732, -0.99748, -0.0697919, -0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_L"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("5")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, 0.237654, -0.00293004, 0.0207339, -0.0724503, 0.997156, 0.236766, -0.968644, -0.0753018, -0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_L"
 bone_idx = 11
 script = ExtResource("5")
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, 0.643161, -0.0351718, 0.0290327, 0.0201225, 0.999376, 0.643468, -0.765466, -0.00328059, -0.000328456, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_L"
 bone_idx = 12
 script = ExtResource("5")
 length = 0.025
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, 0.95453, -0.0243818, 0.0374454, 0.0138673, 0.999202, 0.954107, -0.297791, -0.0316226, 0.0205207, -0.00467056, -0.148631)
 bone_name = "Middle_Distal_L"
 bone_idx = 13
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, 0.047074, 0.0237409, -0.0169882, -0.138981, 0.990149, 0.0499098, -0.989175, -0.137988, -0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_L"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("5")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, 0.181854, 0.0266582, 0.0109494, -0.202722, 0.979175, 0.183471, -0.962202, -0.20126, -0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_L"
 bone_idx = 16
 script = ExtResource("5")
 length = 0.028
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778393, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_L"
 bone_idx = 17
 script = ExtResource("5")
 length = 0.025
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381387, 0.924068, 0.025339, 0.114105, -0.0742599, 0.990689, 0.917346, -0.374945, -0.133762, 0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_L"
 bone_idx = 18
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, 0.0165318, 0.0422887, -0.0385953, -0.181426, 0.982647, 0.0239172, -0.983265, -0.180601, -4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_L"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("5")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, 0.239304, 0.0579745, 0.0185535, -0.305761, 0.951928, 0.245527, -0.921544, -0.300787, 0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_L"
 bone_idx = 21
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, 0.713816, 0.0374602, 0.103947, -0.153407, 0.982681, 0.707199, -0.683325, -0.181481, 0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_L"
 bone_idx = 22
 script = ExtResource("5")
 length = 0.015
 
-[node name="Hand_Glove_low_L@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Glove_low_L/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, 0.939844, 0.0220291, 0.162162, -0.081867, 0.983362, 0.926011, -0.331647, -0.180315, 0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_L"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_Glove_low_L" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_gfg8a")
+tree_root = SubResource("AnimationNodeBlendTree_kvyku")
 anim_player = NodePath("../Hand_Glove_low_L/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/right_physics_fullglove_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/right_physics_fullglove_low.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="AnimationNodeBlendTree" uid="uid://m85b1gogdums" path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" id="6"]
 [ext_resource type="Script" path="res://addons/godot-xr-tools/hands/hand_physics_bone.gd" id="8"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_60yel"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_koc4o"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_caigx"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_e3fsb"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_73xac"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_7psdm"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_neei8"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_1fjc2"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_sdm1s"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ai2qv"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_l7k65"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_6ule7"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_60yel")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_koc4o")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_caigx")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_e3fsb")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_73xac")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_7psdm")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_neei8")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_1fjc2")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_sdm1s")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_ai2qv")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="RightPhysicsHand" type="Node3D"]
 script = ExtResource("4")
+bone_group = "RightHand"
 hand_blend_tree = ExtResource("6")
 default_pose = ExtResource("3_e8slj")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 [node name="mesh_Hand_low_R" parent="Hand_low_R/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("3")
 
-[node name="Hand_low_R@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, 1.83077e-05, -1.52659e-08, -1.52668e-08, 0.00166774, 0.999999, 1.83077e-05, -0.999999, 0.00166774, -3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_R"
 bone_idx = 0
 script = ExtResource("8")
 width_ratio = 0.8
 
-[node name="Hand_low_R@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, -0.0514604, 0.0176509, 0.017651, 0.613335, 0.789626, -0.0514604, -0.788145, 0.613335, -0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_R"
 bone_idx = 1
 script = ExtResource("8")
 length = 0.05
 
-[node name="Hand_low_R@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, -0.383958, 0.0587628, 0.124052, 0.434264, 0.892203, -0.368087, -0.814856, 0.447796, -0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_R"
 bone_idx = 2
 script = ExtResource("8")
 
-[node name="Hand_low_R@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, -0.366844, -0.0151708, 0.154037, 0.352396, 0.923087, -0.333283, -0.860954, 0.384292, -0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_R"
 bone_idx = 3
 script = ExtResource("8")
 length = 0.02
 
-[node name="Hand_low_R@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, -0.0336562, 0.0231681, -0.0231985, -0.00051113, 0.999731, -0.0336353, -0.999433, -0.00129147, 0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_R"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("8")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_low_R@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, -0.0419385, 0.0509327, -0.0413169, 0.204661, 0.97796, -0.0514381, -0.977934, 0.202483, 0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_R"
 bone_idx = 6
 script = ExtResource("8")
 
-[node name="Hand_low_R@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, -0.644453, 0.0854741, 0.0405881, 0.178251, 0.983148, -0.648829, -0.743577, 0.161601, 0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_R"
 bone_idx = 7
 script = ExtResource("8")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_low_R@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356467, -0.927111, 0.115741, 0.109286, 0.164404, 0.98032, -0.927894, -0.336803, 0.159925, -0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_R"
 bone_idx = 8
 script = ExtResource("8")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_low_R@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, 0.0127165, 0.00125617, -0.000365489, -0.0698022, 0.997561, 0.0127732, -0.99748, -0.0697919, 0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_R"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("8")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_low_R@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, -0.237654, 0.00293004, -0.0207339, -0.0724503, 0.997156, -0.236766, -0.968644, -0.0753018, 0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_R"
 bone_idx = 11
 script = ExtResource("8")
 
-[node name="Hand_low_R@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, -0.643162, 0.0351718, -0.0290327, 0.0201225, 0.999376, -0.643468, -0.765466, -0.00328059, 0.00032845, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_R"
 bone_idx = 12
 script = ExtResource("8")
 length = 0.025
 
-[node name="Hand_low_R@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, -0.95453, 0.0243818, -0.0374454, 0.0138673, 0.999202, -0.954107, -0.297791, -0.0316226, -0.0205207, -0.00467055, -0.148631)
 bone_name = "Middle_Distal_R"
 bone_idx = 13
 script = ExtResource("8")
 length = 0.02
 
-[node name="Hand_low_R@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, -0.047074, -0.0237409, 0.0169882, -0.138981, 0.990149, -0.0499098, -0.989175, -0.137988, 0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_R"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("8")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_low_R@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, -0.181854, -0.0266582, -0.0109494, -0.202722, 0.979175, -0.183471, -0.962202, -0.20126, 0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_R"
 bone_idx = 16
 script = ExtResource("8")
 length = 0.028
 
-[node name="Hand_low_R@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, -0.634603, -0.0200164, -0.0794844, -0.127948, 0.98859, -0.629924, -0.762173, -0.149291, -0.000778395, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_R"
 bone_idx = 17
 script = ExtResource("8")
 length = 0.025
 
-[node name="Hand_low_R@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381388, -0.924068, -0.025339, -0.114105, -0.0742599, 0.990689, -0.917346, -0.374945, -0.133762, -0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_R"
 bone_idx = 18
 script = ExtResource("8")
 length = 0.02
 
-[node name="Hand_low_R@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, -0.0165318, -0.0422887, 0.0385953, -0.181426, 0.982647, -0.0239172, -0.983265, -0.180601, 4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_R"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("8")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_low_R@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, -0.239304, -0.0579745, -0.0185535, -0.305761, 0.951928, -0.245527, -0.921544, -0.300787, -0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_R"
 bone_idx = 21
 script = ExtResource("8")
 length = 0.02
 
-[node name="Hand_low_R@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, -0.713816, -0.0374602, -0.103947, -0.153407, 0.982681, -0.707199, -0.683325, -0.181481, -0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_R"
 bone_idx = 22
 script = ExtResource("8")
 length = 0.015
 
-[node name="Hand_low_R@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_low_R/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, -0.939844, -0.0220291, -0.162162, -0.081867, 0.983362, -0.926011, -0.331647, -0.180315, -0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_R"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_low_R" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_l7k65")
+tree_root = SubResource("AnimationNodeBlendTree_6ule7")
 anim_player = NodePath("../Hand_low_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/right_physics_hand_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/right_physics_hand_low.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Material" uid="uid://dbvge3quu3bju" path="res://addons/godot-xr-tools/hands/materials/caucasian_hand.material" id="5"]
 [ext_resource type="AnimationNodeBlendTree" uid="uid://m85b1gogdums" path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" id="7"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rw5cd"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_d2moa"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_3liek"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_o028d"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_j2nhk"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_rwysm"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_svl77"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_l0mk4"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_8t3gu"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_it0su"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_li0ij"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_km4vp"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_rw5cd")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_d2moa")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_3liek")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_o028d")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_j2nhk")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_rwysm")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_svl77")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_l0mk4")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_8t3gu")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_it0su")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="RightPhysicsHand" type="Node3D"]
 script = ExtResource("3")
+bone_group = "RightHand"
 hand_blend_tree = ExtResource("7")
 default_pose = ExtResource("3_b86a5")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 [node name="mesh_Hand_Nails_low_R" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("5")
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, 1.83077e-05, -1.52659e-08, -1.52668e-08, 0.00166774, 0.999999, 1.83077e-05, -0.999999, 0.00166774, -3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_R"
 bone_idx = 0
 script = ExtResource("4")
 width_ratio = 0.8
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, -0.0514604, 0.0176509, 0.017651, 0.613335, 0.789626, -0.0514604, -0.788145, 0.613335, -0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_R"
 bone_idx = 1
 script = ExtResource("4")
 length = 0.05
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, -0.383958, 0.0587628, 0.124052, 0.434264, 0.892203, -0.368087, -0.814856, 0.447796, -0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_R"
 bone_idx = 2
 script = ExtResource("4")
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, -0.366844, -0.0151708, 0.154037, 0.352396, 0.923087, -0.333283, -0.860954, 0.384292, -0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_R"
 bone_idx = 3
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, -0.0336562, 0.0231681, -0.0231985, -0.00051113, 0.999731, -0.0336353, -0.999433, -0.00129147, 0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_R"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, -0.0419385, 0.0509327, -0.0413169, 0.204661, 0.97796, -0.0514381, -0.977934, 0.202483, 0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_R"
 bone_idx = 6
 script = ExtResource("4")
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, -0.644453, 0.0854741, 0.0405881, 0.178251, 0.983148, -0.648829, -0.743577, 0.161601, 0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_R"
 bone_idx = 7
 script = ExtResource("4")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356467, -0.927111, 0.115741, 0.109286, 0.164404, 0.98032, -0.927894, -0.336803, 0.159925, -0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_R"
 bone_idx = 8
 script = ExtResource("4")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, 0.0127165, 0.00125617, -0.000365489, -0.0698022, 0.997561, 0.0127732, -0.99748, -0.0697919, 0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_R"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("4")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, -0.237654, 0.00293004, -0.0207339, -0.0724503, 0.997156, -0.236766, -0.968644, -0.0753018, 0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_R"
 bone_idx = 11
 script = ExtResource("4")
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, -0.643162, 0.0351718, -0.0290327, 0.0201225, 0.999376, -0.643468, -0.765466, -0.00328059, 0.00032845, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_R"
 bone_idx = 12
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, -0.95453, 0.0243818, -0.0374454, 0.0138673, 0.999202, -0.954107, -0.297791, -0.0316226, -0.0205207, -0.00467055, -0.148631)
 bone_name = "Middle_Distal_R"
 bone_idx = 13
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, -0.047074, -0.0237409, 0.0169882, -0.138981, 0.990149, -0.0499098, -0.989175, -0.137988, 0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_R"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, -0.181854, -0.0266582, -0.0109494, -0.202722, 0.979175, -0.183471, -0.962202, -0.20126, 0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_R"
 bone_idx = 16
 script = ExtResource("4")
 length = 0.028
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, -0.634603, -0.0200164, -0.0794844, -0.127948, 0.98859, -0.629924, -0.762173, -0.149291, -0.000778395, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_R"
 bone_idx = 17
 script = ExtResource("4")
 length = 0.025
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381388, -0.924068, -0.025339, -0.114105, -0.0742599, 0.990689, -0.917346, -0.374945, -0.133762, -0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_R"
 bone_idx = 18
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, -0.0165318, -0.0422887, 0.0385953, -0.181426, 0.982647, -0.0239172, -0.983265, -0.180601, 4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_R"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("4")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, -0.239304, -0.0579745, -0.0185535, -0.305761, 0.951928, -0.245527, -0.921544, -0.300787, -0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_R"
 bone_idx = 21
 script = ExtResource("4")
 length = 0.02
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, -0.713816, -0.0374602, -0.103947, -0.153407, 0.982681, -0.707199, -0.683325, -0.181481, -0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_R"
 bone_idx = 22
 script = ExtResource("4")
 length = 0.015
 
-[node name="Hand_Nails_low_R@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Nails_low_R/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, -0.939844, -0.0220291, -0.162162, -0.081867, 0.983362, -0.926011, -0.331647, -0.180315, -0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_R"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_Nails_low_R" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_li0ij")
+tree_root = SubResource("AnimationNodeBlendTree_km4vp")
 anim_player = NodePath("../Hand_Nails_low_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0.0

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/right_physics_tac_glove_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/right_physics_tac_glove_low.tscn
@@ -8,39 +8,40 @@
 [ext_resource type="Script" path="res://addons/godot-xr-tools/hands/hand_physics_bone.gd" id="5"]
 [ext_resource type="Script" path="res://addons/godot-xr-tools/hands/physics_hand.gd" id="6"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_47dg5"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_d3g7m"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_u8oa1"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_hr14p"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_p10ot"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_av2ad"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_xl7l4"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_8kdoe"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_wmdow"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_5qnsq"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_vnv28"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_64w6y"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_47dg5")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_d3g7m")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_u8oa1")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_hr14p")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_p10ot")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_av2ad")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_xl7l4")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_8kdoe")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_wmdow")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_5qnsq")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="RightPhysicsHand" type="Node3D"]
 script = ExtResource("6")
+bone_group = "RightHand"
 hand_blend_tree = ExtResource("3")
 default_pose = ExtResource("3_xodao")
 
@@ -71,34 +72,34 @@ bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 [node name="mesh_Glove_low_R" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("4")
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneRoot" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="1"]
+[node name="BoneRoot" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="1"]
 transform = Transform3D(1, 1.83077e-05, -1.52659e-08, -1.52668e-08, 0.00166774, 0.999999, 1.83077e-05, -0.999999, 0.00166774, -3.86425e-08, -1.86975e-05, 0.0271756)
 bone_name = "Wrist_R"
 bone_idx = 0
 script = ExtResource("5")
 width_ratio = 0.8
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="2"]
+[node name="BoneThumbMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, -0.0514604, 0.0176509, 0.017651, 0.613335, 0.789626, -0.0514604, -0.788145, 0.613335, -0.00999954, 0.0200266, 3.59323e-05)
 bone_name = "Thumb_Metacarpal_R"
 bone_idx = 1
 script = ExtResource("5")
 length = 0.05
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="3"]
+[node name="BoneThumbProximal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="3"]
 transform = Transform3D(0.921479, -0.383958, 0.0587628, 0.124052, 0.434264, 0.892203, -0.368087, -0.814856, 0.447796, -0.012311, 0.0475754, -0.0353648)
 bone_name = "Thumb_Proximal_R"
 bone_idx = 2
 script = ExtResource("5")
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="4"]
+[node name="BoneThumbDistal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="4"]
 transform = Transform3D(0.930159, -0.366844, -0.0151708, 0.154037, 0.352396, 0.923087, -0.333283, -0.860954, 0.384292, -0.028494, 0.0658787, -0.0697092)
 bone_name = "Thumb_Distal_R"
 bone_idx = 3
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="5"]
+[node name="BoneIndexMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="5"]
 transform = Transform3D(0.999165, -0.0336562, 0.0231681, -0.0231985, -0.00051113, 0.999731, -0.0336353, -0.999433, -0.00129147, 0.0100005, 0.0224317, 3.59286e-05)
 bone_name = "Index_Metacarpal_R"
 bone_idx = 5
@@ -106,29 +107,29 @@ script = ExtResource("5")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="6"]
+[node name="BoneIndexProximal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="6"]
 transform = Transform3D(0.997821, -0.0419385, 0.0509327, -0.0413169, 0.204661, 0.97796, -0.0514381, -0.977934, 0.202483, 0.00729559, 0.0223907, -0.0802861)
 bone_name = "Index_Proximal_R"
 bone_idx = 6
 script = ExtResource("5")
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="7"]
+[node name="BoneIndexMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="7"]
 transform = Transform3D(0.759851, -0.644453, 0.0854741, 0.0405881, 0.178251, 0.983148, -0.648829, -0.743577, 0.161601, 0.00569705, 0.0301916, -0.117561)
 bone_name = "Index_Intermediate_R"
 bone_idx = 7
 script = ExtResource("5")
 length = 0.025
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="8"]
+[node name="BoneIndexDistal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="8"]
 transform = Transform3D(0.356467, -0.927111, 0.115741, 0.109286, 0.164404, 0.98032, -0.927894, -0.336803, 0.159925, -0.0145038, 0.035779, -0.140869)
 bone_name = "Index_Distal_R"
 bone_idx = 8
 script = ExtResource("5")
 length = 0.02
-bone_group = "index_finger"
+bone_group = "IndexFinger"
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="9"]
+[node name="BoneMiddleMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="9"]
 transform = Transform3D(0.999918, 0.0127165, 0.00125617, -0.000365489, -0.0698022, 0.997561, 0.0127732, -0.99748, -0.0697919, 0.0100005, 0.00355416, 3.59286e-05)
 bone_name = "Middle_Metacarpal_R"
 bone_idx = 10
@@ -136,27 +137,27 @@ script = ExtResource("5")
 length = 0.08
 width_ratio = 0.2
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="10"]
+[node name="BoneMiddleProximal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="10"]
 transform = Transform3D(0.971345, -0.237654, 0.00293004, -0.0207339, -0.0724503, 0.997156, -0.236766, -0.968644, -0.0753018, 0.0110237, -0.00206236, -0.0802245)
 bone_name = "Middle_Proximal_R"
 bone_idx = 11
 script = ExtResource("5")
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="11"]
+[node name="BoneMiddleMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="11"]
 transform = Transform3D(0.764922, -0.643162, 0.0351718, -0.0290327, 0.0201225, 0.999376, -0.643468, -0.765466, -0.00328059, 0.00032845, -0.00532286, -0.123817)
 bone_name = "Middle_Intermediate_R"
 bone_idx = 12
 script = ExtResource("5")
 length = 0.025
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="12"]
+[node name="BoneMiddleDistal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="12"]
 transform = Transform3D(0.297115, -0.95453, 0.0243818, -0.0374454, 0.0138673, 0.999202, -0.954107, -0.297791, -0.0316226, -0.0205207, -0.00467055, -0.148631)
 bone_name = "Middle_Distal_R"
 bone_idx = 13
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="13"]
+[node name="BoneRingMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="13"]
 transform = Transform3D(0.998609, -0.047074, -0.0237409, 0.0169882, -0.138981, 0.990149, -0.0499098, -0.989175, -0.137988, 0.0100005, -0.0130734, 3.59304e-05)
 bone_name = "Ring_Metacarpal_R"
 bone_idx = 15
@@ -164,28 +165,28 @@ script = ExtResource("5")
 length = 0.07
 width_ratio = 0.2
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneRingProximal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="14"]
+[node name="BoneRingProximal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="14"]
 transform = Transform3D(0.982964, -0.181854, -0.0266582, -0.0109494, -0.202722, 0.979175, -0.183471, -0.962202, -0.20126, 0.00651963, -0.0233502, -0.0731075)
 bone_name = "Ring_Proximal_R"
 bone_idx = 16
 script = ExtResource("5")
 length = 0.028
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="15"]
+[node name="BoneRingMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="15"]
 transform = Transform3D(0.772579, -0.634603, -0.0200164, -0.0794844, -0.127948, 0.98859, -0.629924, -0.762173, -0.149291, -0.000778395, -0.0314857, -0.111722)
 bone_name = "Ring_Intermediate_R"
 bone_idx = 17
 script = ExtResource("5")
 length = 0.025
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BoneRingDistal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="16"]
+[node name="BoneRingDistal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381388, -0.924068, -0.025339, -0.114105, -0.0742599, 0.990689, -0.917346, -0.374945, -0.133762, -0.0184188, -0.0350424, -0.132908)
 bone_name = "Ring_Distal_R"
 bone_idx = 18
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="17"]
+[node name="BonePinkyMetacarpal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, -0.0165318, -0.0422887, 0.0385953, -0.181426, 0.982647, -0.0239172, -0.983265, -0.180601, 4.58211e-07, -0.0299734, 3.59304e-05)
 bone_name = "Little_Metacarpal_R"
 bone_idx = 20
@@ -193,21 +194,21 @@ script = ExtResource("5")
 length = 0.07
 width_ratio = 0.18
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="18"]
+[node name="BonePinkyProximal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="18"]
 transform = Transform3D(0.969212, -0.239304, -0.0579745, -0.0185535, -0.305761, 0.951928, -0.245527, -0.921544, -0.300787, -0.00108587, -0.0418952, -0.0645756)
 bone_name = "Little_Proximal_R"
 bone_idx = 21
 script = ExtResource("5")
 length = 0.02
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="19"]
+[node name="BonePinkyMiddle" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="19"]
 transform = Transform3D(0.699331, -0.713816, -0.0374602, -0.103947, -0.153407, 0.982681, -0.707199, -0.683325, -0.181481, -0.00901247, -0.0520231, -0.0951004)
 bone_name = "Little_Intermediate_R"
 bone_idx = 22
 script = ExtResource("5")
 length = 0.015
 
-[node name="Hand_Glove_low_R@Armature@Skeleton@BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="20"]
+[node name="BonePinkyDistal" type="BoneAttachment3D" parent="Hand_Glove_low_R/Armature/Skeleton3D" index="20"]
 transform = Transform3D(0.340891, -0.939844, -0.0220291, -0.162162, -0.081867, 0.983362, -0.926011, -0.331647, -0.180315, -0.0218786, -0.0547881, -0.107417)
 bone_name = "Little_Distal_R"
 bone_idx = 23
@@ -217,7 +218,7 @@ length = 0.015
 [node name="AnimationPlayer" parent="Hand_Glove_low_R" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_vnv28")
+tree_root = SubResource("AnimationNodeBlendTree_64w6y")
 anim_player = NodePath("../Hand_Glove_low_R/AnimationPlayer")
 active = true
 parameters/Grip/blend_amount = 0


### PR DESCRIPTION
This pull request fixes issue #427 by:
 - Fixing XRToolsHandPhysicsBone names from godot 3 import.
 - Fixing bone group names for LeftHand and RightHand.
 - Fixing bone group names for IndexFinger.