### PR TITLE
Fix collision hands when they get too far from the real hands

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,7 @@
 # 4.2.1
 - Fixed snap-zones showing highlight when disabled.
 - Fixed pickup leaving target highlighted after picking up.
+- Fixed collision hands getting stuck too far from the real hands.
 
 # 4.2.0
 - Environments can now be set normally in scenes loaded through the staging system.

--- a/addons/godot-xr-tools/hands/collision_hand.gd
+++ b/addons/godot-xr-tools/hands/collision_hand.gd
@@ -36,6 +36,9 @@ const DEFAULT_MASK := 0b0000_0000_0000_0000_1111_1111_1111_1111
 # How much displacement is required for the hand to start orienting to a surface
 const ORIENT_DISPLACEMENT := 0.05
 
+# Distance to teleport hands
+const TELEPORT_DISTANCE := 1.0
+
 
 ## Controls the hand collision mode
 @export var mode : CollisionHandMode = CollisionHandMode.COLLIDE
@@ -157,6 +160,11 @@ func _move_to_target():
 
 	# Handle TELEPORT
 	if mode == CollisionHandMode.TELEPORT:
+		global_transform = _target.global_transform
+		return
+
+	# Handle too far from target
+	if global_position.distance_to(_target.global_position) > TELEPORT_DISTANCE:
 		global_transform = _target.global_transform
 		return
 


### PR DESCRIPTION
This pull request fixes issue #529 by detecting when the collision hands get too far from the target, and teleporting them.