### PR TITLE
Fix the lag in the finger-poke

### DIFF
--- a/addons/godot-xr-tools/player/player_body.tscn
+++ b/addons/godot-xr-tools/player/player_body.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" path="res://addons/godot-xr-tools/player/player_body.gd" id="1"]
 
 [node name="PlayerBody" type="CharacterBody3D" groups=["player_body"]]
+process_priority = -100
 top_level = true
 collision_layer = 524288
 collision_mask = 1023

--- a/addons/godot-xr-tools/player/poke/poke.tscn
+++ b/addons/godot-xr-tools/player/poke/poke.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3]
+[gd_scene load_steps=6 format=3 uid="uid://bjcxf427un2wp"]
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools/player/poke/poke.gd" id="1"]
 [ext_resource type="Script" path="res://addons/godot-xr-tools/player/poke/poke_body.gd" id="2"]
@@ -14,25 +14,26 @@ height = 0.01
 radial_segments = 32
 rings = 16
 
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_yhep2"]
+transparency = 1
+shading_mode = 0
+albedo_color = Color(0.8, 0.8, 1, 0.5)
+
 [node name="Poke" type="Node3D"]
 script = ExtResource("1")
 
-[node name="PokeBody" type="RigidBody3D" parent="."]
+[node name="PokeBody" type="StaticBody3D" parent="."]
 top_level = true
 collision_layer = 131072
 collision_mask = 65535
-gravity_scale = 0.0
-custom_integrator = true
-max_contacts_reported = 1
-contact_monitor = true
 script = ExtResource("2")
-teleport_distance = 0.1
 
 [node name="CollisionShape" type="CollisionShape3D" parent="PokeBody"]
 shape = SubResource("1")
 
 [node name="MeshInstance" type="MeshInstance3D" parent="PokeBody"]
 mesh = SubResource("2")
+surface_material_override/0 = SubResource("StandardMaterial3D_yhep2")
 
-[connection signal="body_entered" from="PokeBody" to="." method="_on_PokeBody_body_entered"]
-[connection signal="body_exited" from="PokeBody" to="." method="_on_PokeBody_body_exited"]
+[connection signal="body_contact_end" from="PokeBody" to="." method="_on_PokeBody_body_contact_end"]
+[connection signal="body_contact_start" from="PokeBody" to="." method="_on_PokeBody_body_contact_start"]

--- a/addons/godot-xr-tools/player/poke/poke_body.gd
+++ b/addons/godot-xr-tools/player/poke/poke_body.gd
@@ -1,23 +1,103 @@
-extends RigidBody3D
+extends StaticBody3D
 
-# distance at which we teleport our poke body
-@export var teleport_distance : float = 0.2
 
-func _integrate_forces(state: PhysicsDirectBodyState3D):
-	# get the position of our parent that we are following
-	var following_transform = get_parent().global_transform
+## Signal called when we start to contact an object
+signal body_contact_start(node)
 
-	# see how much we need to move
-	var delta_movement = following_transform.origin - state.transform.origin
-	var delta_length = delta_movement.length()
+## Signal called when we end contact with an object
+signal body_contact_end(node)
 
-	if delta_length > teleport_distance:
-		# teleport our poke body to its new location
-		state.angular_velocity = Vector3()
-		state.linear_velocity = Vector3()
-		state.transform.origin = following_transform.origin
+
+## Distance at which we teleport our poke body
+@export var teleport_distance : float = 0.1
+
+## Enable or disable pushing rigid bodies
+@export var push_bodies : bool = true
+
+## Stiffness of the finger
+@export var stiffness : float = 10.0
+
+## Maximum finger force
+@export var maximum_force : float = 1.0
+
+
+# Node currently in contact with
+var _contact : Node3D = null
+
+# Target XRToolsPoke
+@onready var _target : XRToolsPoke = get_parent()
+
+
+# Add support for is_xr_class on XRTools classes
+func is_xr_class(name : String) -> bool:
+	return name == "XRToolsPokeBody"
+
+
+# Try moving to the parent Poke node
+func _physics_process(_delta):
+	# Get the current position and contact
+	var old_position := global_position
+	var old_contact := _contact
+
+	# Calculate the movement to perform
+	var target_position := _target.global_position
+	var to_target := target_position - old_position
+	var effort := to_target.length()
+
+	# Decide whether to teleport or slide
+	if effort > teleport_distance:
+		# Perform Teleport
+		global_position = target_position
 	else:
-		# trigger physics to move our body in one step
-		state.angular_velocity = Vector3()
-		state.linear_velocity = delta_movement / state.step
-		state.integrate_forces()
+		# Perform Slide (up to 4 times)
+		_contact = null
+		var force_direction := to_target.normalized()
+		var next_direction := force_direction
+		for n in 4:
+			# Calculate how efficiently we can move/slide
+			var efficiency := next_direction.dot(force_direction)
+			if efficiency <= 0.0 or effort <= 0.0:
+				break
+
+			# Perform the move
+			var step_physical := effort * efficiency
+			var collision := move_and_collide(next_direction * step_physical)
+
+			# If no collision then we have moved the rest of the distance
+			if not collision:
+				break
+
+			# Calculate how much of the move remains [0..1]
+			var remains := collision.get_remainder().length() / step_physical
+			remains = clamp(remains, 0.0, 1.0)
+
+			# Update the remaining effort
+			effort *= remains
+
+			# Calculate the next slide direction
+			next_direction = force_direction.slide(collision.get_normal()).normalized()
+
+			# Save the contact
+			_contact = collision.get_collider()
+
+			# Optionally support pushing rigid bodies
+			if push_bodies:
+				var contact_rigid := _contact as RigidBody3D
+				if contact_rigid:
+					# Calculate the finger force
+					var force := target_position - global_position
+					force *= stiffness
+					force = force.limit_length(maximum_force)
+
+					# Apply as an impulse
+					contact_rigid.apply_impulse(
+						force,
+						collision.get_position() - contact_rigid.global_position)
+
+	# Report when we stop being in contact with the current object
+	if old_contact and old_contact != _contact:
+		body_contact_end.emit(old_contact)
+
+	# Report when we start touching a new object
+	if _contact and _contact != old_contact:
+		body_contact_start.emit(_contact)


### PR DESCRIPTION
This pull request fixes issue #328 by implementing the following changes:
 - Change the PokeBody from being a RigidBody3D driven by `_integrate_forces` to a StaticBody3D driven by `_physics_process`
 - Set the PlayerBody `process_priority` to -100 so its physics processing is performed before anything else

The problem with the old implementation is that `_integrate_forces` is not actually performed in the physics processing phase, and so ignores any priority rules. This means that we cannot enforce the body to move first, and then ensure the poke updates in the same frame with the updated body.

Unfortunately with Godot 4 removing KinematicBody, and CharacterBody3D being too tied to character movement; the move_and_slide functionality had to be implemented in gdscript.

This implementation uses StaticBody3D rather than directly using the PhysicsDirectSpaceState3D/PhysicsServer3D because only PhysicsBody3D objects get the logic to "de-collide" objects in C++, and implementing the loops in gdscript would be crippling.