### PR TITLE
Refactor player height adjustment

### DIFF
--- a/addons/godot-xr-tools/user_settings/user_settings.gd
+++ b/addons/godot-xr-tools/user_settings/user_settings.gd
@@ -12,6 +12,8 @@ enum WebXRPrimary {
 }
 
 
+@export_group("Input")
+
 ## User setting for snap-turn
 @export var snap_turning : bool = true
 
@@ -21,8 +23,12 @@ enum WebXRPrimary {
 ## User setting for y axis dead zone
 @export var x_axis_dead_zone : float = 0.2
 
-## User setting for player height adjust
-@export var player_height_adjust : float = 0.0: set = set_player_height_adjust
+@export_group("Player")
+
+## User setting for player height
+@export var player_height : float = 1.85: set = set_player_height
+
+@export_group("WebXR")
 
 ## User setting for WebXR primary
 @export var webxr_primary : WebXRPrimary = WebXRPrimary.AUTO: set = set_webxr_primary
@@ -46,17 +52,18 @@ func _ready():
 
 ## Reset to default values
 func reset_to_defaults() -> void:
-	# Reset to defaults
+	# Reset to defaults.
+	# Where applicable we obtain our project settings
 	snap_turning = XRTools.get_default_snap_turning()
 	y_axis_dead_zone = XRTools.get_y_axis_dead_zone()
 	x_axis_dead_zone = XRTools.get_x_axis_dead_zone()
-	player_height_adjust = 0.0
+	player_height = XRTools.get_player_standard_height()
 	webxr_primary = WebXRPrimary.AUTO
 	webxr_auto_primary = 0
 
-## Set the player height adjust property
-func set_player_height_adjust(new_value : float) -> void:
-	player_height_adjust = clamp(new_value, -1.0, 1.0)
+## Set the player height property
+func set_player_height(new_value : float) -> void:
+	player_height = clamp(new_value, 1.0, 2.5)
 
 ## Set the WebXR primary
 func set_webxr_primary(new_value : WebXRPrimary) -> void:
@@ -88,7 +95,7 @@ func save() -> void:
 			"x_axis_dead_zone" : x_axis_dead_zone
 		},
 		"player" : {
-			"height_adjust" : player_height_adjust
+			"height" : player_height
 		},
 		"webxr" : {
 			"webxr_primary" : webxr_primary,
@@ -161,8 +168,8 @@ func _load() -> void:
 	# Parse our player settings
 	if settings.has("player"):
 		var player : Dictionary = settings["player"]
-		if player.has("height_adjust"):
-			player_height_adjust = player["height_adjust"]
+		if player.has("height"):
+			player_height = player["height"]
 
 	# Parse our WebXR settings
 	if settings.has("webxr"):

--- a/addons/godot-xr-tools/user_settings/user_settings_ui.gd
+++ b/addons/godot-xr-tools/user_settings/user_settings_ui.gd
@@ -1,20 +1,24 @@
 extends TabContainer
 
-@export_node_path("XRCamera3D") var camera
+signal player_height_changed(new_height)
 
-@export var player_head_height : float = 0.1
+@onready var snap_turning_button = $Input/InputVBox/SnapTurning/SnapTurningCB
+@onready var y_deadzone_slider = $Input/InputVBox/yAxisDeadZone/yAxisDeadZoneSlider
+@onready var x_deadzone_slider = $Input/InputVBox/xAxisDeadZone/xAxisDeadZoneSlider
+@onready var player_height_slider = $Player/PlayerVBox/PlayerHeight/PlayerHeightSlider
+@onready var webxr_primary_button = $WebXR/WebXRVBox/WebXR/WebXRPrimary
 
 func _update():
 	# Input
-	$Input/SnapTurning/SnapTurningCB.button_pressed = XRToolsUserSettings.snap_turning
-	$Input/yAxisDeadZone/yAxisDeadZoneSlider.value = XRToolsUserSettings.y_axis_dead_zone
-	$Input/xAxisDeadZone/xAxisDeadZoneSlider.value = XRToolsUserSettings.x_axis_dead_zone
+	snap_turning_button.button_pressed = XRToolsUserSettings.snap_turning
+	y_deadzone_slider.value = XRToolsUserSettings.y_axis_dead_zone
+	x_deadzone_slider.value = XRToolsUserSettings.x_axis_dead_zone
 
 	# Player
-	$Player/PlayerHeight/PlayerHeightSlider.value = XRToolsUserSettings.player_height_adjust
+	player_height_slider.value = XRToolsUserSettings.player_height
 
 	# WebXR
-	$WebXR/WebXR/WebXRPrimary.selected = XRToolsUserSettings.webxr_primary
+	webxr_primary_button.selected = XRToolsUserSettings.webxr_primary
 
 
 # Called when the node enters the scene tree for the first time.
@@ -38,28 +42,18 @@ func _on_Reset_pressed():
 	if XRToolsUserSettings:
 		XRToolsUserSettings.reset_to_defaults()
 		_update()
+		emit_signal("player_height_changed", XRToolsUserSettings.player_height)
+
 
 # Input settings changed
 func _on_SnapTurningCB_pressed():
-	XRToolsUserSettings.snap_turning = $Input/SnapTurning/SnapTurningCB.button_pressed
+	XRToolsUserSettings.snap_turning = snap_turning_button.button_pressed
+
 
 # Player settings changed
 func _on_PlayerHeightSlider_drag_ended(_value_changed):
-	XRToolsUserSettings.player_height_adjust = $Player/PlayerHeight/PlayerHeightSlider.value
-
-
-func _on_PlayerHeightStandard_pressed():
-	if camera.is_empty():
-		return
-
-	var camera_node = get_node_or_null(camera)
-	if !camera_node:
-		return
-
-	var base_height = camera_node.transform.origin.y + player_head_height
-	var height_adjust = XRTools.get_player_standard_height() - base_height
-	XRToolsUserSettings.player_height_adjust = height_adjust
-	$Player/PlayerHeight/PlayerHeightSlider.value = XRToolsUserSettings.player_height_adjust
+	XRToolsUserSettings.player_height = player_height_slider.value
+	emit_signal("player_height_changed", XRToolsUserSettings.player_height)
 
 
 func _on_web_xr_primary_item_selected(index: int) -> void:
@@ -67,9 +61,8 @@ func _on_web_xr_primary_item_selected(index: int) -> void:
 
 
 func _on_y_axis_dead_zone_slider_value_changed(value):
-	XRToolsUserSettings.y_axis_dead_zone = $Input/yAxisDeadZone/yAxisDeadZoneSlider.value
+	XRToolsUserSettings.y_axis_dead_zone = y_deadzone_slider.value
 
 func _on_x_axis_dead_zone_slider_value_changed(value):
-	XRToolsUserSettings.x_axis_dead_zone = $Input/xAxisDeadZone/xAxisDeadZoneSlider.value
-
+	XRToolsUserSettings.x_axis_dead_zone = x_deadzone_slider.value
 

--- a/addons/godot-xr-tools/user_settings/user_settings_ui.tscn
+++ b/addons/godot-xr-tools/user_settings/user_settings_ui.tscn
@@ -10,128 +10,138 @@ size_flags_vertical = 3
 theme_override_font_sizes/font_size = 12
 script = ExtResource("1")
 
-[node name="Input" type="VBoxContainer" parent="."]
+[node name="Input" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="InputVBox" type="VBoxContainer" parent="Input"]
 layout_mode = 2
 
-[node name="SnapTurning" type="HBoxContainer" parent="Input"]
+[node name="SnapTurning" type="HBoxContainer" parent="Input/InputVBox"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Input/SnapTurning"]
+[node name="Label" type="Label" parent="Input/InputVBox/SnapTurning"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Snap turning:"
 
-[node name="SnapTurningCB" type="CheckBox" parent="Input/SnapTurning"]
+[node name="SnapTurningCB" type="CheckBox" parent="Input/InputVBox/SnapTurning"]
 layout_mode = 2
 
-[node name="yAxisDeadZone" type="HBoxContainer" parent="Input"]
+[node name="yAxisDeadZone" type="HBoxContainer" parent="Input/InputVBox"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Input/yAxisDeadZone"]
+[node name="Label" type="Label" parent="Input/InputVBox/yAxisDeadZone"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Y axis dead zone"
 
-[node name="yAxisDeadZoneSlider" type="HSlider" parent="Input/yAxisDeadZone"]
+[node name="yAxisDeadZoneSlider" type="HSlider" parent="Input/InputVBox/yAxisDeadZone"]
 layout_mode = 2
 size_flags_horizontal = 3
 max_value = 0.5
 step = 0.01
 value = 0.1
 
-[node name="xAxisDeadZone" type="HBoxContainer" parent="Input"]
+[node name="xAxisDeadZone" type="HBoxContainer" parent="Input/InputVBox"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Input/xAxisDeadZone"]
+[node name="Label" type="Label" parent="Input/InputVBox/xAxisDeadZone"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "X axis dead zone"
 
-[node name="xAxisDeadZoneSlider" type="HSlider" parent="Input/xAxisDeadZone"]
+[node name="xAxisDeadZoneSlider" type="HSlider" parent="Input/InputVBox/xAxisDeadZone"]
 layout_mode = 2
 size_flags_horizontal = 3
 max_value = 0.5
 step = 0.01
 value = 0.2
 
-[node name="HSeparator" type="HSeparator" parent="Input"]
+[node name="HSeparator" type="HSeparator" parent="Input/InputVBox"]
 layout_mode = 2
 
-[node name="Buttons" type="HBoxContainer" parent="Input"]
+[node name="Buttons" type="HBoxContainer" parent="Input/InputVBox"]
 layout_mode = 2
 alignment = 1
 
-[node name="Save" type="Button" parent="Input/Buttons"]
+[node name="Save" type="Button" parent="Input/InputVBox/Buttons"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Apply"
 
-[node name="Reset" type="Button" parent="Input/Buttons"]
+[node name="Reset" type="Button" parent="Input/InputVBox/Buttons"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Reset"
 
-[node name="Player" type="VBoxContainer" parent="."]
+[node name="Player" type="MarginContainer" parent="."]
 visible = false
 layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
 
-[node name="PlayerHeight" type="HBoxContainer" parent="Player"]
+[node name="PlayerVBox" type="VBoxContainer" parent="Player"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Player/PlayerHeight"]
+[node name="PlayerHeight" type="HBoxContainer" parent="Player/PlayerVBox"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Player/PlayerVBox/PlayerHeight"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Height adjust:"
 
-[node name="PlayerHeightSlider" type="HSlider" parent="Player/PlayerHeight"]
+[node name="PlayerHeightSlider" type="HSlider" parent="Player/PlayerVBox/PlayerHeight"]
 layout_mode = 2
 size_flags_horizontal = 3
-min_value = -1.0
-max_value = 1.0
-step = 0.1
+min_value = 1.0
+max_value = 2.5
+step = 0.05
+value = 1.0
 
-[node name="PlayerHeightCalc" type="HBoxContainer" parent="Player"]
+[node name="HSeparator" type="HSeparator" parent="Player/PlayerVBox"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Player/PlayerHeightCalc"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-
-[node name="PlayerHeightStandard" type="Button" parent="Player/PlayerHeightCalc"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Set to standard"
-
-[node name="HSeparator" type="HSeparator" parent="Player"]
-layout_mode = 2
-
-[node name="Buttons" type="HBoxContainer" parent="Player"]
+[node name="Buttons" type="HBoxContainer" parent="Player/PlayerVBox"]
 layout_mode = 2
 alignment = 1
 
-[node name="Save" type="Button" parent="Player/Buttons"]
+[node name="Save" type="Button" parent="Player/PlayerVBox/Buttons"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Apply"
 
-[node name="Reset" type="Button" parent="Player/Buttons"]
+[node name="Reset" type="Button" parent="Player/PlayerVBox/Buttons"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Reset"
 
-[node name="WebXR" type="VBoxContainer" parent="."]
+[node name="WebXR" type="MarginContainer" parent="."]
 visible = false
 layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
 
-[node name="WebXR" type="HBoxContainer" parent="WebXR"]
+[node name="WebXRVBox" type="VBoxContainer" parent="WebXR"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="WebXR/WebXR"]
+[node name="WebXR" type="HBoxContainer" parent="WebXR/WebXRVBox"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="WebXR/WebXRVBox/WebXR"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "WebXR primary:"
 
-[node name="WebXRPrimary" type="OptionButton" parent="WebXR/WebXR"]
+[node name="WebXRPrimary" type="OptionButton" parent="WebXR/WebXRVBox/WebXR"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 item_count = 3
@@ -143,32 +153,31 @@ popup/item_1/id = 1
 popup/item_2/text = "Trackpad"
 popup/item_2/id = 2
 
-[node name="HSeparator" type="HSeparator" parent="WebXR"]
+[node name="HSeparator" type="HSeparator" parent="WebXR/WebXRVBox"]
 layout_mode = 2
 
-[node name="Buttons" type="HBoxContainer" parent="WebXR"]
+[node name="Buttons" type="HBoxContainer" parent="WebXR/WebXRVBox"]
 layout_mode = 2
 alignment = 1
 
-[node name="Save" type="Button" parent="WebXR/Buttons"]
+[node name="Save" type="Button" parent="WebXR/WebXRVBox/Buttons"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Apply"
 
-[node name="Reset" type="Button" parent="WebXR/Buttons"]
+[node name="Reset" type="Button" parent="WebXR/WebXRVBox/Buttons"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Reset"
 
-[connection signal="pressed" from="Input/SnapTurning/SnapTurningCB" to="." method="_on_SnapTurningCB_pressed"]
-[connection signal="value_changed" from="Input/yAxisDeadZone/yAxisDeadZoneSlider" to="." method="_on_y_axis_dead_zone_slider_value_changed"]
-[connection signal="value_changed" from="Input/xAxisDeadZone/xAxisDeadZoneSlider" to="." method="_on_x_axis_dead_zone_slider_value_changed"]
-[connection signal="pressed" from="Input/Buttons/Save" to="." method="_on_Save_pressed"]
-[connection signal="pressed" from="Input/Buttons/Reset" to="." method="_on_Reset_pressed"]
-[connection signal="drag_ended" from="Player/PlayerHeight/PlayerHeightSlider" to="." method="_on_PlayerHeightSlider_drag_ended"]
-[connection signal="pressed" from="Player/PlayerHeightCalc/PlayerHeightStandard" to="." method="_on_PlayerHeightStandard_pressed"]
-[connection signal="pressed" from="Player/Buttons/Save" to="." method="_on_Save_pressed"]
-[connection signal="pressed" from="Player/Buttons/Reset" to="." method="_on_Reset_pressed"]
-[connection signal="item_selected" from="WebXR/WebXR/WebXRPrimary" to="." method="_on_web_xr_primary_item_selected"]
-[connection signal="pressed" from="WebXR/Buttons/Save" to="." method="_on_Save_pressed"]
-[connection signal="pressed" from="WebXR/Buttons/Reset" to="." method="_on_Reset_pressed"]
+[connection signal="pressed" from="Input/InputVBox/SnapTurning/SnapTurningCB" to="." method="_on_SnapTurningCB_pressed"]
+[connection signal="value_changed" from="Input/InputVBox/yAxisDeadZone/yAxisDeadZoneSlider" to="." method="_on_y_axis_dead_zone_slider_value_changed"]
+[connection signal="value_changed" from="Input/InputVBox/xAxisDeadZone/xAxisDeadZoneSlider" to="." method="_on_x_axis_dead_zone_slider_value_changed"]
+[connection signal="pressed" from="Input/InputVBox/Buttons/Save" to="." method="_on_Save_pressed"]
+[connection signal="pressed" from="Input/InputVBox/Buttons/Reset" to="." method="_on_Reset_pressed"]
+[connection signal="drag_ended" from="Player/PlayerVBox/PlayerHeight/PlayerHeightSlider" to="." method="_on_PlayerHeightSlider_drag_ended"]
+[connection signal="pressed" from="Player/PlayerVBox/Buttons/Save" to="." method="_on_Save_pressed"]
+[connection signal="pressed" from="Player/PlayerVBox/Buttons/Reset" to="." method="_on_Reset_pressed"]
+[connection signal="item_selected" from="WebXR/WebXRVBox/WebXR/WebXRPrimary" to="." method="_on_PlayerHeightSlider_drag_ended"]
+[connection signal="pressed" from="WebXR/WebXRVBox/Buttons/Save" to="." method="_on_Save_pressed"]
+[connection signal="pressed" from="WebXR/WebXRVBox/Buttons/Reset" to="." method="_on_Reset_pressed"]

--- a/addons/godot-xr-tools/xr_tools.gd
+++ b/addons/godot-xr-tools/xr_tools.gd
@@ -1,6 +1,10 @@
 class_name XRTools
 extends Node
 
+## Below are helper functions to obtain various project settings that drive
+## the default behavior of XR Tools. The project settings themselves are
+## registered in plugin.gd.
+## Some of these settings can be overridden by the user through user settings.
 
 static func get_grip_threshold() -> float:
 	# can return null which is not a float, so don't type this!

--- a/scenes/main_menu/main_menu_level.gd
+++ b/scenes/main_menu/main_menu_level.gd
@@ -36,3 +36,7 @@ func _on_Demos_child_entered_tree(_node):
 
 func _on_Demos_child_exiting_tree(_node):
 	_update_demo_positions()
+
+
+func _on_settings_ui_player_height_changed(new_height):
+	$XROrigin3D/PlayerBody.calibrate_player_height()

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -26,65 +26,65 @@
 [ext_resource type="Texture2D" uid="uid://cr1l4g7btdyht" path="res://scenes/origin_gravity_demo/origin_gravity_demo.png" id="32_c4n1q"]
 [ext_resource type="Texture2D" uid="uid://dhd30j0xpcxoi" path="res://scenes/sphere_world_demo/sphere_world_demo.png" id="34_xw8ig"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_yqsfa"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_aiai1"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_jdv1k"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_qsflq"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_4kd16"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_dkrib"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_kmgyq"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_kjau2"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_dwrr3"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_a2bml"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_d60s1"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_s5ump"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_yqsfa")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_aiai1")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_jdv1k")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_qsflq")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_4kd16")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_dkrib")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_kmgyq")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_kjau2")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_dwrr3")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_a2bml")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ioevk"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_eique"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_cwu41"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_trfyy"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_q1tmf"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_dm4vo"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_cnpg1"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_suwvf"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_wgk0i"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_emhrf"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_w38hj"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_7d2p7"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_ioevk")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_eique")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_cwu41")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_trfyy")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_q1tmf")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_dm4vo")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_cnpg1")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_suwvf")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_wgk0i")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_emhrf")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
@@ -123,7 +123,7 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_d60s1")
+tree_root = SubResource("AnimationNodeBlendTree_s5ump")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("5_xgcrx")]
 
@@ -165,7 +165,7 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_w38hj")
+tree_root = SubResource("AnimationNodeBlendTree_7d2p7")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5_xgcrx")]
 
@@ -253,10 +253,10 @@ title = ExtResource("34_xw8ig")
 
 [node name="SettingsUI" parent="." index="3" instance=ExtResource("26_0uyxa")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.5)
-camera = NodePath("../XROrigin3D/XRCamera3D")
 
 [connection signal="child_entered_tree" from="Demos" to="." method="_on_Demos_child_entered_tree"]
 [connection signal="child_exiting_tree" from="Demos" to="." method="_on_Demos_child_exiting_tree"]
+[connection signal="player_height_changed" from="SettingsUI" to="." method="_on_settings_ui_player_height_changed"]
 
 [editable path="XROrigin3D/LeftHand/LeftHand"]
 [editable path="XROrigin3D/LeftHand/LeftHand/Hand_low_L"]

--- a/scenes/main_menu/objects/settings_ui.gd
+++ b/scenes/main_menu/objects/settings_ui.gd
@@ -1,13 +1,12 @@
 extends Node3D
 
-@export_node_path("XRCamera3D") var camera : NodePath
+signal player_height_changed(new_height)
+
+func _on_player_height_changed(new_height):
+	emit_signal("player_height_changed", new_height)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	var camera_node = get_node_or_null(camera)
-	if camera_node:
-		var scene = $Screen/Viewport2Din3D.get_scene_instance()
-		if scene:
-			var settings_ui = scene.get_node_or_null("UserSettingsUI")
-			if settings_ui:
-				settings_ui.camera = camera_node.get_path()
+	var scene = $Screen/Viewport2Din3D.get_scene_instance()
+	if scene:
+		scene.connect("player_height_changed", _on_player_height_changed)

--- a/scenes/main_menu/objects/settings_ui.tscn
+++ b/scenes/main_menu/objects/settings_ui.tscn
@@ -9,7 +9,7 @@
 [ext_resource type="Resource" uid="uid://bhvrpfo4ecbub" path="res://addons/godot-xr-tools/hands/poses/pose_point_right.tres" id="7_tfhna"]
 
 [sub_resource type="BoxMesh" id="1"]
-size = Vector3(0.65, 0.525, 0.02)
+size = Vector3(0.7, 0.7, 0.02)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_7u64y"]
 size = Vector3(0.65, 0.2, 0.5)
@@ -24,8 +24,8 @@ surface_material_override/0 = ExtResource("2_jyjdc")
 
 [node name="Viewport2Din3D" parent="Screen" instance=ExtResource("1")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.015)
-screen_size = Vector2(0.625, 0.5)
-viewport_size = Vector2(250, 200)
+screen_size = Vector2(0.625, 0.625)
+viewport_size = Vector2(250, 250)
 scene = ExtResource("2")
 
 [node name="CSGCylinder" type="CSGCylinder3D" parent="."]

--- a/scenes/main_menu/objects/settings_ui_content.gd
+++ b/scenes/main_menu/objects/settings_ui_content.gd
@@ -1,0 +1,7 @@
+extends VBoxContainer
+
+signal player_height_changed(new_height)
+
+
+func _on_user_settings_ui_player_height_changed(new_height):
+	emit_signal("player_height_changed", new_height)

--- a/scenes/main_menu/objects/settings_ui_content.tscn
+++ b/scenes/main_menu/objects/settings_ui_content.tscn
@@ -1,25 +1,25 @@
-[gd_scene load_steps=2 format=3 uid="uid://hpxufsmhvnq0"]
+[gd_scene load_steps=3 format=3 uid="uid://hpxufsmhvnq0"]
 
 [ext_resource type="PackedScene" uid="uid://ytsxet2k47lj" path="res://addons/godot-xr-tools/user_settings/user_settings_ui.tscn" id="1"]
+[ext_resource type="Script" path="res://scenes/main_menu/objects/settings_ui_content.gd" id="1_4ef25"]
 
 [node name="SettingsUIContent" type="VBoxContainer"]
 offset_right = 250.0
 offset_bottom = 252.0
 size_flags_horizontal = 0
+script = ExtResource("1_4ef25")
 
 [node name="Header" type="HBoxContainer" parent="."]
-offset_right = 250.0
-offset_bottom = 60.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Header"]
-offset_right = 250.0
-offset_bottom = 60.0
+layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 12
 text = "Welcome to Godot XR Tools. Use the joysticks on your controllers to move around."
 autowrap_mode = 2
 
 [node name="UserSettingsUI" parent="." instance=ExtResource("1")]
-offset_top = 64.0
-offset_right = 250.0
-offset_bottom = 252.0
+layout_mode = 2
+
+[connection signal="player_height_changed" from="UserSettingsUI" to="." method="_on_user_settings_ui_player_height_changed"]


### PR DESCRIPTION
This PR redoes the player height implementation.

Our default setting in project settings remains however our user settings now store a user overridden version of this.

As our loading screen has the "trigger to continue" logic we can assume the player is standing (or sitting) in "rest" and we calculate the offset required to make the virtual player the height stored in our settings.

This means XR tools can now be played while seated but controlling the character as if standing up. 

Note that this is different from @pietru2004 PRs where we actually want the character to be seated (in a vehicle or otherwise) if I understand correctly. This is something we do want to support properly but I haven't had time to look into this properly.