### PR TITLE
Added process_physics_priority settings for Godot 4.1+

### DIFF
--- a/addons/godot-xr-tools/hands/scenes/collision/collision_hand_left.tscn
+++ b/addons/godot-xr-tools/hands/scenes/collision/collision_hand_left.tscn
@@ -7,6 +7,7 @@ size = Vector3(0.045, 0.075, 0.1)
 
 [node name="CollisionHandLeft" type="StaticBody3D"]
 process_priority = -90
+process_physics_priority = -90
 collision_layer = 131072
 collision_mask = 327711
 script = ExtResource("1_t5acd")

--- a/addons/godot-xr-tools/hands/scenes/collision/collision_hand_right.tscn
+++ b/addons/godot-xr-tools/hands/scenes/collision/collision_hand_right.tscn
@@ -7,6 +7,7 @@ size = Vector3(0.045, 0.075, 0.1)
 
 [node name="CollisionHandRight" type="StaticBody3D"]
 process_priority = -90
+process_physics_priority = -90
 collision_layer = 131072
 collision_mask = 327711
 script = ExtResource("1_so3hf")

--- a/addons/godot-xr-tools/player/player_body.tscn
+++ b/addons/godot-xr-tools/player/player_body.tscn
@@ -4,6 +4,7 @@
 
 [node name="PlayerBody" type="CharacterBody3D" groups=["player_body"]]
 process_priority = -100
+process_physics_priority = -100
 top_level = true
 collision_layer = 524288
 collision_mask = 1023


### PR DESCRIPTION
This pull request adds the `process_physics_priority` settings to objects needing custom physics order. The settings are required for Godot 4.1+, but are ignored for Godot 4.0 which uses the `process_priority` setting for both render and physics.