### PR TITLE
Automatically update hand poses in the editor

### DIFF
--- a/addons/godot-xr-tools/hands/poses/hand_pose_settings.gd
+++ b/addons/godot-xr-tools/hands/poses/hand_pose_settings.gd
@@ -1,3 +1,4 @@
+@tool
 @icon("res://addons/godot-xr-tools/editor/icons/hand.svg")
 class_name XRToolsHandPoseSettings
 extends Resource
@@ -10,7 +11,19 @@ extends Resource
 
 
 ## Hand-open pose
-@export var open_pose : Animation
+@export var open_pose : Animation : set = set_open_pose
 
 ## Hand-closed pose
-@export var closed_pose : Animation
+@export var closed_pose : Animation : set = set_closed_pose
+
+
+# Called when the open pose is changed
+func set_open_pose(p_open_pose : Animation) -> void:
+	open_pose = p_open_pose
+	emit_changed()
+
+
+# Called when the closed pose is changed
+func set_closed_pose(p_closed_pos : Animation) -> void:
+	closed_pose = p_closed_pos
+	emit_changed()

--- a/addons/godot-xr-tools/objects/grab_points/grab_point_hand.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grab_point_hand.gd
@@ -107,8 +107,16 @@ func _set_hand(new_value : Hand) -> void:
 
 
 func _set_hand_pose(new_value : XRToolsHandPoseSettings) -> void:
+	# Unsubscribe from the old hand-pose changed signal
+	if Engine.is_editor_hint() and hand_pose:
+		hand_pose.changed.disconnect(_update_editor_preview)
+
+	# Save the hand pose
 	hand_pose = new_value
-	if Engine.is_editor_hint():
+
+	# Update the editor preview
+	if Engine.is_editor_hint() and hand_pose:
+		hand_pose.changed.connect(_update_editor_preview)
 		_update_editor_preview()
 
 


### PR DESCRIPTION
This PR updates the editor-preview hand-pose when changing the pose resource. As such the developer does not have to toggle between open/closed preview to see the updated hand pose.