### PR TITLE
Add check/setting for foveated rendering

### DIFF
--- a/addons/godot-xr-tools/xr/start_xr.gd
+++ b/addons/godot-xr-tools/xr/start_xr.gd
@@ -90,6 +90,9 @@ func _get_configuration_warnings() -> PackedStringArray:
 func _setup_for_openxr() -> bool:
 	print("OpenXR: Configuring interface")
 
+	# Get our viewport
+	var vp : Viewport = get_viewport()
+
 	# Set the render target size multiplier - must be done befor initializing interface
 	# NOTE: Only implemented in Godot 4.1+
 	if "render_target_size_multiplier" in xr_interface:
@@ -115,7 +118,13 @@ func _setup_for_openxr() -> bool:
 	DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
 
 	# Switch the viewport to XR
-	get_viewport().use_xr = true
+	vp.use_xr = true
+
+	# Enable VRS
+	if RenderingServer.get_rendering_device():
+		vp.vrs_mode = Viewport.VRS_XR
+	elif int(ProjectSettings.get_setting("xr/openxr/foveation_level")) == 0:
+		push_warning("OpenXR: Recommend setting Foveation level to High in Project Settings")
 
 	# Report success
 	return true

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Godot XR Tools Demo"
 run/main_scene="res://demo_staging.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon.png"
 
 [autoload]
@@ -59,4 +59,6 @@ limits/time/time_rollover_secs=30.0
 [xr]
 
 openxr/enabled=true
+openxr/foveation_level=3
+openxr/foveation_dynamic=true
 shaders/enabled=true


### PR DESCRIPTION
This PR adds a bit of code to our start xr script that:
- in Vulkan sets our `vrs_mode` to VRS_XR which, when supported, enables foveated rendering
- in compatibility, checks if our project setting has foveated rendering enabled and warns the user if this is not the case.

Note that this will bring the minimum Godot version to 4.2.x