### PR TITLE
Restore correct movement - forwards/backwards on & strafing optional

### DIFF
--- a/addons/godot-xr-tools/functions/movement_direct.gd
+++ b/addons/godot-xr-tools/functions/movement_direct.gd
@@ -43,9 +43,9 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 	## get input action with deadzone correction applied
 	var dz_input_action = XRToolsUserSettings.get_adjusted_vector2(_controller, input_action)
 
-	player_body.ground_control_velocity.x += dz_input_action.x * max_speed
+	player_body.ground_control_velocity.y += dz_input_action.y * max_speed
 	if strafe:
-		player_body.ground_control_velocity.y += dz_input_action.y * max_speed
+		player_body.ground_control_velocity.x += dz_input_action.x * max_speed
 
 	# Clamp ground control
 	var length := player_body.ground_control_velocity.length()


### PR DESCRIPTION
This pull request fixes a bug introduced with the #233 pull request for dead zones.