### PR TITLE
added collision fade

### DIFF
--- a/assets/meshes/collision_fade/scenes/fade_area.tscn
+++ b/assets/meshes/collision_fade/scenes/fade_area.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://b3o3tygsi5vw"]
+
+[ext_resource type="Script" path="res://assets/meshes/collision_fade/scripts/fade_area.gd" id="1_m3jgp"]
+
+[node name="FadeArea" type="Node3D"]
+script = ExtResource("1_m3jgp")

--- a/assets/meshes/collision_fade/scenes/fade_collision.tscn
+++ b/assets/meshes/collision_fade/scenes/fade_collision.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dlivaur4w2m12"]
+
+[ext_resource type="Script" path="res://assets/meshes/collision_fade/scripts/fade_collision.gd" id="1_2vuvb"]
+
+[node name="FadeCollision" type="Node3D"]
+script = ExtResource("1_2vuvb")

--- a/assets/meshes/collision_fade/scenes/fade_in_out.tscn
+++ b/assets/meshes/collision_fade/scenes/fade_in_out.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dapr8mrnkgum0"]
+
+[ext_resource type="Script" path="res://assets/meshes/collision_fade/scripts/fade_in_out.gd" id="1_gqyql"]
+
+[node name="FadeInOut" type="Node"]
+script = ExtResource("1_gqyql")

--- a/assets/meshes/collision_fade/scenes/fader.tscn
+++ b/assets/meshes/collision_fade/scenes/fader.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=5 format=3 uid="uid://w82xvrc74u1b"]
+
+[ext_resource type="Script" path="res://assets/meshes/collision_fade/scripts/fader.gd" id="1_r8ais"]
+[ext_resource type="Shader" path="res://assets/meshes/collision_fade/shader/fade.gdshader" id="2_oa6c6"]
+
+[sub_resource type="QuadMesh" id="QuadMesh_iv1ir"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_tmf72"]
+render_priority = 127
+shader = ExtResource("2_oa6c6")
+shader_parameter/albedo = Color(0, 0, 0, 0)
+
+[node name="Fader" type="Node3D"]
+script = ExtResource("1_r8ais")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = SubResource("QuadMesh_iv1ir")
+surface_material_override/0 = SubResource("ShaderMaterial_tmf72")

--- a/assets/meshes/collision_fade/scripts/fade_area.gd
+++ b/assets/meshes/collision_fade/scripts/fade_area.gd
@@ -1,0 +1,72 @@
+extends Node3D
+
+## Rate to obscure
+##
+## @desc:
+##    This property controls the rate the fader will adjust to obscure the
+##    view. Larger numeric values will obscure faster. For example a value of 3
+##    will fully obscure the scene in 1/3rd of a second.
+@export var obscure_rate := 3.0
+
+## Rate to reveal
+##
+## @desc:
+##     This property controls the rate the fader will adjust to reveal the
+##     view. Larger numeric values will reveal faster. For example a value of
+##     3 will fully reveal the scene in 1/3rd of a second.
+@export var reveal_rate := 1.0
+
+## Default fade if not in a fade area
+##
+## @desc:
+##    This property sets the default fade if the player is not in a fade area
+@export var default_fade := 1.0
+
+## Layers to check
+##
+## @desc:
+##    This property sets the layers this fade area checks for.
+@export var fade_area_layers := 2 # (int, LAYERS_3D_PHYSICS)
+
+# Current fade contribution [0..1] - used by Fader
+var fade_contribution := 0.0
+
+# World space to use for collision detection
+var space : PhysicsDirectSpaceState3D = null
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	# Get the space to test collisions in
+	space = get_world_3d().get_direct_space_state()
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	add_to_group("fade_contributor")
+	# Find all area collisions
+	var collisions = PhysicsRayQueryParameters3D.new()
+	collisions.from = global_transform.origin
+	#collisions.to = 32
+	collisions.exclude = []
+
+	collisions.collision_mask = 2
+	var result = space.intersect_ray(collisions)
+	if result:
+		return false
+		return true 
+	# Calculate the fade
+	var fade = default_fade
+	var fade_priority = -1;
+	for c in collisions:
+		var area = c["collider"]
+		if area.is_in_group("fade_area"):
+			if area.priority > fade_priority:
+				fade = area.fade_level
+				fade_priority = area.priority;
+	
+	# Adjust the contribution
+	if fade_contribution < fade:
+		# Fade in to target (obscure)
+		fade_contribution = min(fade_contribution + obscure_rate * delta, fade)
+	elif fade_contribution > fade:
+		# Fade out to target (reveal)
+		fade_contribution = max(fade_contribution - reveal_rate * delta, fade)

--- a/assets/meshes/collision_fade/scripts/fade_collision.gd
+++ b/assets/meshes/collision_fade/scripts/fade_collision.gd
@@ -1,0 +1,65 @@
+extends Node3D
+
+## Layers to collide with
+##
+## @desc:
+##    This property sets the layers this fade collision checks for.
+@export var collision_layers : int= 2
+
+## Collision distance at which fading begins
+##
+## @desc:
+##    This distance sets how far away from the camera a collision must be to
+##    begin obscuring the view
+@export var fade_start_distance := 0.3
+
+## Collision distance for totally obscuring the view
+##
+## @desc:
+##    This distance sets how far away from the camera a collision must be to
+##    totally obscure the view
+@export var fade_full_distance := 0.15
+
+# Current fade contribution [0..1] - used by Fader
+var fade_contribution := 0.0
+
+# Shape to use for collision detection
+var collision_shape : Shape3D = null
+
+# Parameters to use for collision detection
+var collision_parameters : PhysicsShapeQueryParameters3D = null
+
+# World space to use for collision detection
+var space : PhysicsDirectSpaceState3D = null
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	add_to_group("fade_contributor")
+	# Construct a sphere for the collision shape
+	collision_shape = SphereShape3D.new()
+	collision_shape.radius = fade_start_distance
+	
+	# Construct the collosion parameters
+	collision_parameters = PhysicsShapeQueryParameters3D.new()
+	collision_parameters.collision_mask = collision_layers
+	collision_parameters.set_shape(collision_shape)
+
+	# Get the space to test collisions in
+	space = get_world_3d().direct_space_state
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _physics_process(delta):
+	# Update the collision parameters to include our global location
+	collision_parameters.transform = global_transform
+	# Find closest collision
+	var results = space.get_rest_info(collision_parameters)
+	if "point" in results:
+		# Collision detected, calculate distance to closet collision point
+		var delta_pos = global_transform.origin - results["point"]
+		var length = delta_pos.length()
+		
+		# Fade based on distance
+		fade_contribution = inverse_lerp(fade_start_distance, fade_full_distance, length)
+	else:
+		# No collision
+		fade_contribution = 0.0

--- a/assets/meshes/collision_fade/scripts/fade_in_out.gd
+++ b/assets/meshes/collision_fade/scripts/fade_in_out.gd
@@ -1,0 +1,50 @@
+extends Node
+
+## Rate to obscure
+##
+## @desc:
+##    This property controls the rate the fader will adjust to obscure the
+##    view. Larger numeric values will obscure faster. For example a value of 3
+##    will fully obscure the scene in 1/3rd of a second.
+@export var obscure_rate := 1.0
+
+## Rate to reveal
+##
+## @desc:
+##     This property controls the rate the fader will adjust to reveal the
+##     view. Larger numeric values will reveal faster. For example a value of
+##     3 will fully reveal the scene in 1/3rd of a second.
+@export var reveal_rate := 1.0
+
+## Initial fade contribution [0..1]
+##
+## @desc:
+##    This property contains the initial fade level at start.
+@export var initial_fade := 1.0
+
+## Current fade target [0..1]
+##
+## @desc:
+##    This property contains the target fade for this fade function. The 
+##    'fade_contribution' will slew to this target based on the 'fade_in_rate'
+##    and 'fade_out_rate' properties. The user can set this value for an initial
+##    fade target at start.
+@export var fade_target := 0.0
+
+# Current fade contribution [0..1] - used by Fader
+var fade_contribution := 1.0
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	add_to_group("fade_contributor")
+	fade_contribution = initial_fade
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	# Adjust the fade
+	if fade_contribution < fade_target:
+		# Fade in to target (obscure)
+		fade_contribution = min(fade_contribution + obscure_rate * delta, fade_target)
+	elif fade_contribution > fade_target:
+		# Fade out to target (reveal)
+		fade_contribution = max(fade_contribution - reveal_rate * delta, fade_target)

--- a/assets/meshes/collision_fade/scripts/fader.gd
+++ b/assets/meshes/collision_fade/scripts/fader.gd
@@ -1,0 +1,38 @@
+extends Node3D
+
+# Current fade level [0..1]
+var current_fade := 0.0
+
+# Material on fade mesh
+var fade_material : Material = null
+
+# Array of fade-contributors
+var fade_contributors = Array()
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	# Get the fade material
+	fade_material = $MeshInstance3D.get_surface_override_material(0)
+	
+	# Get all fade contributor nodes
+	fade_contributors = get_tree().get_nodes_in_group("fade_contributor")
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	# Get the highest fade from all contributors [0..1]
+	var fade = 0.0
+	for f in fade_contributors:
+		fade = max(fade, f.fade_contribution)
+	
+	# Clamp the fade to ensure legal range
+	fade = clampf(fade, 0.0, 1.0)
+	
+	# Adjust the fade level if necessary
+	if fade != current_fade:
+		# Update the current fade
+		current_fade = fade
+		
+		# Set the fade mesh alpha channel
+		fade_material.set_shader_parameter("albedo", Color(0.0, 0.0, 0.0, fade))
+		# Enable the fade mesh only if we have anything to fade
+		$MeshInstance3D.visible = current_fade > 0

--- a/assets/meshes/collision_fade/shader/fade.gdshader
+++ b/assets/meshes/collision_fade/shader/fade.gdshader
@@ -1,0 +1,12 @@
+shader_type spatial;
+render_mode blend_mix,depth_draw_opaque,cull_disabled,unshaded,depth_test_disabled;
+uniform vec4 albedo : source_color;
+
+void vertex() {
+	POSITION = vec4(VERTEX.xy * 2.0, 1.0, 1.0);
+}
+
+void fragment() {
+	ALBEDO = albedo.rgb;
+	ALPHA = albedo.a;
+}

--- a/scenes/basic_movement_demo/basic_movement_demo.tscn
+++ b/scenes/basic_movement_demo/basic_movement_demo.tscn
@@ -1,12 +1,15 @@
-[gd_scene load_steps=36 format=3 uid="uid://bbcamgruwhrq4"]
+[gd_scene load_steps=40 format=3 uid="uid://bbcamgruwhrq4"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="Script" path="res://scenes/demo_scene_base.gd" id="2_5ptmo"]
 [ext_resource type="PackedScene" uid="uid://b4kad2kuba1yn" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn" id="2_54yy3"]
+[ext_resource type="PackedScene" uid="uid://w82xvrc74u1b" path="res://assets/meshes/collision_fade/scenes/fader.tscn" id="3_gg6oh"]
 [ext_resource type="PackedScene" uid="uid://b6bk2pj8vbj28" path="res://addons/godot-xr-tools/functions/movement_turn.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://dapr8mrnkgum0" path="res://assets/meshes/collision_fade/scenes/fade_in_out.tscn" id="4_dk6ud"]
 [ext_resource type="PackedScene" uid="uid://bjcxf427un2wp" path="res://addons/godot-xr-tools/player/poke/poke.tscn" id="4_j425l"]
 [ext_resource type="PackedScene" uid="uid://bl2nuu3qhlb5k" path="res://addons/godot-xr-tools/functions/movement_direct.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://clt88d5d1dje4" path="res://addons/godot-xr-tools/functions/movement_crouch.tscn" id="5_2ekvc"]
+[ext_resource type="PackedScene" uid="uid://dlivaur4w2m12" path="res://assets/meshes/collision_fade/scenes/fade_collision.tscn" id="5_hlkmc"]
 [ext_resource type="PackedScene" uid="uid://diyu06cw06syv" path="res://addons/godot-xr-tools/player/player_body.tscn" id="6"]
 [ext_resource type="PackedScene" uid="uid://l2n30mpbkdyw" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/right_hand_low.tscn" id="6_0hbex"]
 [ext_resource type="PackedScene" uid="uid://bdc23valbh8gf" path="res://assets/meshes/ramps/ramps.tscn" id="8"]
@@ -20,66 +23,67 @@
 [ext_resource type="PackedScene" uid="uid://ct3p5sgwvkmva" path="res://assets/meshes/control_pad/control_pad.tscn" id="13_51xax"]
 [ext_resource type="PackedScene" uid="uid://ca6c2h3xsflxf" path="res://assets/maps/holodeck_map.tscn" id="16_v54dt"]
 [ext_resource type="Texture2D" uid="uid://bskwc0drdadnd" path="res://assets/wahooney.itch.io/brown_grid.png" id="20_k5co8"]
+[ext_resource type="PackedScene" uid="uid://bt08qiog5e1ct" path="res://scenes/basic_movement_demo/objects/fade_instructions.tscn" id="21_g78p4"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_334h1"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_8keet"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_owb1g"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_22ksv"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_boi4n"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_musif"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_fnyu5"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rwvxb"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_v8rnq"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ltph0"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_ljr1p"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_58jkx"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_334h1")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_8keet")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_owb1g")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_22ksv")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_boi4n")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_musif")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_fnyu5")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_rwvxb")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_v8rnq")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_ltph0")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_3t6qm"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ah7cb"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_3i43j"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ydqfu"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_n5y7i"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_hlt61"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_q31qn"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_smyja"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_shlyq"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_pr2ke"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_gmumo"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_fwbc1"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_3t6qm")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_ah7cb")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_3i43j")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_ydqfu")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_n5y7i")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_hlt61")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_q31qn")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_smyja")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_shlyq")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_pr2ke")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"output", 0, &"Grip", &"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1"]
 
@@ -97,6 +101,12 @@ size = Vector3(2, 0.5, 8)
 
 [node name="BasicMovementDemo" instance=ExtResource("1")]
 script = ExtResource("2_5ptmo")
+
+[node name="Fader" parent="XROrigin3D/XRCamera3D" index="0" instance=ExtResource("3_gg6oh")]
+
+[node name="FadeInOut" parent="XROrigin3D/XRCamera3D/Fader" index="1" instance=ExtResource("4_dk6ud")]
+
+[node name="FadeCollision" parent="XROrigin3D/XRCamera3D/Fader" index="2" instance=ExtResource("5_hlkmc")]
 
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("2_54yy3")]
 
@@ -132,7 +142,7 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_ljr1p")
+tree_root = SubResource("AnimationNodeBlendTree_58jkx")
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("5")]
 strafe = true
@@ -180,7 +190,7 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_gmumo")
+tree_root = SubResource("AnimationNodeBlendTree_fwbc1")
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5")]
 
@@ -202,6 +212,18 @@ crouch_type = 1
 
 [node name="HolodeckMap" parent="." index="1" instance=ExtResource("16_v54dt")]
 
+[node name="Wall1" parent="HolodeckMap" index="3"]
+collision_layer = 3
+
+[node name="Wall2" parent="HolodeckMap" index="4"]
+collision_layer = 3
+
+[node name="Wall3" parent="HolodeckMap" index="5"]
+collision_layer = 3
+
+[node name="Wall4" parent="HolodeckMap" index="6"]
+collision_layer = 3
+
 [node name="MainMenuTeleport" parent="." index="2" instance=ExtResource("11")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 7)
 title = ExtResource("12")
@@ -212,13 +234,16 @@ spawn_point_transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 [node name="Instructions" parent="." index="3" instance=ExtResource("12_qasi6")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, -4)
 
-[node name="Ramps" parent="." index="4" instance=ExtResource("8")]
+[node name="FadeInstructions" parent="." index="4" instance=ExtResource("21_g78p4")]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 11.85, 4, 0.15)
+
+[node name="Ramps" parent="." index="5" instance=ExtResource("8")]
 transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 6, 0, 0)
 
-[node name="Mound" parent="." index="5" instance=ExtResource("9")]
+[node name="Mound" parent="." index="6" instance=ExtResource("9")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7, 0, 0)
 
-[node name="Block" type="StaticBody3D" parent="." index="6"]
+[node name="Block" type="StaticBody3D" parent="." index="7"]
 transform = Transform3D(-4.2222e-08, -0.258819, 0.965926, -1.13133e-08, 0.965926, 0.258819, -1, 0, -4.37114e-08, 0, 2.5, -10)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Block" index="0"]
@@ -232,3 +257,4 @@ shape = SubResource("BoxShape3D_24jr5")
 [editable path="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L"]
 [editable path="XROrigin3D/RightHand/RightHand"]
 [editable path="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R"]
+[editable path="HolodeckMap"]

--- a/scenes/basic_movement_demo/objects/fade_instructions.tscn
+++ b/scenes/basic_movement_demo/objects/fade_instructions.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=5 format=3 uid="uid://bt08qiog5e1ct"]
+
+[ext_resource type="PackedScene" uid="uid://clujaf3u776a3" path="res://addons/godot-xr-tools/objects/viewport_2d_in_3d.tscn" id="1_fgp5w"]
+[ext_resource type="PackedScene" uid="uid://d1i0fadwbjxr0" path="res://scenes/basic_movement_demo/objects/fade_instructions_2d.tscn" id="2_k6iih"]
+[ext_resource type="Material" uid="uid://cliyhjfvy8pfd" path="res://assets/maps/holodeck/materials/base.material" id="3_si8lj"]
+
+[sub_resource type="BoxMesh" id="1"]
+material = ExtResource("3_si8lj")
+size = Vector3(4.2, 2.7, 0.1)
+
+[node name="FadeInstructions" type="Node3D"]
+
+[node name="Viewport2Din3D" parent="." instance=ExtResource("1_fgp5w")]
+screen_size = Vector2(4, 2.5)
+collision_layer = 0
+scene = ExtResource("2_k6iih")
+viewport_size = Vector2(400, 250)
+update_mode = 0
+unshaded = true
+
+[node name="MeshInstance" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.1)
+mesh = SubResource("1")

--- a/scenes/basic_movement_demo/objects/fade_instructions_2d.tscn
+++ b/scenes/basic_movement_demo/objects/fade_instructions_2d.tscn
@@ -1,0 +1,39 @@
+[gd_scene format=3 uid="uid://d1i0fadwbjxr0"]
+
+[node name="FadeInstructions" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+offset_right = 400.0
+offset_bottom = 250.0
+color = Color(0, 0, 0, 0.87451)
+
+[node name="Description" type="RichTextLabel" parent="."]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 390.0
+offset_bottom = 240.0
+theme_override_constants/line_separation = -3
+theme_override_font_sizes/normal_font_size = 12
+text = "Collision Fade
+
+walk up a wall to experience the fade upon collision.
+
+ > how to setup your environment for the fader:
+   - select all the static bodys that you wish to influence the fader
+   - set their collision layer to = 2
+
+
+ > how to add it to your scenes:
+   - drag and drop the fader.tscn - scene as child of the camera
+   - drag and drop the fade_in_out.tscn
+	 and the fade_collision.tscn - scene as children of the fader
+
+"


### PR DESCRIPTION
this adds fade upon collision

https://github.com/GodotVR/godot-xr-tools/assets/56046022/79597692-75e9-4fbc-9226-48df14a8e97b



walk up a wall to experience the fade upon collision.

 > how to setup your environment for the fader:
   - select all the static bodys that you wish to influence the fader
   - set their collision layer to = 2


 > how to add it to your scenes:
   - drag and drop the fader.tscn - scene as child of the camera
   - drag and drop the fade_in_out.tscn and the fade_collision.tscn - scene as children of the fader

based upon @Malcolmnixon  work from 2022 which was made for a earlier version of xr tools for godot 3.5, link is below
https://github.com/Malcolmnixon/godot-xr-tools-experiments