### PR TITLE
Fix grappling on gridmaps

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@
 - Blend player height changes and prevent the player from standing up under a low ceiling.
 - **minor-breakage** Added support for swapping held items between hands.
 - Added jog-in-place movement provider.
+- Added support for grappling on GridMap instances
 
 # 4.2.1
 - Fixed snap-zones showing highlight when disabled.

--- a/addons/godot-xr-tools/functions/movement_grapple.gd
+++ b/addons/godot-xr-tools/functions/movement_grapple.gd
@@ -117,13 +117,21 @@ func _ready():
 	_line.hide()
 
 
-# Update grapple display objects
-func _process(_delta: float):
+# Update the grappling line and target
+func _physics_process(_delta : float):
 	# Skip if running in the editor
 	if Engine.is_editor_hint():
 		return
 
-	# Update grapple line
+	# If pointing grappler at target then show the target
+	if enabled and not is_active and _is_raycast_valid():
+		_grapple_target.global_transform.origin = _grapple_raycast.get_collision_point()
+		_grapple_target.global_transform = _grapple_target.global_transform.orthonormalized()
+		_grapple_target.visible = true
+	else:
+		_grapple_target.visible = false
+
+	# If actively grappling then update and show the grappling line
 	if is_active:
 		var line_length := (hook_point - _controller.global_transform.origin).length()
 		_line_helper.look_at(hook_point, Vector3.UP)
@@ -132,14 +140,6 @@ func _process(_delta: float):
 		_line.visible = true
 	else:
 		_line.visible = false
-
-	# Update grapple target
-	if enabled and !is_active and _is_raycast_valid():
-		_grapple_target.global_transform.origin  = _grapple_raycast.get_collision_point()
-		_grapple_target.global_transform = _grapple_target.global_transform.orthonormalized()
-		_grapple_target.visible = true
-	else:
-		_grapple_target.visible = false
 
 
 # Perform grapple movement
@@ -220,14 +220,12 @@ func _set_grappling(active: bool) -> void:
 
 # Test if the raycast is striking a valid target
 func _is_raycast_valid() -> bool:
-	# Fail if raycast not colliding
-	if not _grapple_raycast.is_colliding():
+	# Test if the raycast hit a collider
+	var target = _grapple_raycast.get_collider()
+	if not is_instance_valid(target):
 		return false
 
-	# Get the target of the raycast
-	var target : CollisionObject3D = _grapple_raycast.get_collider()
-
-	# Check tartget layer
+	# Check collider layer
 	return true if target.collision_layer & grapple_enable_mask else false
 
 


### PR DESCRIPTION
This PR fixes issue #541 by only updating the RayCast3D when needed in the physics frame (to prevent getting stale data), and by relaxing the type of collider to be of anything the RayCast3D can collide with - including GridMaps.

The following screen-shots were taken using the KayKit City Builder Bits assets in a GridMap.
![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/42a87c92-df2c-4f36-96cd-b655af1dd3c1)
![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/344c1b6a-079b-4a0f-aa18-05bed888e08c)
