### PR TITLE
Fix properties forwarding to only forward customized properties.

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,6 @@
+# 4.3.3
+- Fix Viewport2Din3D property forwarding
+
 # 4.3.2
 - Move fade logic into effect
 - Added collision fade support

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -267,8 +267,8 @@ func _update_scene_property_list():
 				var all_properties := node_script.get_script_property_list()
 
 				# Join this with the custom property list of the object created by the script
-				if scene_node.has_method("get_property_list"):
-					all_properties.append_array(scene_node.get_property_list())
+				if scene_node.has_method("_get_property_list"):
+					all_properties.append_array(scene_node.call("_get_property_list"))
 
 				for property in all_properties:
 					# Filter out only the properties that are supposed to be stored, or are used for grouping


### PR DESCRIPTION
This PR fixes bug #646 in property-forwarding for Viewport2Din3D introduced by gdlint cleanup whereby **ALL** properties of the sub-scene (including its script) were copied to the Viewport2Din3D node.