### PR TITLE
Prevent initial or ranged snapping in the editor.

### DIFF
--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -71,13 +71,14 @@ func _ready():
 	_update_snap_mode()
 
 	# Perform the initial object check when next idle
-	call_deferred("_initial_object_check")
+	if not Engine.is_editor_hint():
+		call_deferred("_initial_object_check")
 
 
 # Called on each frame to update the pickup
 func _process(_delta):
-	# Skip if not enabled
-	if not enabled:
+	# Skip if in editor or not enabled
+	if Engine.is_editor_hint() or not enabled:
 		return
 
 	# Skip if we aren't doing range-checking


### PR DESCRIPTION
This pull request fixes issue #434 by preventing the snap-zone from performing snapping when the editor is running.