### PR TITLE
Upgrade use of legacy properties in the Viewport2Din3D script

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -319,10 +319,10 @@ func set_filter(new_filter: bool) -> void:
 func _update_screen_size() -> void:
 	$Screen.mesh.size = screen_size
 	$StaticBody3D.screen_size = screen_size
-	$StaticBody3D/CollisionShape3D.shape.extents = Vector3(
-			screen_size.x * 0.5,
-			screen_size.y * 0.5,
-			0.01)
+	$StaticBody3D/CollisionShape3D.shape.size = Vector3(
+			screen_size.x,
+			screen_size.y,
+			0.02)
 
 
 # Enabled update handler
@@ -437,8 +437,14 @@ func _update_render() -> void:
 
 		# If using a temporary material then update transparency
 		if _screen_material and not material:
-			_screen_material.flags_transparent = transparent != TransparancyMode.OPAQUE
-			_screen_material.params_use_alpha_scissor = transparent == TransparancyMode.SCISSOR
+			# Set the transparancy mode
+			match transparent:
+				TransparancyMode.OPAQUE:
+					_screen_material.transparency = BaseMaterial3D.TRANSPARENCY_DISABLED
+				TransparancyMode.TRANSPARENT:
+					_screen_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+				TransparancyMode.SCISSOR:
+					_screen_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA_SCISSOR
 
 		# Set the viewport background transparency mode and force a redraw
 		$Viewport.transparent_bg = transparent != TransparancyMode.OPAQUE


### PR DESCRIPTION
This PR fixes issues #568 and #569 by:
- Switching from BaseMaterial3D.flags_transparent to BaseMaterial3D.transparency
- Switching from BoxShape3D.extents to BoxShape3D.size