### PR TITLE
Fix world-grab movement

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,11 @@
+# 4.3.1
+- Fix saving project when using plugin-tools to set physics layers or enable OpenXR
+- Fix updating the editor-preview hand-pose
+- Fix jumping on slopes
+- Fix material warnings by converting binary .material files to .tres files
+- Fix staging to use threaded loading while starting the fade
+- Fix broken world-grab script
+
 # 4.3.0
 - Upgraded project to Godot 4.1 as the new minimum version.
 - Added reporting of stage load errors.

--- a/addons/godot-xr-tools/objects/world_grab_area.gd
+++ b/addons/godot-xr-tools/objects/world_grab_area.gd
@@ -40,7 +40,7 @@ func request_highlight(_from, _on) -> void:
 	pass
 
 # Called by XRToolsFunctionPickup when this is picked up by a controller
-func pick_up(by: Node3D, _with_controller: XRController3D) -> void:
+func pick_up(by: Node3D) -> void:
 	# Get the ID to save the grab handle under
 	var id = by.get_instance_id()
 

--- a/addons/godot-xr-tools/objects/world_grab_area.tscn
+++ b/addons/godot-xr-tools/objects/world_grab_area.tscn
@@ -3,4 +3,6 @@
 [ext_resource type="Script" path="res://addons/godot-xr-tools/objects/world_grab_area.gd" id="1_uxhq5"]
 
 [node name="WorldGrabArea" type="Area3D"]
+collision_layer = 262144
+collision_mask = 524288
 script = ExtResource("1_uxhq5")

--- a/scenes/world_grab_demo/world_grab_demo.tscn
+++ b/scenes/world_grab_demo/world_grab_demo.tscn
@@ -183,8 +183,6 @@ body_forward_mix = 0.0
 
 [node name="WorldGrabAreaZeroG" parent="." index="2" instance=ExtResource("8_ochso")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5, 0)
-collision_layer = 262144
-collision_mask = 524288
 gravity_space_override = 3
 gravity = 0.0
 linear_damp = 1.0


### PR DESCRIPTION
Fix world-grab movement to work with two-handed pickup changes.
Fix world-grab default area collision settings.
Update versions.md to include recent fixes.