### PR TITLE
feat(demo): make teleport "beam" visible only if teleport is active

### DIFF
--- a/assets/meshes/teleport/teleport.gd
+++ b/assets/meshes/teleport/teleport.gd
@@ -13,7 +13,16 @@ extends Node3D
 @export var title: Texture2D: set = _set_title
 
 ## Can Teleporter be used
-@export var active: bool: set = _set_active
+@export var active: bool = true: set = _set_active
+
+## Is teleport beam visible if inactive
+@export var inactive_beam_visible: bool = false: set = _set_inactive_beam_visible
+
+## The beam color in active state
+@export var active_beam_color: Color = Color("#2b40f8"): set = _set_active_beam_color
+
+## The beam color in inactive state
+@export var inactive_beam_color: Color = Color("#ad0400"): set = _set_inactive_beam_color
 
 # Scene base to trigger loading
 @onready var _scene_base: XRToolsSceneBase = get_node(scene_base)
@@ -64,6 +73,25 @@ func _set_active(value):
 	if is_inside_tree():
 		_update_teleport()
 		
-func _update_teleport():
-	$TeleportArea/Cylinder.visible = active
+func _set_active_beam_color(value):
+	active_beam_color = value
+	if is_inside_tree():
+		_update_teleport()
 
+func _set_inactive_beam_color(value):
+	inactive_beam_color = value
+	if is_inside_tree():
+		_update_teleport()
+
+func _set_inactive_beam_visible(value):
+	inactive_beam_visible = value
+	if is_inside_tree():
+		_update_teleport()
+
+func _update_teleport():
+	if active:
+		$TeleportArea/Cylinder.get_surface_override_material(0).set_shader_parameter("beam_color", active_beam_color)
+		$TeleportArea/Cylinder.visible = true
+	else:
+		$TeleportArea/Cylinder.get_surface_override_material(0).set_shader_parameter("beam_color", inactive_beam_color)
+		$TeleportArea/Cylinder.visible = inactive_beam_visible

--- a/assets/meshes/teleport/teleport.gd
+++ b/assets/meshes/teleport/teleport.gd
@@ -13,16 +13,15 @@ extends Node3D
 @export var title: Texture2D: set = _set_title
 
 ## Can Teleporter be used
-@export var active := true
-
+@export var active: bool: set = _set_active
 
 # Scene base to trigger loading
 @onready var _scene_base: XRToolsSceneBase = get_node(scene_base)
 
-
 func _ready():
 	_update_title()
-
+	_update_teleport()
+	
 
 # Called when the player enters the teleport area
 func _on_TeleportArea_body_entered(body: Node3D):
@@ -59,3 +58,12 @@ func _update_title():
 	if title:
 		var material: ShaderMaterial = $TeleportBody/Top.get_active_material(1)
 		material.set_shader_parameter("Title", title)
+
+func _set_active(value):
+	active = value
+	if is_inside_tree():
+		_update_teleport()
+		
+func _update_teleport():
+	$TeleportArea/Cylinder.visible = active
+

--- a/assets/meshes/teleport/teleport_area_shader.tres
+++ b/assets/meshes/teleport/teleport_area_shader.tres
@@ -4,9 +4,6 @@
 output_port_for_preview = 0
 function = 17
 
-[sub_resource type="VisualShaderNodeColorConstant" id="13"]
-constant = Color(0.169944, 0.249712, 0.97294, 1)
-
 [sub_resource type="VisualShaderNodeInput" id="14"]
 input_name = "time"
 
@@ -45,16 +42,23 @@ output_port_for_preview = 0
 expanded_output_ports = [0]
 input_name = "uv"
 
+[sub_resource type="VisualShaderNodeColorParameter" id="VisualShaderNodeColorParameter_sreim"]
+expanded_output_ports = [0]
+parameter_name = "beam_color"
+default_value_enabled = true
+default_value = Color(0.168627, 0.25098, 0.972549, 1)
+
 [sub_resource type="VisualShader" id="22"]
 code = "shader_type spatial;
 render_mode blend_add, cull_disabled, unshaded;
 
+uniform vec4 beam_color : source_color = vec4(0.168627, 0.250980, 0.972549, 1.000000);
 
 
 
 void fragment() {
-// ColorConstant:19
-	vec4 n_out19p0 = vec4(0.169944, 0.249712, 0.972940, 1.000000);
+// ColorParameter:50
+	vec4 n_out50p0 = beam_color;
 
 
 // Input:2
@@ -106,7 +110,7 @@ void fragment() {
 
 
 // VectorOp:40
-	vec3 n_out40p0 = vec3(n_out19p0.xyz) * vec3(n_out49p0);
+	vec3 n_out40p0 = vec3(n_out50p0.xyz) * vec3(n_out49p0);
 
 
 // Output:0
@@ -116,7 +120,7 @@ void fragment() {
 
 }
 "
-graph_offset = Vector2(-491.978, 45.2689)
+graph_offset = Vector2(118.2, -413.764)
 modes/blend = 1
 modes/cull = 2
 flags/unshaded = true
@@ -127,8 +131,6 @@ nodes/fragment/5/node = SubResource("21")
 nodes/fragment/5/position = Vector2(-580, 280)
 nodes/fragment/12/node = SubResource("8")
 nodes/fragment/12/position = Vector2(360, 160)
-nodes/fragment/19/node = SubResource("13")
-nodes/fragment/19/position = Vector2(1365, -84)
 nodes/fragment/25/node = SubResource("19")
 nodes/fragment/25/position = Vector2(-80, 20)
 nodes/fragment/26/node = SubResource("23")
@@ -145,8 +147,11 @@ nodes/fragment/48/node = SubResource("30")
 nodes/fragment/48/position = Vector2(1071, 42)
 nodes/fragment/49/node = SubResource("31")
 nodes/fragment/49/position = Vector2(1302, 84)
-nodes/fragment/connections = PackedInt32Array(2, 0, 25, 0, 25, 0, 27, 0, 26, 0, 27, 1, 27, 0, 12, 0, 12, 0, 47, 2, 46, 0, 48, 0, 47, 0, 48, 1, 48, 0, 49, 0, 49, 0, 0, 1, 40, 0, 0, 0, 49, 0, 40, 1, 19, 0, 40, 0, 5, 2, 26, 0, 12, 0, 46, 2)
+nodes/fragment/50/node = SubResource("VisualShaderNodeColorParameter_sreim")
+nodes/fragment/50/position = Vector2(1160, -460)
+nodes/fragment/connections = PackedInt32Array(2, 0, 25, 0, 25, 0, 27, 0, 26, 0, 27, 1, 27, 0, 12, 0, 12, 0, 47, 2, 46, 0, 48, 0, 47, 0, 48, 1, 48, 0, 49, 0, 49, 0, 0, 1, 40, 0, 0, 0, 49, 0, 40, 1, 5, 2, 26, 0, 12, 0, 46, 2, 50, 0, 40, 0)
 
 [resource]
 render_priority = 0
 shader = SubResource("22")
+shader_parameter/beam_color = Color(0.168627, 0.25098, 0.972549, 1)

--- a/assets/meshes/teleport/teleport_area_shader.tres
+++ b/assets/meshes/teleport/teleport_area_shader.tres
@@ -152,6 +152,7 @@ nodes/fragment/50/position = Vector2(1160, -460)
 nodes/fragment/connections = PackedInt32Array(2, 0, 25, 0, 25, 0, 27, 0, 26, 0, 27, 1, 27, 0, 12, 0, 12, 0, 47, 2, 46, 0, 48, 0, 47, 0, 48, 1, 48, 0, 49, 0, 49, 0, 0, 1, 40, 0, 0, 0, 49, 0, 40, 1, 5, 2, 26, 0, 12, 0, 46, 2, 50, 0, 40, 0)
 
 [resource]
+resource_local_to_scene = true
 render_priority = 0
 shader = SubResource("22")
 shader_parameter/beam_color = Color(0.168627, 0.25098, 0.972549, 1)

--- a/scenes/main_menu/main_menu_level.gd
+++ b/scenes/main_menu/main_menu_level.gd
@@ -6,7 +6,6 @@ func _update_demo_positions() -> void:
 	var count = 0
 	var visible_children := []
 	for teleporter in $Demos.get_children():
-		teleporter.active = teleporter.visible
 		teleporter.set_collision_disabled(!teleporter.visible)
 		if teleporter.visible:
 			count += 1

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -26,65 +26,65 @@
 [ext_resource type="Texture2D" uid="uid://cr1l4g7btdyht" path="res://scenes/origin_gravity_demo/origin_gravity_demo.png" id="32_c4n1q"]
 [ext_resource type="Texture2D" uid="uid://dhd30j0xpcxoi" path="res://scenes/sphere_world_demo/sphere_world_demo.png" id="34_xw8ig"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_sxvnk"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_4ghkl"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_yn8lo"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_jd7ei"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_v218t"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_lrg5h"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_juryi"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_tr0h0"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_shlrf"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_3s7cf"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_dmkus"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_n0phm"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_sxvnk")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_4ghkl")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_yn8lo")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_jd7ei")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_v218t")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_lrg5h")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_juryi")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_tr0h0")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_shlrf")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_3s7cf")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_iel8d"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_f81he"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_q6nlw"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_relme"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_am4xx"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_jkn3d"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_wfk17"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_f60qf"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_x1jnr"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_wgx1n"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_tncqy"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_bmq1d"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_iel8d")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_f81he")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_q6nlw")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_relme")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_am4xx")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_jkn3d")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_wfk17")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_f60qf")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_x1jnr")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_wgx1n")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
@@ -123,7 +123,7 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_dmkus")
+tree_root = SubResource("AnimationNodeBlendTree_n0phm")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("5_xgcrx")]
 
@@ -165,7 +165,7 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_tncqy")
+tree_root = SubResource("AnimationNodeBlendTree_bmq1d")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5_xgcrx")]
 


### PR DESCRIPTION
When I was playing around with the teleports in the demo,
I noticed that there is no visible clue if they are active or inactive.

This PR makes the cylinder containing the "beam" only visible if the teleporter is active.

What do you think?