### PR TITLE
Fix snap-zones highlighting when disabled

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,6 @@
+# 4.2.1
+- Fixed snap-zones showing highlight when disabled.
+
 # 4.2.0
 - Environments can now be set normally in scenes loaded through the staging system.
 - Fixed issue with not being able to push rigid bodies when colliding with them.


### PR DESCRIPTION
This pull request fixes issue #522 by using the `enabled` property when sending the highlight_updated and close_highlight_updated signals. A disabled snap-zone always requests highlighting be disabled.