### PR TITLE
Mark project settings as basic so they are always shown

### DIFF
--- a/addons/godot-xr-tools/plugin.gd
+++ b/addons/godot-xr-tools/plugin.gd
@@ -32,6 +32,8 @@ func _define_project_setting(
 	}
 
 	ProjectSettings.add_property_info(property_info)
+	if ProjectSettings.has_method("set_as_basic"):
+		ProjectSettings.call("set_as_basic", p_name, true)
 	ProjectSettings.set_initial_value(p_name, p_default_val)
 
 


### PR DESCRIPTION
This is only possible in v4.1 onwards, but the way I did this should mean the change is just skipped in 4.0, but in order to see our project settings right away instead of selecting "advanced settings" is by marking them as basic.
We are doing that in this PR.