### PR TITLE
Simplify player up planes and vectors.

### DIFF
--- a/addons/godot-xr-tools/functions/movement_climb.gd
+++ b/addons/godot-xr-tools/functions/movement_climb.gd
@@ -174,8 +174,9 @@ func _set_climbing(active: bool, player_body: XRToolsPlayerBody) -> void:
 		emit_signal("player_climb_start")
 	else:
 		# Calculate the forward direction (based on camera-forward)
-		var dir_forward = -player_body.up_player_plane.project(
-			player_body.camera_node.global_transform.basis.z).normalized()
+		var dir_forward = -player_body.camera_node.global_transform.basis.z \
+				.slide(player_body.up_player) \
+				.normalized()
 
 		# Set player velocity based on averaged velocity, fling multiplier,
 		# and a forward push

--- a/addons/godot-xr-tools/functions/movement_flight.gd
+++ b/addons/godot-xr-tools/functions/movement_flight.gd
@@ -140,32 +140,33 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	var pitch_vector: Vector3
 	if pitch == FlightPitch.HEAD:
 		# Use the vertical part of the 'head' forwards vector
-		pitch_vector = -_camera.transform.basis.z.y * player_body.up_player_vector
+		pitch_vector = -_camera.transform.basis.z.y * player_body.up_player
 	else:
 		# Use the vertical part of the 'controller' forwards vector
-		pitch_vector = -_controller.transform.basis.z.y * player_body.up_player_vector
+		pitch_vector = -_controller.transform.basis.z.y * player_body.up_player
 
 	# Select the bearing vector
 	var bearing_vector: Vector3
 	if bearing == FlightBearing.HEAD:
 		# Use the horizontal part of the 'head' forwards vector
-		bearing_vector = -player_body.up_player_plane.project(
-				_camera.global_transform.basis.z)
+		bearing_vector = -_camera.global_transform.basis.z \
+				.slide(player_body.up_player)
 	elif bearing == FlightBearing.CONTROLLER:
 		# Use the horizontal part of the 'controller' forwards vector
-		bearing_vector = -player_body.up_player_plane.project(
-				_controller.global_transform.basis.z)
+		bearing_vector = -_controller.global_transform.basis.z \
+				.slide(player_body.up_player)
 	else:
 		# Use the horizontal part of the 'body' forwards vector
 		var left := _left_controller.global_transform.origin
 		var right := _right_controller.global_transform.origin
 		var left_to_right := right - left
-		bearing_vector = player_body.up_player_plane.project(
-				left_to_right.rotated(player_body.up_player_vector, PI/2))
+		bearing_vector = left_to_right \
+				.rotated(player_body.up_player, PI/2) \
+				.slide(player_body.up_player)
 
 	# Construct the flight bearing
 	var forwards := (bearing_vector.normalized() + pitch_vector).normalized()
-	var side := forwards.cross(player_body.up_player_vector)
+	var side := forwards.cross(player_body.up_player)
 
 	# Construct the target velocity
 	var joy_forwards := _controller.get_vector2("primary").y

--- a/addons/godot-xr-tools/functions/movement_footstep.gd
+++ b/addons/godot-xr-tools/functions/movement_footstep.gd
@@ -133,7 +133,7 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 # Update the foot spatial to be where the players foot is
 func _update_foot_spatial() -> void:
 	# Project the players camera down to the XZ plane (real-world space)
-	var local_foot := Plane.PLANE_XZ.project(player_body.camera_node.position)
+	var local_foot := player_body.camera_node.position.slide(Vector3.UP)
 
 	# Move the foot_spatial to the local foot in the global origin space
 	_foot_spatial.global_position = player_body.origin_node.global_transform * local_foot

--- a/addons/godot-xr-tools/functions/movement_glide.gd
+++ b/addons/godot-xr-tools/functions/movement_glide.gd
@@ -158,11 +158,11 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	var left_to_right := right_position - left_position
 
 	if turn_with_roll:
-		var angle = -left_to_right.dot(player_body.up_player_vector)
+		var angle = -left_to_right.dot(player_body.up_player)
 		player_body.rotate_player(roll_turn_speed * delta * angle)
 
 	# If not falling, then not gliding
-	var vertical_velocity := player_body.velocity.dot(player_body.up_gravity_vector)
+	var vertical_velocity := player_body.velocity.dot(player_body.up_gravity)
 	vertical_velocity += wings_impulse_velocity
 	if vertical_velocity >= glide_min_fall_speed && wings_impulse_velocity == 0.0:
 		_set_gliding(false)
@@ -180,14 +180,16 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	vertical_velocity = lerp(vertical_velocity, glide_fall_speed, vertical_slew_rate * delta)
 
 	# Lerp the horizontal velocity towards forward_speed
-	var horizontal_velocity := player_body.up_gravity_plane.project(player_body.velocity)
-	var dir_forward := player_body.up_gravity_plane.project(
-			left_to_right.rotated(player_body.up_gravity_vector, PI/2)).normalized()
+	var horizontal_velocity := player_body.velocity.slide(player_body.up_gravity)
+	var dir_forward := left_to_right \
+			.rotated(player_body.up_gravity, PI/2) \
+			.slide(player_body.up_gravity) \
+			.normalized()
 	var forward_velocity := dir_forward * glide_forward_speed
 	horizontal_velocity = horizontal_velocity.lerp(forward_velocity, horizontal_slew_rate * delta)
 
 	# Perform the glide
-	var glide_velocity := horizontal_velocity + vertical_velocity * player_body.up_gravity_vector
+	var glide_velocity := horizontal_velocity + vertical_velocity * player_body.up_gravity
 	player_body.velocity = player_body.move_body(glide_velocity)
 
 	# Report exclusive motion performed (to bypass gravity)

--- a/addons/godot-xr-tools/functions/movement_wall_walk.gd
+++ b/addons/godot-xr-tools/functions/movement_wall_walk.gd
@@ -23,7 +23,7 @@ const DEFAULT_MASK := 0b0000_0000_0000_0000_0000_0000_0000_1000
 func physics_pre_movement(_delta: float, player_body: XRToolsPlayerBody):
 	# Test for collision with wall under feet
 	var wall_collision := player_body.move_and_collide(
-		player_body.up_player_vector * -stick_distance, true, true, true)
+		player_body.up_player * -stick_distance, true, true, true)
 	if !wall_collision:
 		return
 


### PR DESCRIPTION
This pull request simplifies how the XRToolsPlayerBody tracks the gravity and player "up" information. The player currently uses:
- `gravity_up_vector : Vector3` vector pointing up in the local gravity
- `gravity_up_plane : Plane ` origin-plane pointing up in the local gravity
- `player_up_vector : Vector3` vector pointing in the players up direction
- `player_up_plane : Plane` origin-plane pointing in the players up direction

The planes are all at the origin and their `Plane.project` methods are used to flatten vectors to be "horizontal", as this approach works even when the player may be oriented/rotated due to local gravity fields or wall-walking. For example:
```gdscript
# Get the horizontal-direction the player is looking. This is done by taking the camera -Z (forwards)
# vector and projecting it onto an origin-plane horizontal to the player.
var camera_forwards := player_body.up_player_plane \
        .project(-player_body.camera_node.global_transform.basis.z) \
        .normalized()
```

While this process is easy to comprehend, it's actually overly complicated because `Vector3.slide` does the same thing.
```gdscript
# Get the horizontal-direction the player is looking. This is done by taking the camera -Z (forwards)
# vector and sliding it onto the an origin-plane defined by the players up direction.
var camera_forwards := -player_body.camera_node.global_transform.basis.z
        .slide(player_body.up_player_vector) \
        .normalized()
```

Having two representations of the same information inefficient and opens the possibility for the representations to get out of sync. As such this pull request replaces the old fields with:
- `gravity_up : Vector3` vector pointing up in the local gravity (Vector3.slide replaces Plane.project)
- `player_up : Vector3` vector pointing in the players up direction (Vector3.slide replaces Plane.project)
