### PR TITLE
Fix issues with static body not being detected by area3D

### DIFF
--- a/addons/godot-xr-tools/hands/scenes/collision/collision_hand_left.tscn
+++ b/addons/godot-xr-tools/hands/scenes/collision/collision_hand_left.tscn
@@ -5,11 +5,11 @@
 [sub_resource type="BoxShape3D" id="BoxShape3D_bv7in"]
 size = Vector3(0.045, 0.075, 0.1)
 
-[node name="CollisionHandLeft" type="StaticBody3D"]
+[node name="CollisionHandLeft" type="AnimatableBody3D"]
 process_priority = -90
-process_physics_priority = -90
 collision_layer = 131072
 collision_mask = 327711
+sync_to_physics = false
 script = ExtResource("1_t5acd")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]

--- a/addons/godot-xr-tools/hands/scenes/collision/collision_hand_right.tscn
+++ b/addons/godot-xr-tools/hands/scenes/collision/collision_hand_right.tscn
@@ -5,11 +5,11 @@
 [sub_resource type="BoxShape3D" id="BoxShape3D_fc2ij"]
 size = Vector3(0.045, 0.075, 0.1)
 
-[node name="CollisionHandRight" type="StaticBody3D"]
+[node name="CollisionHandRight" type="AnimatableBody3D"]
 process_priority = -90
-process_physics_priority = -90
 collision_layer = 131072
 collision_mask = 327711
+sync_to_physics = false
 script = ExtResource("1_so3hf")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]

--- a/addons/godot-xr-tools/objects/force_body/force_body.gd
+++ b/addons/godot-xr-tools/objects/force_body/force_body.gd
@@ -1,11 +1,11 @@
 @tool
 class_name XRToolsForceBody
-extends StaticBody3D
+extends AnimatableBody3D
 
 
 ## XRTools Force Body script
 ##
-## This script enhances StaticBody3D with move_and_slide and the ability
+## This script enhances AnimatableBody3D with move_and_slide and the ability
 ## to push bodies by emparting forces on them.
 
 
@@ -42,6 +42,9 @@ func is_xr_class(name : String) -> bool:
 ## This function moves and slides along the [param move] vector. It returns
 ## information about the last collision, or null if no collision
 func move_and_slide(move : Vector3) -> ForceBodyCollision:
+	# Make sure this is off or weird shit happens...
+	sync_to_physics = false
+
 	# Loop performing the movement steps
 	var step_move := move
 	var ret : ForceBodyCollision = null

--- a/addons/godot-xr-tools/player/poke/poke.tscn
+++ b/addons/godot-xr-tools/player/poke/poke.tscn
@@ -14,7 +14,7 @@ height = 0.01
 radial_segments = 32
 rings = 16
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_yhep2"]
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_g1b1h"]
 transparency = 1
 shading_mode = 0
 albedo_color = Color(0.8, 0.8, 1, 0.5)
@@ -22,10 +22,11 @@ albedo_color = Color(0.8, 0.8, 1, 0.5)
 [node name="Poke" type="Node3D"]
 script = ExtResource("1")
 
-[node name="PokeBody" type="StaticBody3D" parent="."]
+[node name="PokeBody" type="AnimatableBody3D" parent="."]
 top_level = true
 collision_layer = 131072
 collision_mask = 4259839
+sync_to_physics = false
 script = ExtResource("2")
 
 [node name="CollisionShape" type="CollisionShape3D" parent="PokeBody"]
@@ -33,7 +34,7 @@ shape = SubResource("1")
 
 [node name="MeshInstance" type="MeshInstance3D" parent="PokeBody"]
 mesh = SubResource("2")
-surface_material_override/0 = SubResource("StandardMaterial3D_yhep2")
+surface_material_override/0 = SubResource("StandardMaterial3D_g1b1h")
 
 [connection signal="body_contact_end" from="PokeBody" to="." method="_on_PokeBody_body_contact_end"]
 [connection signal="body_contact_start" from="PokeBody" to="." method="_on_PokeBody_body_contact_start"]


### PR DESCRIPTION
Turns out that `StaticBody3D` is no longer detected by `Area3D` in Godot 4.
This is causing issues when using collision hands and interactable.

One workaround seems to be to use the new `AnimatableBody3D`.

Still looking into other effected areas.