### PR TITLE
Fix pickup leaving target highlighted

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,6 @@
 # 4.2.1
 - Fixed snap-zones showing highlight when disabled.
+- Fixed pickup leaving target highlighted after picking up.
 
 # 4.2.0
 - Environments can now be set normally in scenes loaded through the staging system.

--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -405,6 +405,7 @@ func _pick_up_object(target: Node3D) -> void:
 
 	# If object picked up then emit signal
 	if is_instance_valid(picked_up_object):
+		picked_up_object.request_highlight(self, false)
 		emit_signal("has_picked_up", picked_up_object)
 
 


### PR DESCRIPTION
This pull request fixes bug #524 by having the XRToolsFunctionPickup clear its highlight request on the target when it picks it up.