### PR TITLE
Control physical keyboard and gamepad inputs for Viewport2Din3D

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -10,6 +10,7 @@
 - Added support for world-grab movement.
 - Fixed editor errors when using hand physics bones.
 - Added support for climbable grab-points.
+- Added control of keyboard or gamepad inputs to Viewport2Din3D instances.
 
 # 4.2.1
 - Fixed snap-zones showing highlight when disabled.

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -80,6 +80,15 @@ const DEFAULT_LAYER := 0b0000_0000_0101_0000_0000_0000_0000_0001
 ## Update throttle property
 @export var throttle_fps : float = 30.0
 
+# Input property group
+@export_group("Input")
+
+## Allow physical keyboard input to viewport
+@export var input_keyboard : bool = true
+
+## Allow gamepad input to viewport
+@export var input_gamepad : bool = false
+
 # Rendering property group
 @export_group("Rendering")
 
@@ -197,10 +206,17 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 	pointer_event.emit(event)
 
 
-# Handler for input eventsd
+# Handler for input events
 func _input(event):
-	if not (event is InputEventMouseButton):
+	# Map keyboard events to the viewport if enabled
+	if input_keyboard and (event is InputEventKey or event is InputEventShortcut):
 		$Viewport.push_input(event)
+		return
+
+	# Map gamepad events to the viewport if enable
+	if input_gamepad and (event is InputEventJoypadButton or event is InputEventJoypadMotion):
+		$Viewport.push_input(event)
+		return
 
 
 # Process event


### PR DESCRIPTION
This PR fixes issue #562 by allowing software control over whether keyboard or gamepad input is mapped into a Viewport2Din3D. Additionally this rejects all other types of input such as mouse, touch, gesture, screen-drag, etc.

![image](https://github.com/GodotVR/godot-xr-tools/assets/1863707/e75f0501-a557-41ca-8cf8-7564d12f19cb)
