### PR TITLE
use get_normal() method instead of accessing property directly

### DIFF
--- a/addons/godot-xr-tools/player/player_body.gd
+++ b/addons/godot-xr-tools/player/player_body.gd
@@ -732,7 +732,7 @@ func _apply_velocity_and_control(delta: float):
 
 		# Detect if bounce should be performed
 		if bounciness > 0.0 and magnitude >= bounce_threshold:
-			local_velocity += 2 * collision.normal * magnitude * bounciness
+			local_velocity += 2 * collision.get_normal() * magnitude * bounciness
 			velocity = local_velocity + ground_velocity
 			emit_signal("player_bounced", collision_node, magnitude)
 


### PR DESCRIPTION
In  Godot 4, the `KinematicCollision3D` class has a `get_normal()` method instead of the `normal` property from its Godot 3.x counterpart, `KinematicCollision`.