### PR TITLE
Fix slope movement

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,7 @@
 # 4.2.0
 - Environments can now be set normally in scenes loaded through the staging system.
 - Fixed issue with not being able to push rigid bodies when colliding with them.
+- Fixed player movement on slopes.
 
 # 4.1.0
 - Enhanced grappling to support collision and target layers

--- a/addons/godot-xr-tools/player/player_body.gd
+++ b/addons/godot-xr-tools/player/player_body.gd
@@ -344,7 +344,7 @@ func request_jump(skip_jump_velocity := false):
 func move_body(p_velocity: Vector3) -> Vector3:
 	velocity = p_velocity
 	max_slides = 4
-	up_direction = up_gravity_vector
+	up_direction = ground_vector
 
 	move_and_slide()
 


### PR DESCRIPTION
This pull request fixes issue #477 and restores normal character movement on slopes.

The CharacterBody3D will not support sliding down slopes due to gravity regardless of the options. What it will do is support sliding on a flat surface. The fix is simply to switch the CharacterBody3D 'up_direction' from the local gravity 'up' to the surface-normal of the ground. This translates the unsupported "sliding down slopes" into "sliding on a flat surface".

![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/f63487a2-8019-40e6-bff4-932086d0e956)

Diagram 1 - Shows how we were trying to use CharacterBody3D which does not work.

Diagram 2 - Shows how this PR changes CharacterBody3D and makes it work.

Diagram 3 - Same as the second with the observer reference frame rotated showing how the movement actually works - like pushing a piece of paper across a table.