### PR TITLE
enable OptionButton to work from vr-simulator

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -199,7 +199,8 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 
 # Handler for input eventsd
 func _input(event):
-	$Viewport.push_input(event)
+	if not (event is InputEventMouseButton):
+		$Viewport.push_input(event)
 
 
 # Process event


### PR DESCRIPTION
When trying to click on an OptionButton using the [xr-simulator](https://github.com/Cafezinhu/godot-vr-simulator) add-on they never popup.  This seems to be due to it receiving double clicks.  

I don't know exactly what this push_event function is doing as a lot of events go through it that don't get into the UI (when not holding down the E key in the simulator), but I think it's responsible for duplicate clicks going through and immediately closing the popup.  

There's something problematic happening in the implementation, as reported at: https://github.com/godotengine/godot/issues/81579#issuecomment-1729468644

(The other bug where the popup remains activated and pops up again if you had selected the option in the mode of a click release is still there after this change.)

