### PR TITLE
Fix hand pose on held object destruction

### DIFF
--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -156,6 +156,13 @@ func _ready():
 			_grab_points.push_back(grab_point)
 
 
+# Called when the node exits the tree
+func _exit_tree():
+	# Ensure any hand poses we have applied are revoked on exit
+	if is_instance_valid(by_hand):
+		by_hand.remove_pose_override(self)
+
+
 # Test if this object can be picked up
 func can_pick_up(_by: Node3D) -> bool:
 	return enabled and _state == PickableState.IDLE


### PR DESCRIPTION
This pull request fixes issue #542 by having the pickable object unregister any hand-pose override when it leaves the scene-tree.