### PR TITLE
Change wall-walking to use the Godot 4.x version of move_and_collide

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,6 +3,7 @@
 - Added collision fade support
 - Added fix for slowly sliding on slopes
 - Added fix for ground-control preventing jumping over objects
+- Fix unreliable wall-walking collision
 
 # 4.3.1
 - Fix saving project when using plugin-tools to set physics layers or enable OpenXR

--- a/addons/godot-xr-tools/functions/movement_wall_walk.gd
+++ b/addons/godot-xr-tools/functions/movement_wall_walk.gd
@@ -23,7 +23,7 @@ const DEFAULT_MASK := 0b0000_0000_0000_0000_0000_0000_0000_1000
 func physics_pre_movement(_delta: float, player_body: XRToolsPlayerBody):
 	# Test for collision with wall under feet
 	var wall_collision := player_body.move_and_collide(
-		player_body.up_player * -stick_distance, true, true, true)
+		player_body.up_player * -stick_distance, true)
 	if !wall_collision:
 		return
 


### PR DESCRIPTION
This PR corrects the wall-walking move_and_collide to use the Godot 4.x function parameters rather than the 3.x parameters. 

Specifically the code is using move_and_collide to get a KinematicCollision for the object the player is standing on.

It was doing this by passing the following parameters which are valid for Godot 3.x:
1. Movement vector
2. true (default)
3. true (default)
4. true for test_only (to test without performing the move)

However for Godot 4.x the test_only moved to the second parameter. The third and fourth parameters are the float safety_margin and the boolean recovery_as_collision. Providing true to these results in unreliable KinematicCollision data.