### PR TITLE
add render_priority and no_depth_test as option to viewport2d_in_3d

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -47,6 +47,12 @@ const DEFAULT_LAYER := 0b0000_0000_0001_0000_0000_0000_0000_0001
 ## Alpha Scissor Threshold property
 @export var alpha_scissor_threshold : float = 0.25: set = set_alpha_scissor_threshold
 
+## Render priority property
+@export var render_priority : int = 0
+
+## no depth test property
+@export var no_depth_test : bool = false
+
 ## Unshaded
 @export var unshaded : bool = false: set = set_unshaded
 
@@ -81,6 +87,8 @@ func _ready():
 	material = StandardMaterial3D.new()
 	material.flags_unshaded = true
 	material.params_cull_mode = StandardMaterial3D.CULL_DISABLED
+	material.set_render_priority(render_priority)
+	material.no_depth_test = no_depth_test
 	$Screen.set_surface_override_material(0, material)
 
 	# apply properties


### PR DESCRIPTION
Added options to set no_depth_test and render priority to the mesh material inside viewport2d_in_3d

As the material is created in runtime, we need to expose this values in the script, otherwise changes in the material will not affect the created viewport.

I keep default values as in previous versions.

![no_depth_viewport_inspector](https://github.com/GodotVR/godot-xr-tools/assets/437199/b1413661-285c-459c-b036-6dc2b6f6cb12)

![no_depth_viewport_use_case](https://github.com/GodotVR/godot-xr-tools/assets/437199/edf3266e-317e-4f7e-9898-474266037269)
