### PR TITLE
Fix slope movement

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,7 @@
 # 4.2.0
 - Environments can now be set normally in scenes loaded through the staging system.
 - Fixed issue with not being able to push rigid bodies when colliding with them.
+- Fixed player movement on slopes.
 
 # 4.1.0
 - Enhanced grappling to support collision and target layers

--- a/addons/godot-xr-tools/functions/movement_direct.gd
+++ b/addons/godot-xr-tools/functions/movement_direct.gd
@@ -43,9 +43,9 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 	## get input action with deadzone correction applied
 	var dz_input_action = XRToolsUserSettings.get_adjusted_vector2(_controller, input_action)
 
-	player_body.ground_control_velocity.y += dz_input_action.y * max_speed
+	player_body.ground_control_velocity.x += dz_input_action.x * max_speed
 	if strafe:
-		player_body.ground_control_velocity.x += dz_input_action.x * max_speed
+		player_body.ground_control_velocity.y += dz_input_action.y * max_speed
 
 	# Clamp ground control
 	var length := player_body.ground_control_velocity.length()

--- a/addons/godot-xr-tools/functions/movement_direct.gd
+++ b/addons/godot-xr-tools/functions/movement_direct.gd
@@ -43,9 +43,9 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 	## get input action with deadzone correction applied
 	var dz_input_action = XRToolsUserSettings.get_adjusted_vector2(_controller, input_action)
 
-	player_body.ground_control_velocity.x += dz_input_action.x * max_speed
+	player_body.ground_control_velocity.y += dz_input_action.y * max_speed
 	if strafe:
-		player_body.ground_control_velocity.y += dz_input_action.y * max_speed
+		player_body.ground_control_velocity.x += dz_input_action.x * max_speed
 
 	# Clamp ground control
 	var length := player_body.ground_control_velocity.length()

--- a/addons/godot-xr-tools/player/player_body.gd
+++ b/addons/godot-xr-tools/player/player_body.gd
@@ -344,7 +344,7 @@ func request_jump(skip_jump_velocity := false):
 func move_body(p_velocity: Vector3) -> Vector3:
 	velocity = p_velocity
 	max_slides = 4
-	up_direction = up_gravity_vector
+	up_direction = ground_vector
 
 	move_and_slide()
 


### PR DESCRIPTION
This pull request fixes issue #477 and restores normal character movement on slopes.

The CharacterBody3D will not support sliding down slopes due to gravity regardless of the options. What it will do is support sliding on a flat surface. The fix is simply to switch the CharacterBody3D 'up_direction' from the local gravity 'up' to the surface-normal of the ground. This translates the unsupported "sliding down slopes" into "sliding on a flat surface".

![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/8752ccad-414a-4e0a-a2a0-31b25646818d)

Diagram 1 - Shows how we were trying to use CharacterBody3D which does not work.

Diagram 2 - Shows how this PR changes CharacterBody3D and makes it work.

Diagram 3 - Same as the second with the observer reference frame rotated showing how the movement actually works - like pushing a piece of paper across a table.

