### PR TITLE
Fixed WebXR input in all demo scenes

### DIFF
--- a/scenes/origin_gravity_demo/origin_gravity_demo.tscn
+++ b/scenes/origin_gravity_demo/origin_gravity_demo.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=21 format=3 uid="uid://dyfx10nwe0oil"]
+[gd_scene load_steps=22 format=3 uid="uid://dyfx10nwe0oil"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://rypqa6qcv0st" path="res://assets/maps/basic_map.tscn" id="2"]
+[ext_resource type="Script" path="res://scenes/demo_scene_base.gd" id="2_xypqg"]
 [ext_resource type="Material" path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" id="3"]
 [ext_resource type="PackedScene" uid="uid://diyu06cw06syv" path="res://addons/godot-xr-tools/player/player_body.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://c2q5phg8w08o" path="res://addons/godot-xr-tools/functions/movement_jump.tscn" id="5"]
@@ -35,6 +36,7 @@ _data = {
 point_count = 5
 
 [node name="OriginGravityDemo" instance=ExtResource("1")]
+script = ExtResource("2_xypqg")
 
 [node name="XROrigin3D" parent="." index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 36)

--- a/scenes/pointer_demo/pointer_demo.tscn
+++ b/scenes/pointer_demo/pointer_demo.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=14 format=3 uid="uid://deq6satll2p5x"]
+[gd_scene load_steps=15 format=3 uid="uid://deq6satll2p5x"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://3a6wjr3a13vd" path="res://assets/meshes/teleport/teleport.tscn" id="2"]
+[ext_resource type="Script" path="res://scenes/demo_scene_base.gd" id="2_pbiwr"]
 [ext_resource type="PackedScene" uid="uid://rypqa6qcv0st" path="res://assets/maps/basic_map.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://b4kad2kuba1yn" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn" id="3_j5kt2"]
 [ext_resource type="Texture2D" uid="uid://ckw6nliyayo6a" path="res://scenes/main_menu/return to main menu.png" id="4"]
@@ -15,6 +16,7 @@
 [ext_resource type="PackedScene" uid="uid://bk34216s7eynw" path="res://scenes/pointer_demo/objects/color_change_cube.tscn" id="15"]
 
 [node name="PointerDemo" instance=ExtResource("1")]
+script = ExtResource("2_pbiwr")
 
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("3_j5kt2")]
 

--- a/scenes/sphere_world_demo/sphere_world_demo.tscn
+++ b/scenes/sphere_world_demo/sphere_world_demo.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=28 format=3 uid="uid://b5o25nkvyv8ho"]
+[gd_scene load_steps=29 format=3 uid="uid://b5o25nkvyv8ho"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="Material" path="res://assets/wahooney.itch.io/green_grid_triplanar.tres" id="2"]
+[ext_resource type="Script" path="res://scenes/demo_scene_base.gd" id="2_nlk8r"]
 [ext_resource type="PackedScene" uid="uid://diyu06cw06syv" path="res://addons/godot-xr-tools/player/player_body.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://bx1xdisoqo1f6" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/left_tac_glove_low.tscn" id="4"]
 [ext_resource type="Material" uid="uid://p0q2df2dmy62" path="res://addons/godot-xr-tools/hands/materials/ghost_hand.tres" id="4_3wr22"]
@@ -37,6 +38,7 @@ radius = 50.0
 radius = 80.0
 
 [node name="SphereWorldDemo" instance=ExtResource("1")]
+script = ExtResource("2_nlk8r")
 environment = ExtResource("19")
 
 [node name="XROrigin3D" parent="." index="0"]


### PR DESCRIPTION
This pull request modified all demo scenes to use demo_scene_base.gd to support webxr controls. The following scenes were using the default scene_base.gd which does not have the WebXR control-retargeting:
 - Origin Gravity Demo
 - Pointer Demo
 - Sphere World Demo