### PR TITLE
Fixed demo splash-screen image reference in godot-xr-tools addon

### DIFF
--- a/addons/godot-xr-tools/staging/loading_screen.tscn
+++ b/addons/godot-xr-tools/staging/loading_screen.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=14 format=3 uid="uid://bqumugyvkct4r"]
+[gd_scene load_steps=13 format=3 uid="uid://bqumugyvkct4r"]
 
-[ext_resource type="Texture2D" uid="uid://ftrrxm7sxndi" path="res://assets/godot/splash.png" id="1"]
 [ext_resource type="Script" path="res://addons/godot-xr-tools/staging/loading_screen.gd" id="2"]
 [ext_resource type="Shader" uid="uid://4i0pwdtfmtsv" path="res://addons/godot-xr-tools/staging/loading_screen/loading_screen_shader.tres" id="3"]
 [ext_resource type="Texture2D" uid="uid://clbtsf0ahb3fm" path="res://addons/godot-xr-tools/assets/misc/progress_bar.png" id="4"]
@@ -18,7 +17,6 @@ size = Vector2(80, 60)
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_1o2lp"]
 transparency = 1
 shading_mode = 0
-albedo_texture = ExtResource("1")
 
 [sub_resource type="ShaderMaterial" id="18"]
 render_priority = 0
@@ -43,7 +41,6 @@ albedo_texture = ExtResource("5")
 [node name="LoadingScreen" type="Node3D"]
 script = ExtResource("2")
 follow_speed = SubResource("21")
-splash_screen = ExtResource("1")
 
 [node name="SplashScreen" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 15, -50)

--- a/demo_staging.tscn
+++ b/demo_staging.tscn
@@ -1,11 +1,15 @@
-[gd_scene load_steps=3 format=3 uid="uid://dkr1jkk3jerux"]
+[gd_scene load_steps=4 format=3 uid="uid://dkr1jkk3jerux"]
 
 [ext_resource type="PackedScene" uid="uid://bnqnnnet4dw12" path="res://addons/godot-xr-tools/staging/staging.tscn" id="1"]
 [ext_resource type="Script" path="res://demo_staging.gd" id="2"]
+[ext_resource type="Texture2D" uid="uid://ftrrxm7sxndi" path="res://assets/godot/splash.png" id="3_2an2h"]
 
 [node name="DemoStaging" instance=ExtResource("1")]
 script = ExtResource("2")
 main_scene = "res://scenes/main_menu/main_menu_level.tscn"
+
+[node name="LoadingScreen" parent="." index="3"]
+splash_screen = ExtResource("3_2an2h")
 
 [connection signal="scene_exiting" from="." to="." method="_on_Staging_scene_exiting"]
 [connection signal="scene_loaded" from="." to="." method="_on_Staging_scene_loaded"]


### PR DESCRIPTION

This pull request fixes issue #443 where the demo-project splash screen image is present in the godot-xr-tools addon loading screen scene. Instead the addon should not specify the image, and the project should specify the image when it customizes the staging scene.