### PR TITLE
Add double click on function_pointer

### DIFF
--- a/addons/godot-xr-tools/events/pointer_event.gd
+++ b/addons/godot-xr-tools/events/pointer_event.gd
@@ -10,6 +10,9 @@ enum Type {
 
 	## Pointer pressed target
 	PRESSED,
+	
+	## Pointer double click target
+	DOUBLECLICK,
 
 	## Pointer released target
 	RELEASED,
@@ -85,6 +88,19 @@ static func pressed(
 	report(
 		XRToolsPointerEvent.new(
 			Type.PRESSED,
+			pointer,
+			target,
+			at,
+			at))
+
+## Report pointer doubleclick event
+static func doubleclick(
+		pointer : Node3D,
+		target : Node3D,
+		at : Vector3) -> void:
+	report(
+		XRToolsPointerEvent.new(
+			Type.DOUBLECLICK,
 			pointer,
 			target,
 			at,

--- a/addons/godot-xr-tools/events/pointer_event.gd
+++ b/addons/godot-xr-tools/events/pointer_event.gd
@@ -10,7 +10,7 @@ enum Type {
 
 	## Pointer pressed target
 	PRESSED,
-	
+
 	## Pointer double click target
 	DOUBLECLICK,
 

--- a/addons/godot-xr-tools/functions/function_pointer.gd
+++ b/addons/godot-xr-tools/functions/function_pointer.gd
@@ -53,6 +53,9 @@ const SUPPRESS_MASK := 0b0000_0000_0100_0000_0000_0000_0000_0000
 ## Active button action
 @export var active_button_action : String = "trigger_click"
 
+## debounce time for double click
+@export var debounce_active_button_time : float = 0.25
+
 ## Double Click action
 @export var double_click_action : String = "ax_button"
 
@@ -124,6 +127,9 @@ var _controller  : XRController3D
 
 # The currently active controller
 var _active_controller : XRController3D
+
+# flag to manage double click in active button
+var _debounce_active_button = false
 
 
 ## Add support for is_xr_class on XRTools classes
@@ -446,9 +452,17 @@ func _on_button_pressed(p_button : String, controller : XRController3D) -> void:
 	#detect if trigger or double click action
 	if p_button == active_button_action and enabled:
 		if controller == _active_controller:
-			_button_pressed()
+			if _debounce_active_button:
+				_button_doubleclick()
+				_debounce_active_button = false
+			else:
+				_button_pressed()
+				_debounce_active_button = true
+				await get_tree().create_timer(debounce_active_button_time).timeout
+				_debounce_active_button = false
 		else:
 			_active_controller = controller
+
 	if p_button == double_click_action and enabled:
 		if controller == _active_controller:
 			_button_doubleclick()

--- a/addons/godot-xr-tools/functions/function_pointer.gd
+++ b/addons/godot-xr-tools/functions/function_pointer.gd
@@ -53,6 +53,9 @@ const SUPPRESS_MASK := 0b0000_0000_0100_0000_0000_0000_0000_0000
 ## Active button action
 @export var active_button_action : String = "trigger_click"
 
+## Double Click action
+@export var double_click_action : String = "ax_button"
+
 @export_group("Laser")
 
 ## Controls when the laser is visible
@@ -421,6 +424,13 @@ func _button_pressed() -> void:
 		last_collided_at = $RayCast.get_collision_point()
 		XRToolsPointerEvent.pressed(self, target, last_collided_at)
 
+# Pointer-activation button pressed handler
+func _button_doubleclick() -> void:
+	if $RayCast.is_colliding():
+		# Report doubleclick
+		target = $RayCast.get_collider()
+		last_collided_at = $RayCast.get_collision_point()
+		XRToolsPointerEvent.doubleclick(self, target, last_collided_at)
 
 # Pointer-activation button released handler
 func _button_released() -> void:
@@ -433,9 +443,15 @@ func _button_released() -> void:
 
 # Button pressed handler
 func _on_button_pressed(p_button : String, controller : XRController3D) -> void:
+	#detect if trigger or double click action
 	if p_button == active_button_action and enabled:
 		if controller == _active_controller:
 			_button_pressed()
+		else:
+			_active_controller = controller
+	if p_button == double_click_action and enabled:
+		if controller == _active_controller:
+			_button_doubleclick()
 		else:
 			_active_controller = controller
 

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
@@ -87,7 +87,7 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 		XRToolsPointerEvent.Type.PRESSED:
 			_presses[pointer] = true
 			pressed = true
-		
+
 		XRToolsPointerEvent.Type.DOUBLECLICK:
 			_presses[pointer] = true
 			pressed = true
@@ -133,7 +133,7 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 
 			XRToolsPointerEvent.Type.MOVED:
 				_report_mouse_move(pressed, last, at)
-				
+
 			XRToolsPointerEvent.Type.DOUBLECLICK:
 				_report_mouse_down(at)
 				_report_mouse_down_double_click(at)

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
@@ -87,6 +87,10 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 		XRToolsPointerEvent.Type.PRESSED:
 			_presses[pointer] = true
 			pressed = true
+		
+		XRToolsPointerEvent.Type.DOUBLECLICK:
+			_presses[pointer] = true
+			pressed = true
 
 		XRToolsPointerEvent.Type.RELEASED:
 			_presses.erase(pointer)
@@ -99,6 +103,9 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 	match type:
 		XRToolsPointerEvent.Type.PRESSED:
 			_report_touch_down(index, at)
+		
+		XRToolsPointerEvent.Type.DOUBLECLICK:
+			_report_mouse_down_double_click(at)
 
 		XRToolsPointerEvent.Type.RELEASED:
 			_report_touch_up(index, at)
@@ -177,6 +184,17 @@ func _report_mouse_down(at : Vector2) -> void:
 	event.position = at
 	event.global_position = at
 	event.button_mask = 1
+	_viewport.push_input(event)
+
+# Report mouse-down event
+func _report_mouse_down_double_click(at : Vector2) -> void:
+	var event := InputEventMouseButton.new()
+	event.button_index = 1
+	event.pressed = true
+	event.position = at
+	event.global_position = at
+	event.button_mask = 1
+	event.double_click = true
 	_viewport.push_input(event)
 
 

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
@@ -103,9 +103,6 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 	match type:
 		XRToolsPointerEvent.Type.PRESSED:
 			_report_touch_down(index, at)
-		
-		XRToolsPointerEvent.Type.DOUBLECLICK:
-			_report_mouse_down_double_click(at)
 
 		XRToolsPointerEvent.Type.RELEASED:
 			_report_touch_up(index, at)
@@ -136,6 +133,10 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 
 			XRToolsPointerEvent.Type.MOVED:
 				_report_mouse_move(pressed, last, at)
+				
+			XRToolsPointerEvent.Type.DOUBLECLICK:
+				_report_mouse_down(at)
+				_report_mouse_down_double_click(at)
 
 	# Clear pointer information on exit
 	if type == XRToolsPointerEvent.Type.EXITED:


### PR DESCRIPTION
The idea is to add double click actions (i.e.: to allow navigation in a FileDialog, that requieres double click to enter in a folder)

I added two different ways to solve:

- one to detect double click in the trigger with an exposed debounce time

- another by declaring a button to the complete double click action (safer for reduced mobility, as double clicking in the air is a bit dificult for some people)    This second option is ignored if the value is left empty.


Let me know what you think :)
