### PR TITLE
Implement basic collision hands

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,6 +2,8 @@
 - Environments can now be set normally in scenes loaded through the staging system.
 - Fixed issue with not being able to push rigid bodies when colliding with them.
 - Fixed player movement on slopes.
+- Fixed lag in finger-poke.
+- Added initial collision hand support.
 
 # 4.1.0
 - Enhanced grappling to support collision and target layers

--- a/addons/godot-xr-tools/functions/movement_climb.gd
+++ b/addons/godot-xr-tools/functions/movement_climb.gd
@@ -43,14 +43,14 @@ const SNAP_DISTANCE : float = 1.0
 @export var velocity_averages : int = 5
 
 
-## Left climbable
-var _left_climbable : XRToolsClimbable
+# Left climbing handle
+var _left_handle : Node3D
 
-## Right climbable
-var _right_climbable : XRToolsClimbable
+# Right climbing handle
+var _right_handle : Node3D
 
-## Dominant pickup (moving the player)
-var _dominant : XRToolsFunctionPickup
+# Dominant handle (moving the player)
+var _dominant : Node3D
 
 
 # Velocity averager
@@ -62,6 +62,18 @@ var _dominant : XRToolsFunctionPickup
 # Right pickup node
 @onready var _right_pickup_node := XRToolsFunctionPickup.find_right(self)
 
+# Left controller
+@onready var _left_controller := XRHelpers.get_left_controller(self)
+
+# Right controller
+@onready var _right_controller := XRHelpers.get_right_controller(self)
+
+# Left collision hand
+@onready var _left_collision_hand := XRToolsCollisionHand.find_left(self)
+
+# Right collision hand
+@onready var _right_collision_hand := XRToolsCollisionHand.find_right(self)
+
 
 # Add support for is_xr_class on XRTools classes
 func is_xr_class(name : String) -> bool:
@@ -72,6 +84,10 @@ func is_xr_class(name : String) -> bool:
 func _ready():
 	# In Godot 4 we must now manually call our super class ready function
 	super()
+
+	# Do not initialise if in the editor
+	if Engine.is_editor_hint():
+		return
 
 	# Connect pickup funcitons
 	if _left_pickup_node.connect("has_picked_up", _on_left_picked_up):
@@ -91,15 +107,23 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 		_set_climbing(false, player_body)
 		return
 
+	# Check for climbing handles being deleted while held
+	if not is_instance_valid(_left_handle):
+		_left_handle = null
+	if not is_instance_valid(_right_handle):
+		_right_handle = null
+	if not is_instance_valid(_dominant):
+		_dominant = null
+
 	# Snap grabs if too far
-	if is_instance_valid(_left_climbable):
-		var left_pickup_pos := _left_pickup_node.global_transform.origin
-		var left_grab_pos := _left_climbable.get_grab_location(_left_pickup_node)
+	if _left_handle:
+		var left_pickup_pos := _left_controller.global_position
+		var left_grab_pos = _left_handle.global_position
 		if left_pickup_pos.distance_to(left_grab_pos) > SNAP_DISTANCE:
 			_left_pickup_node.drop_object()
-	if is_instance_valid(_right_climbable):
-		var right_pickup_pos := _right_pickup_node.global_transform.origin
-		var right_grab_pos := _right_climbable.get_grab_location(_right_pickup_node)
+	if _right_handle:
+		var right_pickup_pos := _right_controller.global_position
+		var right_grab_pos := _right_handle.global_position
 		if right_pickup_pos.distance_to(right_grab_pos) > SNAP_DISTANCE:
 			_right_pickup_node.drop_object()
 
@@ -112,22 +136,22 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 
 	# Calculate how much the player has moved
 	var offset := Vector3.ZERO
-	if _dominant == _left_pickup_node:
-		var left_pickup_pos := _left_pickup_node.global_transform.origin
-		var left_grab_pos := _left_climbable.get_grab_location(_left_pickup_node)
+	if _dominant == _left_handle:
+		var left_pickup_pos := _left_controller.global_position
+		var left_grab_pos := _left_handle.global_position
 		offset = left_pickup_pos - left_grab_pos
-	elif _dominant == _right_pickup_node:
-		var right_pickup_pos := _right_pickup_node.global_transform.origin
-		var right_grab_pos := _right_climbable.get_grab_location(_right_pickup_node)
+	elif _dominant == _right_handle:
+		var right_pickup_pos := _right_controller.global_position
+		var right_grab_pos := _right_handle.global_position
 		offset = right_pickup_pos - right_grab_pos
 
 	# Move the player by the offset
-	var old_position := player_body.global_transform.origin
+	var old_position := player_body.global_position
 	player_body.move_and_collide(-offset)
 	player_body.velocity = Vector3.ZERO
 
 	# Update the players average-velocity data
-	var distance := player_body.global_transform.origin - old_position
+	var distance := player_body.global_position - old_position
 	_averager.add_distance(delta, distance)
 
 	# Report exclusive motion performed (to bypass gravity)
@@ -165,49 +189,63 @@ func _set_climbing(active: bool, player_body: XRToolsPlayerBody) -> void:
 ## Handler for left controller picked up
 func _on_left_picked_up(what : Node3D) -> void:
 	# Get the climbable
-	_left_climbable = what as XRToolsClimbable
+	var climbable = what as XRToolsClimbable
+	if not climbable:
+		return
 
-	# Transfer climb dominance
-	if is_instance_valid(_left_climbable):
-		_dominant = _left_pickup_node
-	else:
-		_left_climbable = null
+	# Get the handle
+	_left_handle = climbable.get_grab_handle(_left_pickup_node)
+	if not _left_handle:
+		return
+
+	# Switch dominance to the left handle
+	_dominant = _left_handle
+
+	# If collision hands present then target the handle
+	if _left_collision_hand:
+		_left_collision_hand.add_target_override(_left_handle, 0)
 
 
 ## Handler for right controller picked up
 func _on_right_picked_up(what : Node3D) -> void:
 	# Get the climbable
-	_right_climbable = what as XRToolsClimbable
+	var climbable = what as XRToolsClimbable
+	if not climbable:
+		return
 
-	# Transfer climb dominance
-	if is_instance_valid(_right_climbable):
-		_dominant = _right_pickup_node
-	else:
-		_right_climbable = null
+	# Get the handle
+	_right_handle = climbable.get_grab_handle(_right_pickup_node)
+	if not _right_handle:
+		return
+
+	# Switch dominance to the right handle
+	_dominant = _right_handle
+
+	# If collision hands present then target the handle
+	if _right_collision_hand:
+		_right_collision_hand.add_target_override(_right_handle, 0)
 
 
 ## Handler for left controller dropped
 func _on_left_dropped() -> void:
-	# Release climbable
-	_left_climbable = null
+	# If collision hands present then clear handle target
+	if _left_collision_hand:
+		_left_collision_hand.remove_target_override(_left_handle)
 
-	# Transfer climb dominance
-	if is_instance_valid(_right_climbable):
-		_dominant = _right_pickup_node
-	else:
-		_dominant = null
+	# Release handle and transfer dominance
+	_left_handle = null
+	_dominant = _right_handle
 
 
 ## Handler for righ controller dropped
 func _on_right_dropped() -> void:
-	# Release climbable
-	_right_climbable = null
+	# If collision hands present then clear handle target
+	if _right_collision_hand:
+		_right_collision_hand.remove_target_override(_right_handle)
 
-	# Transfer climb dominance
-	if is_instance_valid(_left_climbable):
-		_dominant = _left_pickup_node
-	else:
-		_dominant = null
+	# Release handle and transfer dominance
+	_right_handle = null
+	_dominant = _left_handle
 
 
 # This method verifies the movement provider has a valid configuration.

--- a/addons/godot-xr-tools/hands/collision_hand.gd
+++ b/addons/godot-xr-tools/hands/collision_hand.gd
@@ -1,0 +1,220 @@
+@tool
+class_name XRToolsCollisionHand
+extends XRToolsForceBody
+
+
+## XRTools Collision Hand Container Script
+##
+## This script implements logic for collision hands. Specifically it tracks
+## its ancestor [XRController3D], and can act as a container for hand models
+## and pickup functions.
+
+
+## Modes for collision hand
+enum CollisionHandMode {
+	## Hand is disabled and must be moved externally
+	DISABLED,
+
+	## Hand teleports to controller
+	TELEPORT,
+
+	## Hand collides with world (based on mask)
+	COLLIDE
+}
+
+# Default layer of 18:player-hands
+const DEFAULT_LAYER := 0b0000_0000_0000_0010_0000_0000_0000_0000
+
+# Default mask of 0xFFFF (1..16)
+# - 1:static-world
+# - 2:dynamic-world
+# - 3:pickable-objects
+# - 4:wall-walking
+# - 5:grappling-target
+const DEFAULT_MASK := 0b0000_0000_0000_0000_1111_1111_1111_1111
+
+# How much displacement is required for the hand to start orienting to a surface
+const ORIENT_DISPLACEMENT := 0.05
+
+
+## Controls the hand collision mode
+@export var mode : CollisionHandMode = CollisionHandMode.COLLIDE
+
+
+# Controller to target (if no target overrides)
+var _controller : XRController3D
+
+# Sorted stack of TargetOverride
+var _target_overrides := []
+
+# Current target (controller or override)
+var _target : Node3D
+
+
+## Target-override class
+class TargetOverride:
+	## Target of the override
+	var target : Node3D
+
+	## Target priority
+	var priority : int
+
+	## Target-override constructor
+	func _init(t : Node3D, p : int):
+		target = t
+		priority = p
+
+
+# Add support for is_xr_class on XRTools classes
+func is_xr_class(name : String) -> bool:
+	return name == "XRToolsCollisionHand"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	# Do not initialise if in the editor
+	if Engine.is_editor_hint():
+		return
+
+	# Disconnect from parent transform, as we move to it in the physics step
+	top_level = true
+
+	# Populate nodes
+	_controller = XRTools.find_xr_ancestor(self, "*", "XRController3D")
+
+	# Update the target
+	_update_target()
+
+
+# Handle physics processing
+func _physics_process(_delta):
+	# Do not process if in the editor
+	if Engine.is_editor_hint():
+		return
+
+	# Move to the current target
+	_move_to_target()
+
+
+## This function adds a target override. The collision hand will attempt to
+## move to the highest priority target, or the [XRController3D] if no override
+## is specified.
+func add_target_override(target : Node3D, priority : int) -> void:
+	# Remove any existing target override from this source
+	var modified := _remove_target_override(target)
+
+	# Insert the target override
+	_insert_target_override(target, priority)
+	modified = true
+
+	# Update the target
+	if modified:
+		_update_target()
+
+
+## This function remove a target override.
+func remove_target_override(target : Node3D) -> void:
+	# Remove the target override
+	var modified := _remove_target_override(target)
+
+	# Update the pose
+	if modified:
+		_update_target()
+
+
+## This function searches from the specified node for an [XRToolsCollisionHand]
+## assuming the node is a sibling of the hand under an [XRController3D].
+static func find_instance(node : Node) -> XRToolsCollisionHand:
+	return XRTools.find_xr_child(
+		XRHelpers.get_xr_controller(node),
+		"*",
+		"XRToolsCollisionHand") as XRToolsCollisionHand
+
+
+## This function searches from the specified node for the left controller
+## [XRToolsCollisionHand] assuming the node is a sibling of the [XROrigin3D].
+static func find_left(node : Node) -> XRToolsCollisionHand:
+	return XRTools.find_xr_child(
+		XRHelpers.get_left_controller(node),
+		"*",
+		"XRToolsCollisionHand") as XRToolsCollisionHand
+
+
+## This function searches from the specified node for the right controller
+## [XRToolsCollisionHand] assuming the node is a sibling of the [XROrigin3D].
+static func find_right(node : Node) -> XRToolsCollisionHand:
+	return XRTools.find_xr_child(
+		XRHelpers.get_right_controller(node),
+		"*",
+		"XRToolsCollisionHand") as XRToolsCollisionHand
+
+
+# This function moves the collision hand to the target node.
+func _move_to_target():
+	# Handle DISABLED or no target
+	if mode == CollisionHandMode.DISABLED or not _target:
+		return
+
+	# Handle TELEPORT
+	if mode == CollisionHandMode.TELEPORT:
+		global_transform = _target.global_transform
+		return
+
+	# Orient the hand then move
+	global_transform.basis = _target.global_transform.basis
+	move_and_slide(_target.global_position - global_position)
+
+
+# This function inserts a target override into the overrides list by priority
+# order.
+func _insert_target_override(target : Node3D, priority : int) -> void:
+	# Construct the target override
+	var override := TargetOverride.new(target, priority)
+
+	# Iterate over all target overrides in the list
+	for pos in _target_overrides.size():
+		# Get the target override
+		var o : TargetOverride = _target_overrides[pos]
+
+		# Insert as early as possible to not invalidate sorting
+		if o.priority <= priority:
+			_target_overrides.insert(pos, override)
+			return
+
+	# Insert at the end
+	_target_overrides.push_back(override)
+
+
+# This function removes a target from the overrides list
+func _remove_target_override(target : Node) -> bool:
+	var pos := 0
+	var length := _target_overrides.size()
+	var modified := false
+
+	# Iterate over all pose overrides in the list
+	while pos < length:
+		# Get the target override
+		var o : TargetOverride = _target_overrides[pos]
+
+		# Check for a match
+		if o.target == target:
+			# Remove the override
+			_target_overrides.remove_at(pos)
+			modified = true
+			length -= 1
+		else:
+			# Advance down the list
+			pos += 1
+
+	# Return the modified indicator
+	return modified
+
+
+# This function updates the target for hand movement.
+func _update_target() -> void:
+	# Start by assuming the controller
+	_target = _controller
+
+	# Use first target override if specified
+	if _target_overrides.size():
+		_target = _target_overrides[0].target

--- a/addons/godot-xr-tools/hands/scenes/collision/collision_hand_left.tscn
+++ b/addons/godot-xr-tools/hands/scenes/collision/collision_hand_left.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://bkv43ec6chcf3"]
+
+[ext_resource type="Script" path="res://addons/godot-xr-tools/hands/collision_hand.gd" id="1_t5acd"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_bv7in"]
+size = Vector3(0.045, 0.075, 0.1)
+
+[node name="CollisionHandLeft" type="StaticBody3D"]
+process_priority = -90
+collision_layer = 131072
+collision_mask = 327711
+script = ExtResource("1_t5acd")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.11)
+shape = SubResource("BoxShape3D_bv7in")

--- a/addons/godot-xr-tools/hands/scenes/collision/collision_hand_right.tscn
+++ b/addons/godot-xr-tools/hands/scenes/collision/collision_hand_right.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://c3uoohvnshach"]
+
+[ext_resource type="Script" path="res://addons/godot-xr-tools/hands/collision_hand.gd" id="1_so3hf"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_fc2ij"]
+size = Vector3(0.045, 0.075, 0.1)
+
+[node name="CollisionHandRight" type="StaticBody3D"]
+process_priority = -90
+collision_layer = 131072
+collision_mask = 327711
+script = ExtResource("1_so3hf")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.11)
+shape = SubResource("BoxShape3D_fc2ij")

--- a/addons/godot-xr-tools/objects/climbable.gd
+++ b/addons/godot-xr-tools/objects/climbable.gd
@@ -15,7 +15,7 @@ extends Node3D
 ## If true, the grip control must be held to keep holding the climbable
 var press_to_hold : bool = true
 
-## Dictionary of grab locations by pickup
+## Dictionary of temporary grab-handles indexed by the pickup node.
 var grab_locations := {}
 
 
@@ -45,16 +45,24 @@ func decrease_is_closest():
 
 # Called by XRToolsFunctionPickup when this is picked up by a controller
 func pick_up(by: Node3D, _with_controller: XRController3D) -> void:
-	save_grab_location(by)
+	# Get the ID to save the grab handle under
+	var id = by.get_instance_id()
+
+	# Get or construct the grab handle
+	var handle = grab_locations.get(id)
+	if not handle:
+		handle = Node3D.new()
+		add_child(handle)
+		grab_locations[id] = handle
+
+	# Set the handles global transform. As it's a child of this
+	# climbable it will move as the climbable moves
+	handle.global_transform = by.global_transform
 
 # Called by XRToolsFunctionPickup when this is let go by a controller
 func let_go(_p_linear_velocity: Vector3, _p_angular_velocity: Vector3) -> void:
 	pass
 
-# Save the grab location
-func save_grab_location(p: Node3D):
-	grab_locations[p.get_instance_id()] = to_local(p.global_transform.origin)
-
-# Get the grab location in world-space
-func get_grab_location(p: Node3D) -> Vector3:
-	return to_global(grab_locations[p.get_instance_id()])
+# Get the grab handle
+func get_grab_handle(p: Node3D) -> Node3D:
+	return grab_locations.get(p.get_instance_id())

--- a/addons/godot-xr-tools/objects/force_body/force_body.gd
+++ b/addons/godot-xr-tools/objects/force_body/force_body.gd
@@ -1,0 +1,96 @@
+@tool
+class_name XRToolsForceBody
+extends StaticBody3D
+
+
+## XRTools Force Body script
+##
+## This script enhances StaticBody3D with move_and_slide and the ability
+## to push bodies by emparting forces on them.
+
+
+## Force Body Collision
+class ForceBodyCollision:
+	## Collider object
+	var collider : Node3D
+
+	## Collision point
+	var position : Vector3
+
+	## Collision normal
+	var normal : Vector3
+
+
+## Enables or disables pushing bodies
+@export var push_bodies : bool = true
+
+## Control the stiffness of the body
+@export var stiffness : float = 10.0
+
+## Control the maximum push force
+@export var maximum_force : float = 1.0
+
+## Maximum slides
+@export var max_slides : int = 4
+
+
+## Add support for is_xr_class on XRTools classes
+func is_xr_class(name : String) -> bool:
+	return name == "XRToolsForceBody"
+
+
+## This function moves and slides along the [param move] vector. It returns
+## information about the last collision, or null if no collision
+func move_and_slide(move : Vector3) -> ForceBodyCollision:
+	# Loop performing the movement steps
+	var step_move := move
+	var ret : ForceBodyCollision = null
+	for step in max_slides:
+		# Take the next step
+		var collision := move_and_collide(step_move)
+
+		# If we didn't collide with anything then we have finished the entire
+		# move_and_slide operation
+		if not collision:
+			break
+
+		# Save relevant collision information
+		var collider := collision.get_collider()
+		var postion := collision.get_position()
+		var normal := collision.get_normal()
+
+		# Save the collision information
+		if not ret:
+			ret = ForceBodyCollision.new()
+
+		ret.collider = collider
+		ret.position = postion
+		ret.normal = normal
+
+		# Calculate the next move
+		var next_move := collision.get_remainder().slide(normal)
+
+		# Handle pushing bodies
+		if push_bodies:
+			var body := collider as RigidBody3D
+			if body:
+				# Calculate the momentum lost by the collision
+				var lost_momentum := step_move - next_move
+
+				# TODO: We should consider the velocity of the body such that
+				# we never push it away faster than our own velocity.
+
+				# Apply the lost momentum as an impulse to the body we hit
+				body.apply_impulse(
+					(lost_momentum * stiffness).limit_length(maximum_force),
+					position - body.global_position)
+
+		# Update the remaining movement
+		step_move = next_move
+
+		# Prevent bouncing back along movement path
+		if next_move.dot(move) <= 0:
+			break
+
+	# Return the last collision data
+	return ret

--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -102,8 +102,14 @@ var picked_up_by: Node3D = null
 ## Controller holding this item (may be null if held by snap-zone)
 var by_controller : XRController3D = null
 
+## What node "holds" the object
+var hold_node : Node3D = null
+
 ## Hand holding this item (may be null if held by snap-zone)
 var by_hand : XRToolsHand = null
+
+## Collision hand holding this item (may be null)
+var by_collision_hand : XRToolsCollisionHand = null
 
 # Count of 'is_closest' grabbers
 var _closest_count: int = 0
@@ -201,7 +207,9 @@ func pick_up(by: Node3D, with_controller: XRController3D) -> void:
 	# remember who picked us up
 	picked_up_by = by
 	by_controller = with_controller
+	hold_node = with_controller if with_controller else by
 	by_hand = XRToolsHand.find_instance(by_controller)
+	by_collision_hand = XRToolsCollisionHand.find_instance(by_controller)
 	_active_grab_point = _get_grab_point(by)
 
 	# If we have been picked up by a hand then apply the hand-pose-override
@@ -210,6 +218,12 @@ func pick_up(by: Node3D, with_controller: XRController3D) -> void:
 		var grab_point_hand := _active_grab_point as XRToolsGrabPointHand
 		if grab_point_hand and grab_point_hand.hand_pose:
 			by_hand.add_pose_override(self, GRIP_POSE_PRIORITY, grab_point_hand.hand_pose)
+
+	# If we have been picked up by a collision hand then add collision
+	# exceptions to prevent the hand and pickable colliding.
+	if by_collision_hand:
+		add_collision_exception_with(by_collision_hand)
+		by_collision_hand.add_collision_exception_with(self)
 
 	# Remember the mode before pickup
 	match release_mode:
@@ -272,11 +286,19 @@ func let_go(p_linear_velocity: Vector3, p_angular_velocity: Vector3) -> void:
 	if by_hand:
 		by_hand.remove_pose_override(self)
 
+	# If we are held by a cillision hand then remove any collision exceptions
+	# we may have added.
+	if by_collision_hand:
+		remove_collision_exception_with(by_collision_hand)
+		by_collision_hand.remove_collision_exception_with(self)
+
 	# we are no longer picked up
 	_state = PickableState.IDLE
 	picked_up_by = null
 	by_controller = null
 	by_hand = null
+	by_collision_hand = null
+	hold_node = null
 
 	# Stop any XRToolsMoveTo being used for remote grabbing
 	if _move_to:
@@ -346,7 +368,7 @@ func _start_ranged_grab() -> void:
 	# us to the pickup object at the ranged-grab speed, and also takes into account
 	# the center-pickup position
 	_move_to = XRToolsMoveTo.new()
-	_move_to.start(self, picked_up_by, offset, ranged_grab_speed)
+	_move_to.start(self, hold_node, offset, ranged_grab_speed)
 	_move_to.move_complete.connect(_ranged_grab_complete)
 	self.add_child(_move_to)
 
@@ -377,7 +399,7 @@ func _do_snap_grab() -> void:
 			# Construct the remote transform
 			_remote_transform = RemoteTransform3D.new()
 			_remote_transform.set_name("PickupRemoteTransform")
-			picked_up_by.add_child(_remote_transform)
+			hold_node.add_child(_remote_transform)
 			_remote_transform.transform = snap_transform
 			_remote_transform.remote_path = _remote_transform.get_path_to(self)
 
@@ -391,7 +413,7 @@ func _do_snap_grab() -> void:
 
 			# Reparent to the holder with snap transform
 			original_parent.remove_child(self)
-			picked_up_by.add_child(self)
+			hold_node.add_child(self)
 			transform = snap_transform
 
 	# Emit the picked up signal
@@ -406,13 +428,13 @@ func _do_precise_grab() -> void:
 	match hold_method:
 		HoldMethod.REMOTE_TRANSFORM:
 			# Calculate the precise transform for remote-transforming
-			var precise_transform = picked_up_by.global_transform.inverse() * global_transform
+			var precise_transform = hold_node.global_transform.inverse() * global_transform
 
 			# Construct the remote transform
 			_remote_transform = RemoteTransform3D.new()
 			_remote_transform.set_name("PickupRemoteTransform")
-			picked_up_by.add_child(_remote_transform)
-			_remote_transform.transform = picked_up_by.global_transform.inverse() * global_transform
+			hold_node.add_child(_remote_transform)
+			_remote_transform.transform = hold_node.global_transform.inverse() * global_transform
 			_remote_transform.remote_path = _remote_transform.get_path_to(self)
 
 		HoldMethod.REPARENT:
@@ -421,7 +443,7 @@ func _do_precise_grab() -> void:
 
 			# Reparent to the holder with precise transform
 			original_parent.remove_child(self)
-			picked_up_by.add_child(self)
+			hold_node.add_child(self)
 			global_transform = precise_transform
 
 	# Emit the picked up signal

--- a/addons/godot-xr-tools/player/poke/poke_body.gd
+++ b/addons/godot-xr-tools/player/poke/poke_body.gd
@@ -1,4 +1,5 @@
-extends StaticBody3D
+@tool
+extends XRToolsForceBody
 
 
 ## Signal called when we start to contact an object
@@ -11,15 +12,6 @@ signal body_contact_end(node)
 ## Distance at which we teleport our poke body
 @export var teleport_distance : float = 0.1
 
-## Enable or disable pushing rigid bodies
-@export var push_bodies : bool = true
-
-## Stiffness of the finger
-@export var stiffness : float = 10.0
-
-## Maximum finger force
-@export var maximum_force : float = 1.0
-
 
 # Node currently in contact with
 var _contact : Node3D = null
@@ -30,69 +22,28 @@ var _contact : Node3D = null
 
 # Add support for is_xr_class on XRTools classes
 func is_xr_class(name : String) -> bool:
-	return name == "XRToolsPokeBody"
+	return name == "XRToolsPokeBody" or super(name)
 
 
 # Try moving to the parent Poke node
 func _physics_process(_delta):
-	# Get the current position and contact
-	var old_position := global_position
-	var old_contact := _contact
+	# Do not process if in the editor
+	if Engine.is_editor_hint():
+		return
 
 	# Calculate the movement to perform
-	var target_position := _target.global_position
-	var to_target := target_position - old_position
-	var effort := to_target.length()
+	var target := _target.global_position
+	var to_target := target - global_position
 
 	# Decide whether to teleport or slide
-	if effort > teleport_distance:
-		# Perform Teleport
-		global_position = target_position
+	var old_contact := _contact
+	if to_target.length() > teleport_distance:
+		# Teleport to the target
+		global_position = target
 	else:
-		# Perform Slide (up to 4 times)
-		_contact = null
-		var force_direction := to_target.normalized()
-		var next_direction := force_direction
-		for n in 4:
-			# Calculate how efficiently we can move/slide
-			var efficiency := next_direction.dot(force_direction)
-			if efficiency <= 0.0 or effort <= 0.0:
-				break
-
-			# Perform the move
-			var step_physical := effort * efficiency
-			var collision := move_and_collide(next_direction * step_physical)
-
-			# If no collision then we have moved the rest of the distance
-			if not collision:
-				break
-
-			# Calculate how much of the move remains [0..1]
-			var remains := collision.get_remainder().length() / step_physical
-			remains = clamp(remains, 0.0, 1.0)
-
-			# Update the remaining effort
-			effort *= remains
-
-			# Calculate the next slide direction
-			next_direction = force_direction.slide(collision.get_normal()).normalized()
-
-			# Save the contact
-			_contact = collision.get_collider()
-
-			# Optionally support pushing rigid bodies
-			if push_bodies:
-				var contact_rigid := _contact as RigidBody3D
-				if contact_rigid:
-					# Calculate the finger force
-					var force := target_position - global_position
-					force *= stiffness
-					force = force.limit_length(maximum_force)
-
-					# Apply as an impulse
-					contact_rigid.apply_impulse(
-						force,
-						collision.get_position() - contact_rigid.global_position)
+		# Move and slide to the target
+		var collision := move_and_slide(to_target)
+		_contact = collision.collider if collision else null
 
 	# Report when we stop being in contact with the current object
 	if old_contact and old_contact != _contact:


### PR DESCRIPTION
This PR implements the following:
- Extracted force-pushing-body logic from PokeBody into XRToolsForceBody.
- Modified XRToolsHand so it can be any descendant of an XRController3D (from DigitalN8m4r3/BastiaanOlij)
- Added rough XRToolsCollisionHand script
- Modified interactables demo to hack XRToolsCollisionHand in for now

The interactable demo scene puts an XRToolsCollisionHand under the left controller, and moves everything else under it. It also adds a basic box as a hand collider:
![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/de108b92-0fc3-4a96-a18d-b03bbc4f923e)
![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/28c9e480-990b-4975-84da-24b33f14d6f2)

The XRToolsCollisionHand script has a few experimental modes:
![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/2f7bd532-7d4d-4def-bada-dd5b92c6efda)
