### PR TITLE
Fixed stream of editor errors with hand physics bones in the editor

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -8,6 +8,7 @@
 - **breakage** Added support for two-handed grabbing.
 - Added support for snapping hands to grab-points.
 - Added support for world-grab movement.
+- Fixed editor errors when using hand physics bones.
 
 # 4.2.1
 - Fixed snap-zones showing highlight when disabled.

--- a/addons/godot-xr-tools/hands/hand_physics_bone.gd
+++ b/addons/godot-xr-tools/hands/hand_physics_bone.gd
@@ -55,6 +55,10 @@ func is_xr_class(name : String) -> bool:
 # Called when the node enters the scene tree. This constructs the physics-bone
 # nodes and performs initial positioning.
 func _ready():
+	# Skip if in the editor
+	if Engine.is_editor_hint():
+		return
+
 	# Connect the 'hand_scale_changed' signal
 	var physics_hand := XRToolsHand.find_instance(self) as XRToolsPhysicsHand
 	if physics_hand:
@@ -102,6 +106,10 @@ func _ready():
 # Called during the physics process and moves the physics-bone to follow the
 # skeletal-bone.
 func _physics_process(delta: float) -> void:
+	# Skip if in the editor
+	if Engine.is_editor_hint():
+		return
+
 	_move_bone(delta)
 
 


### PR DESCRIPTION
The XRToolsHandPhysicsBone script needs to be a tool script for editor checks, but it failed to bypass _ready() and _physics_process() behavior in the editor so a stream of errors is produced.