### PR TITLE
Fix custom hand poses triggering legacy remove_animation call

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,7 @@
 # 4.4.0
 - Minimum Godot version changed to 4.2
 - Add pickable action_released signal
+- Fix custom hand poses calling legacy remove_animation
 
 # 4.3.3
 - Fix Viewport2Din3D property forwarding

--- a/addons/godot-xr-tools/hands/hand.gd
+++ b/addons/godot-xr-tools/hands/hand.gd
@@ -339,7 +339,7 @@ func _update_pose() -> void:
 		if open_name == "":
 			open_name = "open_hand"
 			if _animation_player.has_animation(open_name):
-				_animation_player.remove_animation(open_name)
+				_animation_player.get_animation_library("").remove_animation(open_name)
 
 			_animation_player.get_animation_library("").add_animation(open_name, open_pose)
 
@@ -353,7 +353,7 @@ func _update_pose() -> void:
 		if closed_name == "":
 			closed_name = "closed_hand"
 			if _animation_player.has_animation(closed_name):
-				_animation_player.remove_animation(closed_name)
+				_animation_player.get_animation_library("").remove_animation(closed_name)
 
 			_animation_player.get_animation_library("").add_animation(closed_name, closed_pose)
 


### PR DESCRIPTION
This PR fixes #650 by using the players "" global animation library for both adding and removing custom hand poses.