### PR TITLE
Collision Hand and Two Handed - Demo

### DIFF
--- a/addons/godot-xr-tools/objects/collision_hand/collision_hand.gd
+++ b/addons/godot-xr-tools/objects/collision_hand/collision_hand.gd
@@ -1,0 +1,213 @@
+@tool
+class_name XRToolsCollisionHand
+extends CharacterBody3D
+
+#
+# adds collision capabilities to open_xr hands and held objects
+#
+# REQUIRES SETUP:
+# 1) Parent must be ARVROrigin (NOT THE ARVRControllers!)
+# 2) All export NodePaths must be set
+# 3) PhysicsHand and PickupFunction are expected to be children of the controller
+# 4) Held objects may have a get_collider_dict() function to inform
+#    THIS of what colliders it has and their orientation. Dictionary format:
+#    collision_dict = {CollisionShape : Transform, CollisionShape : Transform, ...}
+# 5) Make note of collision layers, do not let the hands collide with whatever
+#    body system you are using
+#
+# THIS addition acts a KinematicBody that "chases" the controller THIS is assigned
+# to. THIS has a simple CollisionShape to simulate the empty hand and will copy
+# the CollisionShapes of held objects and add them to THIS as children; then it
+# will delete the copied CollisionShapes on drop.
+
+@export var controller_path : NodePath
+# On Godot-XR-Dojo Avatar, this will be the "PhysicsHand"
+@export var visual_hand_path : NodePath #Should be child of ARVRController
+@export var pickup_path : NodePath #Should be child of ARVRController
+
+## if set to true, pickable objects will have collision
+@export var pickable_collision : bool = false
+
+@export var is_left_controller : bool = false
+
+## Distance before dropping when stuck
+@export var max_distance : float = 0.2
+
+@export var slide_speed : float = 30.0
+@onready var collision_offset_left : Vector3 = Vector3(-0.029,-0.051,0.129)
+@onready var collision_offset_right : Vector3 = Vector3(0.029,-0.051,0.129)
+
+@onready var controller : XRController3D = get_node(controller_path)
+@onready var visual_hand = get_node(visual_hand_path)
+@onready var pickup = get_node(pickup_path)
+@onready var hand_shape : CollisionShape3D = $HandShape
+
+@onready var hr_transform : RemoteTransform3D = $HandRemoteTransform3D
+@onready var pr_transform : RemoteTransform3D = $PickupRemoteTransform3D
+
+# check for collision when twohanded object is picked up
+var twohanded_collision : bool = false
+var collision
+
+# List of colliders added by grabbed objects
+var collider_list : Array = [] 
+var held_body : PhysicsBody3D
+var _what 
+var _collider
+var two_handed
+var col_dict : Dictionary
+var _mass
+
+
+# Add support for is_xr_class on XRTools classes
+func is_xr_class(name : String) -> bool:
+	return name == "XRToolsCollisionHand"
+
+
+func _ready():
+	if is_left_controller:
+		hand_shape.transform.origin = collision_offset_left
+	else:
+		hand_shape.transform.origin = collision_offset_right
+
+	# Connects Remote Transforms to targets
+	hr_transform.set_transform(visual_hand.get_transform())
+	hr_transform.remote_path = visual_hand.get_path()
+	pr_transform.set_transform(pickup.get_transform())
+	pr_transform.remote_path = pickup.get_path()
+	
+	# Connects signals for grabbing and dropping from pickup function
+	if pickable_collision:
+		pickup.has_picked_up.connect(add_colliders)
+		pickup.has_dropped.connect(remove_colliders)
+
+
+func _physics_process(delta):
+	# Do not initialise if in the editor
+	if Engine.is_editor_hint():
+		return
+
+	if is_instance_valid(held_body):
+		if twohanded_collision:
+			two_handed = held_body.get_node("TwoHanded")
+			if two_handed.using_two_handed:
+				_collider.global_transform = controller.global_transform.looking_at(two_handed.second_hand_controller.global_transform.origin,Vector3.UP)
+
+				## by setting translate self to the get_active_grab_point we get the pickable
+				## positioned correctly when being held with twohands
+				_collider.translate(Vector3(0,0,0)- held_body.get_active_grab_point().transform.origin)
+			else:
+				_collider.global_transform = controller.global_transform
+				_collider.translate(Vector3(0,0,0)- held_body.get_active_grab_point().transform.origin)
+
+	move_to(controller)
+	check_for_drop()
+
+
+# With collision, move self toward target
+func move_to(target : Node) -> void:
+	var t_pos : Vector3 = target.global_transform.origin #Target Position
+	var s_pos : Vector3 = self.global_transform.origin #Self Position
+	
+	var dir : Vector3 = t_pos - s_pos #Move Direction
+	if is_instance_valid(held_body):
+		_mass = held_body.mass
+	else:
+		_mass = 1
+	velocity = dir * slide_speed# _mass ## by removing slide_speed or substituting it, a zero g or weighted/velocity based hand could be achieved
+	move_and_slide()
+	self.set_rotation(controller.rotation)
+
+
+# Checks if held object is too far to be held and drops it if true
+func check_for_drop() -> void:
+	if is_instance_valid(held_body):
+		_check_extended()
+	else:
+		_check()
+
+
+func _check_extended():
+	if held_body.has_node("TwoHanded"):
+		two_handed = held_body.get_node("TwoHanded")
+		if two_handed.using_two_handed:
+			var c_pos = controller.global_transform.origin #Controller Position
+			var s_pos = self.global_transform.origin #Self Position
+			
+			var face_pos = two_handed.second_hand_controller.global_transform.origin #TwoHanded - Second Controller Position
+			var s_dist = s_pos.distance_to(face_pos)
+			var c_dist = c_pos.distance_to(face_pos)
+
+			if s_dist > c_dist + max_distance: #If object too far from face
+				pickup.drop_object()
+				remove_colliders()
+				self.transform = controller.transform
+		else:
+			_check()
+	else:
+		_check()
+
+
+func _check():
+	var c_pos = controller.global_transform.origin #Controller Position
+	var s_pos = self.global_transform.origin #Self Position
+
+	var face_pos = self.get_parent().global_transform.origin
+	var s_dist = s_pos.distance_to(face_pos)
+	var c_dist = c_pos.distance_to(face_pos)
+
+	if s_dist > c_dist + max_distance: #If object too far from face
+		pickup.drop_object()
+		remove_colliders()
+		self.transform = controller.transform
+
+
+# Requests a dictionary of CollisionShapes with Transforms from Spatial object
+# for holding; else finds all CollisionShape children
+# Format: {CollisionShape : Transform, CollisionShape : Transform,...}
+func add_colliders(_what : Node3D) -> void:
+	if is_instance_valid(_what):
+		if _what.has_node("TwoHanded"):
+			twohanded_collision = true
+			#two_handed = _what.get_node("TwoHanded")
+			col_dict = _what.get_node("TwoHanded").get_collider_dict()
+			for key in col_dict.keys():
+				_collider = key.duplicate()
+				_collider.transform = col_dict[key]
+				collider_list.append(_collider)
+				self.add_child(_collider)
+			held_body = _what
+			self.add_collision_exception_with(held_body)
+		if  _what.has_node("PickableCollision"):
+			twohanded_collision = false
+			#two_handed = _what.get_node("TwoHanded")
+			col_dict = _what.get_node("PickableCollision").get_collider_dict()
+			for key in col_dict.keys():
+				_collider = key.duplicate()
+				_collider.transform = col_dict[key]
+				collider_list.append(_collider)
+				self.add_child(_collider)
+			held_body = _what
+			self.add_collision_exception_with(held_body)
+
+
+# Delete colliders used for held object
+func remove_colliders() -> void:
+	if twohanded_collision:
+		twohanded_collision = false
+	for col in collider_list:
+		col.queue_free()
+	collider_list = []
+	if is_instance_valid(held_body):
+		self.remove_collision_exception_with(held_body)
+
+
+## Find an [XRToolsPlayerBody] node.
+##
+## This function searches from the specified node for an [XRToolsPlayerBody]
+## assuming the node is a sibling of the body under an [XROrigin3D].
+static func find_instance(node: Node) -> XRToolsCollisionHand:
+	return XRTools.find_xr_child(
+		XRHelpers.get_xr_origin(node),
+		"*",
+		"XRToolsCollisionHand") as XRToolsCollisionHand

--- a/addons/godot-xr-tools/objects/collision_hand/collision_hand.tscn
+++ b/addons/godot-xr-tools/objects/collision_hand/collision_hand.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=3 format=3 uid="uid://dbw0gg1qiltl0"]
+
+[ext_resource type="Script" path="res://addons/godot-xr-tools/objects/collision_hand/collision_hand.gd" id="1_4gpnm"]
+
+[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_fnt54"]
+radius = 0.0291045
+height = 0.097935
+
+[node name="CollisionHand" type="CharacterBody3D"]
+collision_layer = 268435456
+collision_mask = 268435457
+floor_constant_speed = true
+platform_on_leave = 1
+script = ExtResource("1_4gpnm")
+
+[node name="HandShape" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.029, -0.051, 0.129)
+shape = SubResource("CapsuleShape3D_fnt54")
+
+[node name="HandRemoteTransform3D" type="RemoteTransform3D" parent="."]
+
+[node name="PickupRemoteTransform3D" type="RemoteTransform3D" parent="."]

--- a/addons/godot-xr-tools/objects/collision_hand/pickable_collision/pickable_collision.gd
+++ b/addons/godot-xr-tools/objects/collision_hand/pickable_collision/pickable_collision.gd
@@ -1,0 +1,21 @@
+class_name XRToolsPickableCollision
+extends Node
+
+
+@onready var _parent : XRToolsPickable = get_parent()
+@export var collision_offset_left : Vector3 = Vector3(-0.029,-0.051,0.129)
+@export var collision_offset_right : Vector3 = Vector3(0.029,-0.051,0.129)
+var collision
+
+
+# Add support for is_xr_class on XRTools classes
+func is_xr_class(name : String) -> bool:
+	return name == "XRToolsPickableCollision"
+
+
+func get_collider_dict():
+	collision = _parent.get_node("CollisionShape3D")
+	var _correction = _parent.get_active_grab_point().transform.origin
+	var shape_translate = _parent.get_active_grab_point().transform * collision_offset_right - collision.transform.origin * 2
+	var shape_transform = Transform3D(_parent.get_active_grab_point().transform.basis, shape_translate)
+	return {collision : shape_transform}

--- a/addons/godot-xr-tools/objects/collision_hand/pickable_collision/pickable_collision.tscn
+++ b/addons/godot-xr-tools/objects/collision_hand/pickable_collision/pickable_collision.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://cj0ohmnxlfemk"]
+
+[ext_resource type="Script" path="res://addons/godot-xr-tools/objects/collision_hand/pickable_collision/pickable_collision.gd" id="1_7fwev"]
+
+[node name="PickableCollision" type="Node3D"]
+script = ExtResource("1_7fwev")

--- a/addons/godot-xr-tools/objects/two_handed/two_handed.gd
+++ b/addons/godot-xr-tools/objects/two_handed/two_handed.gd
@@ -1,0 +1,146 @@
+class_name XRToolsTwoHanded
+extends Node
+
+
+@export var interactable_handle : XRToolsInteractableHandle
+@export var second_hand_position : Marker3D
+@export var primary_hand_position : Marker3D
+# Check if is melee
+@export var melee : bool = false
+
+@onready var _parent : XRToolsPickable = get_parent()
+# Check if using two-handed
+var using_two_handed : bool = false
+
+# Store second hand controller
+var second_hand_controller : XRController3D
+# Store second hand node
+var second_hand
+# Store weapon basis just before two-handing
+var basis_before_two_handed : Basis
+# Store primary hand node's transform as it was before two handing
+var primary_hand_original_transform : Transform3D
+# Store second hand node's transform as it was before two handing
+var second_hand_original_transform :Transform3D
+var collision
+## Left hand XRController3D node
+@onready var left_hand_node : XRController3D = XRHelpers.get_left_controller(self)
+
+## Right hand XRController3D node
+@onready var right_hand_node : XRController3D = XRHelpers.get_right_controller(self)
+
+
+# Add support for is_xr_class on XRTools classes
+func is_xr_class(name : String) -> bool:
+	return name == "XRToolsTwoHanded"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	# Store default transform basis
+	basis_before_two_handed = get_parent().transform.basis
+	interactable_handle.transform.origin = Vector3(0,0,0)
+	_parent.picked_up.connect(_on_picked_up)
+	_parent.dropped.connect(_on_dropped)
+	# Connect grabbed and dropped signal from interactable handle for two handed if there is a handle
+	interactable_handle.picked_up.connect(_on_second_hand_grabbed)
+	interactable_handle.dropped.connect(_on_second_hand_dropped)
+
+
+func _process(delta):
+	# If two handed activated, change transform to be guided by both hand positions
+	if using_two_handed and !melee:
+		_correct_alignment()
+	else:
+		pass
+
+func _on_second_hand_grabbed(_handle):
+	# Don't activate two handed mode if not already picked up
+	if !_parent.is_picked_up():
+		return
+	# If item is already picked up, then we're in two-handed mode
+	if _parent.is_picked_up() and _parent.by_controller != null:
+		second_hand_controller = _handle.by_controller
+		second_hand = _handle.by_hand
+		second_hand_original_transform = _handle.by_hand.transform
+		primary_hand_original_transform = _parent.by_hand.transform
+		if second_hand.name.matchn("*left*"):
+			primary_hand_position.transform = _parent.get_node("GrabPointHandRight").transform
+		else:
+			primary_hand_position.transform = _parent.get_node("GrabPointHandLeft").transform
+		if second_hand_position != null:
+			second_hand_position.get_node("RemoteTransform3D").remote_path = _handle.by_hand.get_path()
+		if primary_hand_position != null:	
+			primary_hand_position.get_node("RemoteTransform3D").remote_path = _parent.by_hand.get_path()
+		using_two_handed = true
+		#collision.global_transform = second_hand_controller.global_transform
+		#collision.translate(Vector3(0,0,0)- _parent.get_active_grab_point().transform.origin) 
+# Called when this object is picked up
+func _on_picked_up(_pickable) -> void:
+	_parent.by_controller = _parent.get_picked_up_by_controller()
+	if _parent.by_controller:
+		interactable_handle.transform.origin = Vector3(0,0,0)
+		# Switch the grab point
+		var active_grab_point := _parent.get_active_grab_point()
+		if active_grab_point == $GrabPointHandLeft:
+			_parent.switch_active_grab_point($GrabPointGripLeft)
+		elif active_grab_point == $GrabPointHandRight:
+			_parent.switch_active_grab_point($GrabPointGripRight)
+		elif active_grab_point == $GrabPointGripLeft:
+			_parent.switch_active_grab_point($GrabPointHandLeft)
+		elif active_grab_point == $GrabPointGripRight:
+			_parent.switch_active_grab_point($GrabPointHandRight)		
+		#by_hand.transform.origin = active_grab_point.transform.origin
+
+# Called when this object is dropped
+func _on_dropped(_pickable) -> void:
+	# If not using two handed, do nothing
+	if !using_two_handed:
+		return
+	else:
+		using_two_handed = false
+	# Return to single handed mode
+	primary_hand_position.get_node("RemoteTransform3D").remote_path = ""
+	second_hand_position.get_node("RemoteTransform3D").remote_path = ""
+	second_hand.transform = second_hand_original_transform
+	second_hand_controller = null
+	second_hand = null
+	if _parent.by_controller:
+		_parent.by_controller = null
+		_parent.transform.basis = basis_before_two_handed
+		interactable_handle.transform.origin = Vector3(0,0,0)
+
+func _on_second_hand_dropped(_handle):
+	# If not using two handed, do nothing
+	if !using_two_handed:
+		return
+	else:
+		using_two_handed = false
+	# Return to single handed mode
+	primary_hand_position.get_node("RemoteTransform3D").remote_path = ""
+	second_hand_position.get_node("RemoteTransform3D").remote_path = ""
+	_parent.by_hand.transform = primary_hand_original_transform
+	second_hand.transform = second_hand_original_transform
+	second_hand_controller = null
+	second_hand = null
+	if _parent.is_picked_up() and _parent.by_controller != null:
+		_parent.transform.basis = basis_before_two_handed
+
+
+func _correct_alignment():
+	## by_controller as in the controller that picked up the pickable first is being set to looking_at the second hand controller
+	## this way we get the twohanded working but without the self.translate the twohanded will be displaced because of the
+	## grabpoints
+	_parent.global_transform = _parent.by_controller.global_transform.looking_at(second_hand_controller.global_transform.origin,Vector3.UP)
+
+	## by setting translate self to the get_active_grab_point we get the pickable
+	## positioned correctly when being held with twohands
+	_parent.translate(Vector3(0,0,0)- _parent.get_active_grab_point().transform.origin) 
+
+
+func get_collider_dict():
+	collision = _parent.get_node("CollisionShape3D")
+	var _correction = _parent.get_active_grab_point().transform.origin
+	var shape_translate = _parent.get_active_grab_point().transform * collision.transform.origin - _correction * 2
+	var shape_transform = Transform3D(_parent.get_active_grab_point().transform.basis, shape_translate)
+	return {collision : shape_transform}


### PR DESCRIPTION
**_About:_**
this currently is a barebones setup, that will hopfefuly end up in a demo scene to showcase how to use the above
currently it is not useable in production as it has some issues that would prevent it from being used properly

Anyways here is a quick rundown on how to add the collision hands, as right now there is no demo scene.



**_HowTo:_**
add the collision hand two times under ur xr origing and select the nodes depending on left and right controllers
![grafik](https://github.com/GodotVR/godot-xr-tools/assets/56046022/3843dc8a-1d81-45b6-856a-f50eb7e5fcfe)

if u want to have collision on pickable objects as well, check the pickable_collision mark on the collision hand
and instantiate a PickableCollision.tscn to the pickable object like so

![grafik](https://github.com/GodotVR/godot-xr-tools/assets/56046022/342fe129-a696-4249-bde5-7606189f7e63)

**_Known Bugs:_**
1) Pickable_Collision shapes are off
2) TwoHanded is getting dropped too fast, needs a way to make this not happen that fast or disable when held with two hands?...
3) if holding a pickable with each hands and those get in contact with each other, they slow down the whole session... will need some further investigation