### PR TITLE
Handle scaling of Viewport2Din3D

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.tscn
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.tscn
@@ -41,6 +41,7 @@ script = ExtResource("2")
 viewport_size = Vector2(300, 200)
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.01)
 shape = SubResource("4")
 
 [connection signal="pointer_entered" from="StaticBody3D" to="." method="_on_pointer_entered"]

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
@@ -13,7 +13,7 @@ func _ready():
 # Convert intersection point to screen coordinate
 func global_to_viewport(p_at):
 	var t = $CollisionShape3D.global_transform
-	var at = t.inverse() * p_at
+	var at = t.affine_inverse() * p_at
 
 	# Convert to screen space
 	at.x = ((at.x / screen_size.x) + 0.5) * viewport_size.x


### PR DESCRIPTION
There are times when a Viewport2Din3D has to be scaled - such as when the screen is worn by the player, and the player changes size. This pull request makes Viewport2Din3D scaling functional by:
- Using affine_inverse for global_to_viewport to handle scaling
- Move the collider from "around" the screen to "behind" the screen

The normal `Transform3D.inverse()` method only works when the transform has no scaling. When the transform has scaling the `Transform3D.affine_inverse()` must be used instead.

The change to the collider was because the collider surrounded the screen (1cm in front and back). While this isn't too bad when using an unscaled Viewport2Din3D, the problem gets worse as the screen is scaled up.
![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/bcc5e180-2b1a-474b-b35a-6a248548d92d)
