### PR TITLE
Add is_instance_valid check for highlighting item in snap-zone

### DIFF
--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -137,7 +137,7 @@ func action():
 
 # Ignore highlighting requests from XRToolsFunctionPickup
 func request_highlight(from : Node, on : bool = true) -> void:
-	if picked_up_object:
+	if is_instance_valid(picked_up_object):
 		picked_up_object.request_highlight(from, on)
 
 


### PR DESCRIPTION
This PR fixes issue #547 by adding an is_instance_valid check before attempting to highlight an item in a snap-zone in case it has been freed.