### PR TITLE
Teleport improvements

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,6 +7,7 @@
 - Added support for custom materials for 2D in 3D viewport
 - Updated pointer to support visibility properties and events
 - Modified virtual keyboard to expose viewport controls and default to unshaded
+- Cleaned up teleport and added more properties for customization
 
 # 4.1.0
 - Enhanced grappling to support collision and target layers

--- a/addons/godot-xr-tools/functions/function_teleport.tscn
+++ b/addons/godot-xr-tools/functions/function_teleport.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://fiul51tsyoop"]
+[gd_scene load_steps=8 format=3 uid="uid://fiul51tsyoop"]
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools/functions/function_teleport.gd" id="1"]
 [ext_resource type="Material" uid="uid://bk72wfw25ff0v" path="res://addons/godot-xr-tools/materials/teleport.tres" id="2"]
@@ -16,16 +16,9 @@ size = Vector2(1, 1)
 radius = 0.4
 height = 1.8
 
-[sub_resource type="CapsuleShape3D" id="4"]
-radius = 0.05
-height = 0.1
-
-[node name="FunctionTeleport" type="CharacterBody3D"]
-collision_layer = 524288
-collision_mask = 1023
-input_ray_pickable = false
+[node name="FunctionTeleport" type="Node3D"]
 script = ExtResource("1")
-no_collision_color = Color(0.176471, 0.313726, 0.862745, 1)
+player_material = ExtResource("4")
 
 [node name="Teleport" type="MeshInstance3D" parent="."]
 mesh = SubResource("1")
@@ -42,7 +35,3 @@ surface_material_override/0 = ExtResource("3")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.9, 0)
 mesh = SubResource("3")
 surface_material_override/0 = ExtResource("4")
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, 0, 0)
-shape = SubResource("4")


### PR DESCRIPTION
This pull request cleans up the teleport function by:
- Changing it to extend from a Node3D rather than the CharacterBody3D workaround
- Grouped and enhanced properties

The player can now control the teleport visual textures and the material of the player capsule.

![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/63e5a3db-c481-40cb-8eaa-d3c9f784141b)
![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/7134e043-daff-4ece-8ee9-186785e9ba69)
