### PR TITLE
Report staging load errors

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,6 @@
 # 4.3.0
 - Upgraded project to Godot 4.1 as the new minimum version.
+- Added reporting of stage load errors.
 
 # 4.2.1
 - Fixed snap-zones showing highlight when disabled.


### PR DESCRIPTION
This pull request implements #416 by adding code to report stage load errors by:
- Writing an error message to the log-file and console
- Breaking in the debugger (if present)
- Terminating the application with a non-zero exit code

Testing of a bad stage-load resulted in the following error output to the console:
```
ERROR: Cannot open file 'res://scenes/poke_demo/poke_demo_bad.tscn'.
   at: (scene/resources/resource_format_text.cpp:1659)
ERROR: Failed loading resource: res://scenes/poke_demo/poke_demo_bad.tscn. Make sure resources have been imported by opening the project in the editor at least once.
   at: (core/io/resource_loader.cpp:222)
ERROR: Error 2 loading resource res://scenes/poke_demo/poke_demo_bad.tscn
   at: push_error (core/variant/variant_utility.cpp:903)
```

The following was also written to the log file:
```
USER ERROR: Cannot open file 'res://scenes/poke_demo/poke_demo_bad.tscn'.
   at: load (scene/resources/resource_format_text.cpp:1659)
USER ERROR: Failed loading resource: res://scenes/poke_demo/poke_demo_bad.tscn. Make sure resources have been imported by opening the project in the editor at least once.
   at: _load (core/io/resource_loader.cpp:222)
USER ERROR: Error 2 loading resource res://scenes/poke_demo/poke_demo_bad.tscn
   at: push_error (core/variant/variant_utility.cpp:903)
```