### PR TITLE
Fix slope-sliding by applying ground-friction at the correct time

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,8 @@
 # 4.3.2
 - Move fade logic into effect
 - Added collision fade support
+- Added fix for slowly sliding on slopes
+- Added fix for ground-control preventing jumping over objects
 
 # 4.3.1
 - Fix saving project when using plugin-tools to set physics layers or enable OpenXR


### PR DESCRIPTION
This PR fixes #639 by applying the ground-friction at the correct time in the movement calculations.
This PR also fixes #642 by only applying the steep-slope logic if the player is on the ground.