### PR TITLE
Change environment handling so we can use WorldEnvironment in levels

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,6 @@
+# 4.2.0
+- Environments can now be set normally in scenes loaded through the staging system.
+
 # 4.1.0
 - Enhanced grappling to support collision and target layers
 - Added Godot Editor XR Tools menu for layers and openxr configuration

--- a/addons/godot-xr-tools/staging/scene_base.gd
+++ b/addons/godot-xr-tools/staging/scene_base.gd
@@ -30,13 +30,6 @@ signal request_load_scene(p_scene_path)
 signal request_reset_scene
 
 
-## Environment
-#
-# Here we set the environment we need to set as our world environment
-# once our scene is loaded.
-
-@export var environment : Environment
-
 ## Interface
 
 func _ready() -> void:
@@ -127,14 +120,3 @@ func load_scene(p_scene_path : String) -> void:
 func reset_scene() -> void:
 	emit_signal("request_reset_scene")
 
-
-# Verifies our staging has a valid configuration.
-func _get_configuration_warnings() -> PackedStringArray:
-	var warnings := PackedStringArray()
-
-	# Report missing environment
-	if !environment:
-		warnings.append("No environment specified")
-
-	# Return warnings
-	return warnings

--- a/addons/godot-xr-tools/staging/staging.gd
+++ b/addons/godot-xr-tools/staging/staging.gd
@@ -63,18 +63,6 @@ var current_scene_path : String
 # Tween for fading
 var _tween : Tween
 
-
-## WorldEnvironment
-##
-## You will note that our staging scene has a world environment
-## node included. Godot does not have a mechanism for having
-## multiple world environments in our scene and marking one as
-## active which makes it impractical to embed these in our demo
-## scenes. Instead we will obtain the environment from our demo
-## scene and manage it here. Our world environment at the start
-## belongs to our loading screen and we need to keep a copy.
-@onready var loading_screen_environment = $WorldEnvironment.environment
-
 ## XR Origin
 @onready var xr_origin : XROrigin3D = XRHelpers.get_xr_origin(self)
 
@@ -165,7 +153,6 @@ func load_scene(p_scene_path : String) -> void:
 		xr_origin.set_process_internal(true)
 		xr_origin.current = true
 		xr_camera.current = true
-		$WorldEnvironment.environment = loading_screen_environment
 		$LoadingScreen.progress = 0.0
 		$LoadingScreen.enable_press_to_continue = false
 		$LoadingScreen.follow_camera = true
@@ -226,7 +213,6 @@ func load_scene(p_scene_path : String) -> void:
 	current_scene = new_scene.instantiate()
 	current_scene_path = p_scene_path
 	$Scene.add_child(current_scene)
-	$WorldEnvironment.environment = current_scene.environment
 	_add_signals(current_scene)
 
 	# We create a small delay here to give tracking some time to update our nodes...

--- a/addons/godot-xr-tools/staging/staging.tscn
+++ b/addons/godot-xr-tools/staging/staging.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=10 format=3 uid="uid://bnqnnnet4dw12"]
+[gd_scene load_steps=9 format=3 uid="uid://bnqnnnet4dw12"]
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools/staging/staging.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://bqumugyvkct4r" path="res://addons/godot-xr-tools/staging/loading_screen.tscn" id="2"]
+[ext_resource type="Environment" uid="uid://ckiwtcdsam7ed" path="res://addons/godot-xr-tools/staging/staging_env.tres" id="3_40x3a"]
 [ext_resource type="Shader" path="res://addons/godot-xr-tools/staging/fade.gdshader" id="4"]
 [ext_resource type="PackedScene" path="res://addons/godot-xr-tools/misc/vr_common_shader_cache.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://clc5dre31iskm" path="res://addons/godot-xr-tools/xr/start_xr.tscn" id="6_balvx"]
@@ -13,28 +14,19 @@ size = Vector2(2, 2)
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_snlak"]
 render_priority = 0
 shader = ExtResource("4")
-shader_parameter/alpha = null
-
-[sub_resource type="Sky" id="1"]
-
-[sub_resource type="Environment" id="2"]
-background_mode = 1
-sky = SubResource("1")
+shader_parameter/alpha = 0.0
 
 [node name="Staging" type="Node3D"]
 script = ExtResource("1")
-main_scene = ""
 
 [node name="Fade" type="MeshInstance3D" parent="."]
 mesh = SubResource("4")
 surface_material_override/0 = SubResource("ShaderMaterial_snlak")
 
-[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
-environment = SubResource("2")
-
 [node name="XROrigin3D" type="XROrigin3D" parent="."]
 
 [node name="XRCamera3D" type="XRCamera3D" parent="XROrigin3D"]
+environment = ExtResource("3_40x3a")
 
 [node name="VRCommonShaderCache" parent="XROrigin3D/XRCamera3D" instance=ExtResource("5")]
 

--- a/addons/godot-xr-tools/staging/staging_env.tres
+++ b/addons/godot-xr-tools/staging/staging_env.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Environment" load_steps=2 format=3 uid="uid://ckiwtcdsam7ed"]
+
+[sub_resource type="Sky" id="1"]
+
+[resource]
+background_mode = 1
+sky = SubResource("1")

--- a/assets/maps/basic_map.tscn
+++ b/assets/maps/basic_map.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=6 format=3 uid="uid://rypqa6qcv0st"]
+[gd_scene load_steps=7 format=3 uid="uid://rypqa6qcv0st"]
 
+[ext_resource type="Environment" uid="uid://c75hc5t2ml5re" path="res://demo_env.tres" id="1_d6n2l"]
 [ext_resource type="Material" path="res://assets/wahooney.itch.io/green_grid_triplanar.tres" id="2"]
 
 [sub_resource type="QuadMesh" id="7"]
@@ -15,6 +16,9 @@ size = Vector2(96, 16)
 size = Vector3(100, 16, 2)
 
 [node name="BasicMap" type="Node3D"]
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = ExtResource("1_d6n2l")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.866025, -0.321394, 0.383022, 0, 0.766044, 0.642788, -0.5, -0.55667, 0.663414, 0, 5, 0)

--- a/assets/maps/holodeck_map.tscn
+++ b/assets/maps/holodeck_map.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=10 format=3 uid="uid://ca6c2h3xsflxf"]
+[gd_scene load_steps=11 format=3 uid="uid://ca6c2h3xsflxf"]
 
+[ext_resource type="Environment" uid="uid://bacqoq62qs27y" path="res://assets/maps/holodeck/holodeck_env.tres" id="1_ggqvk"]
 [ext_resource type="Material" uid="uid://bhchqeutlu0os" path="res://assets/maps/holodeck/materials/floor.material" id="1_w8tvf"]
 [ext_resource type="Material" uid="uid://c5no820h1vdbl" path="res://assets/maps/holodeck/materials/holodeck_grid.material" id="2_bu2ws"]
 [ext_resource type="PackedScene" uid="uid://ca4dy4a8x7myp" path="res://assets/maps/holodeck/holodeck_wall.tscn" id="2_eifp0"]
@@ -24,6 +25,9 @@ metallic = 1.0
 roughness = 0.3
 
 [node name="HolodeckMap" type="Node3D"]
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = ExtResource("1_ggqvk")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.814705, -0.576268, -0.0645869, 0.185005, 0.152748, 0.970794, -0.549572, -0.802859, 0.231057, 0, 5.09148, 0)

--- a/demo_staging.tscn
+++ b/demo_staging.tscn
@@ -8,7 +8,7 @@
 script = ExtResource("2")
 main_scene = "res://scenes/main_menu/main_menu_level.tscn"
 
-[node name="LoadingScreen" parent="." index="3"]
+[node name="LoadingScreen" parent="." index="2"]
 splash_screen = ExtResource("3_2an2h")
 
 [connection signal="scene_exiting" from="." to="." method="_on_Staging_scene_exiting"]

--- a/scenes/basic_movement_demo/basic_movement_demo.tscn
+++ b/scenes/basic_movement_demo/basic_movement_demo.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=17 format=3 uid="uid://bbcamgruwhrq4"]
+[gd_scene load_steps=16 format=3 uid="uid://bbcamgruwhrq4"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="Script" path="res://scenes/demo_scene_base.gd" id="2_5ptmo"]
 [ext_resource type="PackedScene" uid="uid://b4kad2kuba1yn" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn" id="2_54yy3"]
-[ext_resource type="Environment" uid="uid://bacqoq62qs27y" path="res://assets/maps/holodeck/holodeck_env.tres" id="3_xhf7c"]
 [ext_resource type="PackedScene" uid="uid://b6bk2pj8vbj28" path="res://addons/godot-xr-tools/functions/movement_turn.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://bl2nuu3qhlb5k" path="res://addons/godot-xr-tools/functions/movement_direct.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://clt88d5d1dje4" path="res://addons/godot-xr-tools/functions/movement_crouch.tscn" id="5_2ekvc"]
@@ -19,7 +18,6 @@
 
 [node name="BasicMovementDemo" instance=ExtResource("1")]
 script = ExtResource("2_5ptmo")
-environment = ExtResource("3_xhf7c")
 
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("2_54yy3")]
 

--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=3]
+[gd_scene load_steps=25 format=3 uid="uid://40a3andy74bw"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="Script" path="res://scenes/demo_scene_base.gd" id="2_nosao"]
@@ -31,9 +31,11 @@ size = Vector3(200, 1, 200)
 
 [node name="ClimbingGlidingDemo" instance=ExtResource("1")]
 script = ExtResource("2_nosao")
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="." index="0"]
 environment = ExtResource("3_tyrna")
 
-[node name="XROrigin3D" parent="." index="0"]
+[node name="XROrigin3D" parent="." index="1"]
 transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -89, 36, -65)
 
 [node name="XRCamera3D" parent="XROrigin3D" index="0"]
@@ -72,11 +74,11 @@ wings_impulse = true
 
 [node name="MovementWind" parent="XROrigin3D" index="6" instance=ExtResource("22")]
 
-[node name="DirectionalLight3D" type="DirectionalLight3D" parent="." index="1"]
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="." index="2"]
 transform = Transform3D(0.866025, -0.321394, 0.383022, 0, 0.766044, 0.642788, -0.5, -0.55667, 0.663414, 0, 5, 0)
 light_energy = 0.8
 
-[node name="Terrain" type="Node3D" parent="." index="2"]
+[node name="Terrain" type="Node3D" parent="." index="3"]
 
 [node name="Ground" type="StaticBody3D" parent="Terrain" index="0"]
 
@@ -224,15 +226,15 @@ transform = Transform3D(-0.999976, 0, 0.00698123, 0, 1, 0, -0.00698123, 0, -0.99
 [node name="ring6" parent="Terrain/Rings" index="5" instance=ExtResource("18_gu236")]
 transform = Transform3D(-0.880477, 0, -0.474088, 0, 1, 0, 0.474088, 0, -0.880477, -47.65, 14.547, -50.234)
 
-[node name="MainMenuTeleport1" parent="." index="3" instance=ExtResource("14")]
+[node name="MainMenuTeleport1" parent="." index="4" instance=ExtResource("14")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -83, 36, -68)
 scene_base = NodePath("..")
 title = ExtResource("13")
 
-[node name="MainMenuTeleport2" parent="." index="4" instance=ExtResource("14")]
+[node name="MainMenuTeleport2" parent="." index="5" instance=ExtResource("14")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 91, 6, 81)
 scene_base = NodePath("..")
 title = ExtResource("13")
 
-[node name="Instructions" parent="." index="5" instance=ExtResource("19_3dxda")]
+[node name="Instructions" parent="." index="6" instance=ExtResource("19_3dxda")]
 transform = Transform3D(-0.5, 0, -0.866025, 0, 1, 0, 0.866025, 0, -0.5, -80, 40, -60)

--- a/scenes/grappling_demo/grappling_demo.tscn
+++ b/scenes/grappling_demo/grappling_demo.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=20 format=3]
+[gd_scene load_steps=19 format=3 uid="uid://bgfw0stwelkt8"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://c78tjrtiyqna8" path="res://addons/godot-xr-tools/functions/movement_grapple.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://b4kad2kuba1yn" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn" id="2_7xgbg"]
 [ext_resource type="Script" path="res://scenes/demo_scene_base.gd" id="2_lm0po"]
 [ext_resource type="PackedScene" uid="uid://bl2nuu3qhlb5k" path="res://addons/godot-xr-tools/functions/movement_direct.tscn" id="3"]
-[ext_resource type="Environment" uid="uid://c75hc5t2ml5re" path="res://demo_env.tres" id="3_kijvh"]
 [ext_resource type="PackedScene" uid="uid://bxm1ply47vaan" path="res://addons/godot-xr-tools/functions/movement_climb.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://c2q5phg8w08o" path="res://addons/godot-xr-tools/functions/movement_jump.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://l2n30mpbkdyw" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/right_hand_low.tscn" id="6_n2v2n"]
@@ -17,12 +16,11 @@
 [ext_resource type="PackedScene" uid="uid://rypqa6qcv0st" path="res://assets/maps/basic_map.tscn" id="13"]
 [ext_resource type="PackedScene" uid="uid://3a6wjr3a13vd" path="res://assets/meshes/teleport/teleport.tscn" id="14"]
 [ext_resource type="Texture2D" uid="uid://ckw6nliyayo6a" path="res://scenes/main_menu/return to main menu.png" id="15"]
-[ext_resource type="PackedScene" path="res://scenes/grappling_demo/objects/instructions.tscn" id="15_vd3ki"]
+[ext_resource type="PackedScene" uid="uid://dkueenih28eux" path="res://scenes/grappling_demo/objects/instructions.tscn" id="15_vd3ki"]
 [ext_resource type="PackedScene" uid="uid://lelocs2v705t" path="res://scenes/grappling_demo/objects/tower.tscn" id="18"]
 
 [node name="GrapplingDemo" instance=ExtResource("1")]
 script = ExtResource("2_lm0po")
-environment = ExtResource("3_kijvh")
 
 [node name="XROrigin3D" parent="." index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 28)

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=39 format=3 uid="uid://037lluf8eoy6"]
+[gd_scene load_steps=38 format=3 uid="uid://037lluf8eoy6"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="Script" path="res://scenes/main_menu/main_menu_level.gd" id="2_taoax"]
-[ext_resource type="Environment" uid="uid://bacqoq62qs27y" path="res://assets/maps/holodeck/holodeck_env.tres" id="3_0xm8i"]
 [ext_resource type="PackedScene" path="res://addons/godot-xr-tools/player/poke/poke.tscn" id="4_eoo0b"]
 [ext_resource type="PackedScene" uid="uid://b6bk2pj8vbj28" path="res://addons/godot-xr-tools/functions/movement_turn.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://bft3xyxs31ci3" path="res://addons/godot-xr-tools/functions/function_pose_detector.tscn" id="5_xgcrx"]
@@ -27,71 +26,70 @@
 [ext_resource type="Texture2D" uid="uid://cr1l4g7btdyht" path="res://scenes/origin_gravity_demo/origin_gravity_demo.png" id="32_c4n1q"]
 [ext_resource type="Texture2D" uid="uid://dhd30j0xpcxoi" path="res://scenes/sphere_world_demo/sphere_world_demo.png" id="34_xw8ig"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vmitg"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_u2mxq"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_gubek"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_7ujqy"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_v4ab2"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_5lab8"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_hu43a"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_esobn"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_cp8md"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_6o1kb"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_vlpqb"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_t0l3n"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_vmitg")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_u2mxq")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_gubek")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_7ujqy")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_v4ab2")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_5lab8")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_hu43a")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_esobn")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_cp8md")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_6o1kb")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_gvmwk"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_81ik1"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_74gdh"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_n4op0"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_3i57j"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_akylf"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vc26w"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_oha8x"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ulbr7"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_j08be"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_acpf2"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_rw4m4"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_gvmwk")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_81ik1")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_74gdh")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_n4op0")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_3i57j")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_akylf")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_vc26w")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_oha8x")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_ulbr7")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_j08be")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
 [node name="MainMenuLevel" instance=ExtResource("1")]
 script = ExtResource("2_taoax")
-environment = ExtResource("3_0xm8i")
 
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("23_pr05t")]
 
@@ -125,7 +123,7 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_vlpqb")
+tree_root = SubResource("AnimationNodeBlendTree_t0l3n")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("5_xgcrx")]
 
@@ -167,7 +165,7 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_acpf2")
+tree_root = SubResource("AnimationNodeBlendTree_rw4m4")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5_xgcrx")]
 

--- a/scenes/origin_gravity_demo/origin_gravity_demo.tscn
+++ b/scenes/origin_gravity_demo/origin_gravity_demo.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=23 format=3]
+[gd_scene load_steps=22 format=3 uid="uid://dgk4405uicrgh"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://rypqa6qcv0st" path="res://assets/maps/basic_map.tscn" id="2"]
 [ext_resource type="Script" path="res://scenes/demo_scene_base.gd" id="2_xypqg"]
 [ext_resource type="Material" path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" id="3"]
-[ext_resource type="Environment" uid="uid://c75hc5t2ml5re" path="res://demo_env.tres" id="3_ejami"]
 [ext_resource type="PackedScene" uid="uid://diyu06cw06syv" path="res://addons/godot-xr-tools/player/player_body.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://c2q5phg8w08o" path="res://addons/godot-xr-tools/functions/movement_jump.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://b6bk2pj8vbj28" path="res://addons/godot-xr-tools/functions/movement_turn.tscn" id="6"]
@@ -38,7 +37,6 @@ point_count = 5
 
 [node name="OriginGravityDemo" instance=ExtResource("1")]
 script = ExtResource("2_xypqg")
-environment = ExtResource("3_ejami")
 
 [node name="XROrigin3D" parent="." index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 36)

--- a/scenes/sphere_world_demo/sphere_world_demo.tscn
+++ b/scenes/sphere_world_demo/sphere_world_demo.tscn
@@ -39,9 +39,11 @@ radius = 80.0
 
 [node name="SphereWorldDemo" instance=ExtResource("1")]
 script = ExtResource("2_nlk8r")
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="." index="0"]
 environment = ExtResource("19")
 
-[node name="XROrigin3D" parent="." index="0"]
+[node name="XROrigin3D" parent="." index="1"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 50, 0)
 
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("4")]
@@ -87,27 +89,27 @@ grapple_collision_mask = 3
 
 [node name="MovementWallWalk" parent="XROrigin3D" index="7" instance=ExtResource("12")]
 
-[node name="Teleport1" parent="." index="1" instance=ExtResource("20")]
+[node name="Teleport1" parent="." index="2" instance=ExtResource("20")]
 transform = Transform3D(-4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0, 1, 49.9, 0, 0)
 scene_base = NodePath("..")
 title = ExtResource("21")
 
-[node name="Teleport2" parent="." index="2" instance=ExtResource("20")]
+[node name="Teleport2" parent="." index="3" instance=ExtResource("20")]
 transform = Transform3D(1.91069e-15, -4.37114e-08, 1, -1, -4.37114e-08, 0, 4.37114e-08, -1, -4.37114e-08, 0, 0, -49.9)
 scene_base = NodePath("..")
 title = ExtResource("21")
 
-[node name="Teleport3" parent="." index="3" instance=ExtResource("20")]
+[node name="Teleport3" parent="." index="4" instance=ExtResource("20")]
 transform = Transform3D(4.37114e-08, -1, -8.74228e-08, -1, -4.37114e-08, 0, -3.82137e-15, 8.74228e-08, -1, -49.9, 0, 0)
 scene_base = NodePath("..")
 title = ExtResource("21")
 
-[node name="Teleport4" parent="." index="4" instance=ExtResource("20")]
+[node name="Teleport4" parent="." index="5" instance=ExtResource("20")]
 transform = Transform3D(-5.73206e-15, 1.31134e-07, -1, -1, -4.37114e-08, 0, -4.37114e-08, 1, 1.31134e-07, 0, 0, 49.9)
 scene_base = NodePath("..")
 title = ExtResource("21")
 
-[node name="World" type="Node3D" parent="." index="5"]
+[node name="World" type="Node3D" parent="." index="6"]
 
 [node name="Body" type="StaticBody3D" parent="World" index="0"]
 collision_layer = 8
@@ -160,6 +162,6 @@ transform = Transform3D(0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, 0.707107, 
 [node name="Donut2" parent="World" index="11" instance=ExtResource("23_nox6a")]
 transform = Transform3D(0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, 0, 49.5, 0)
 
-[node name="DirectionalLight" type="DirectionalLight3D" parent="." index="6"]
+[node name="DirectionalLight" type="DirectionalLight3D" parent="." index="7"]
 transform = Transform3D(1, 0, 0, 0, 0.258819, 0.965926, 0, -0.965926, 0.258819, 0, 60, 0)
 light_energy = 0.8

--- a/scenes/sprinting_demo/sprinting_demo.tscn
+++ b/scenes/sprinting_demo/sprinting_demo.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=23 format=3]
+[gd_scene load_steps=22 format=3 uid="uid://7lfa2oytnw7o"]
 
 [ext_resource type="PackedScene" uid="uid://c2q5phg8w08o" path="res://addons/godot-xr-tools/functions/movement_jump.tscn" id="1"]
 [ext_resource type="Script" path="res://scenes/demo_scene_base.gd" id="2_5a8oj"]
-[ext_resource type="Environment" uid="uid://c75hc5t2ml5re" path="res://demo_env.tres" id="3_27am1"]
 [ext_resource type="PackedScene" uid="uid://rypqa6qcv0st" path="res://assets/maps/basic_map.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="6"]
 [ext_resource type="PackedScene" uid="uid://b4kad2kuba1yn" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn" id="7"]
@@ -20,7 +19,7 @@
 [ext_resource type="PackedScene" path="res://scenes/sprinting_demo/objects/ramp.tscn" id="17"]
 [ext_resource type="PackedScene" uid="uid://diyu06cw06syv" path="res://addons/godot-xr-tools/player/player_body.tscn" id="17_k8kqb"]
 [ext_resource type="PackedScene" path="res://scenes/sprinting_demo/objects/climbing_wall.tscn" id="18"]
-[ext_resource type="PackedScene" path="res://scenes/sprinting_demo/objects/instructions.tscn" id="19"]
+[ext_resource type="PackedScene" uid="uid://d2bvjxai7dke8" path="res://scenes/sprinting_demo/objects/instructions.tscn" id="19"]
 
 [sub_resource type="Curve3D" id="1"]
 bake_interval = 2.0
@@ -32,7 +31,6 @@ point_count = 7
 
 [node name="SprintingDemo" instance=ExtResource("6")]
 script = ExtResource("2_5a8oj")
-environment = ExtResource("3_27am1")
 
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("7")]
 hand_material_override = ExtResource("12")


### PR DESCRIPTION
This PR is a simplification of the way we use environments with the added benefit that we see the correct environment when editing levels.

Instead of us using an environment set on our base scene and assigning this to a world environment through code, our level scenes now have their own world environment. This is now possible as we're no longer using the XROrigin/XRCamera setup in staging but expect each level to configure their own player setup.

Our staging scene uses an environment set on the XRCamera that overrule any currently loaded world environment and ensures our loading scene has a black background. This is the only environment not seen in the IDE when editing.

To further simplify things, the holodeck map scene now contains a world environment with the holodeck environment. This ensures that levels using the holodeck automatically use the correct environment.
Similarly our basic map scene now has a world environment with our demo environment set.

The spherical world has it's own world environment and there are one or two other levels that use the demo environment without using the basic map.

This is a minor breaking change for existing games that use XR Tools and rely on the staging system.