### PR TITLE
Modify connect_scene_signal to match Godot 4 connect

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -102,9 +102,9 @@ func get_scene_instance():
 
 
 # Connect a 2D scene signal
-func connect_scene_signal(which, on, callback):
+func connect_scene_signal(which : String, callback : Callable, flags : int = 0):
 	if scene_node:
-		scene_node.connect(which, on, callback)
+		scene_node.connect(which, callback, flags)
 
 
 # Handler for pointer entered


### PR DESCRIPTION
This pull request fixes issue #441 by updating the connect_scene_signal to match the Godot 4 connect signature.