### PR TITLE
Improve control over pickable object highlighting

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -8,6 +8,7 @@
 - Updated pointer to support visibility properties and events
 - Modified virtual keyboard to expose viewport controls and default to unshaded
 - Cleaned up teleport and added more properties for customization
+- Modified pickup highlighting to support pickables in snap-zones
 
 # 4.1.0
 - Enhanced grappling to support collision and target layers

--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -316,12 +316,12 @@ func _update_closest_object() -> void:
 
 	# remove highlight on old object
 	if is_instance_valid(closest_object):
-		closest_object.decrease_is_closest()
+		closest_object.request_highlight(self, false)
 
 	# add highlight to new object
 	closest_object = new_closest_obj
 	if is_instance_valid(closest_object):
-		closest_object.increase_is_closest()
+		closest_object.request_highlight(self, true)
 
 
 # Find the pickable object closest to our hand's grab location

--- a/addons/godot-xr-tools/objects/climbable.gd
+++ b/addons/godot-xr-tools/objects/climbable.gd
@@ -35,12 +35,8 @@ func can_pick_up(_by: Node3D) -> bool:
 func action():
 	pass
 
-# Called by XRToolsFunctionPickup when this becomes the closest object to a controller
-func increase_is_closest():
-	pass
-
-# Called by XRToolsFunctionPickup when this stops being the closest object to a controller
-func decrease_is_closest():
+# Ignore highlighting requests from XRToolsFunctionPickup
+func request_highlight(_from, _on) -> void:
 	pass
 
 # Called by XRToolsFunctionPickup when this is picked up by a controller

--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -135,14 +135,10 @@ func action():
 	pass
 
 
-# Pickable Method: Ignore snap-zone proximity to grippers
-func increase_is_closest():
-	pass
-
-
-# Pickable Method: Ignore snap-zone proximity to grippers
-func decrease_is_closest():
-	pass
+# Ignore highlighting requests from XRToolsFunctionPickup
+func request_highlight(from : Node, on : bool = true) -> void:
+	if picked_up_object:
+		picked_up_object.request_highlight(from, on)
 
 
 # Pickable Method: Object being grabbed from this snap zone


### PR DESCRIPTION
This pull request switches the pickable object highlighting methods from:
```gdscript
func increase_is_closest()
func decrease_is_closest()
```
to:
```gdscript
func highlight_request(from : Node, on : bool)
```

The old method used reference counting which was prone to dropping counts, and was intended only for proximity-triggering.

The new method saves tracks which nodes are asking for the highlight, so a node can safely set or clear its request any number of times without interfering with other requests. Additionally the highlighting could be for any reason not just proximity.

Finally this method now allows snap-zones to forward highlighting requests to objects in the snap zones. This makes it easier to see which object is ready to be pulled out of a snap-zone.