### PR TITLE
Add render target size multiplier option to StartXR

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,7 @@
 - Enhanced grappling to support collision and target layers
 - Added Godot Editor XR Tools menu for layers and openxr configuration
 - Improved gliding to support roll-turning while flapping
+- Added render_target_size_multiplier to StartXR (requires Godot 4.1+)
 
 # 4.0.0
 - Conversion to Godot 4

--- a/addons/godot-xr-tools/xr/start_xr.gd
+++ b/addons/godot-xr-tools/xr/start_xr.gd
@@ -29,6 +29,9 @@ signal xr_ended
 ## If true, the XR interface is automatically initialized
 @export var auto_initialize : bool = true
 
+## Adjusts the pixel density on the rendering target
+@export var render_target_size_multiplier : float = 1.0
+
 ## If true, the XR passthrough is enabled (OpenXR only)
 @export var enable_passthrough : bool = false: set = _set_enable_passthrough
 
@@ -86,6 +89,11 @@ func _get_configuration_warnings() -> PackedStringArray:
 # Perform OpenXR setup
 func _setup_for_openxr() -> bool:
 	print("OpenXR: Configuring interface")
+
+	# Set the render target size multiplier - must be done befor initializing interface
+	# NOTE: Only implemented in Godot 4.1+
+	if "render_target_size_multiplier" in xr_interface:
+		xr_interface.render_target_size_multiplier = render_target_size_multiplier
 
 	# Initialize the OpenXR interface
 	if not xr_interface.is_initialized():

--- a/addons/godot-xr-tools/xr/start_xr.tscn
+++ b/addons/godot-xr-tools/xr/start_xr.tscn
@@ -4,7 +4,6 @@
 
 [node name="StartXR" type="Node"]
 script = ExtResource("1_ljt1b")
-physics_rate_multiplier = 1.0
 
 [node name="EnterWebXR" type="CanvasLayer" parent="."]
 visible = false


### PR DESCRIPTION
This pull request adds the Render Target Size Multiplier option to godot-xr-tools. This requires Godot 4.0.3 or later (https://github.com/godotengine/godot/pull/73558).