### PR TITLE
Add signal when action button is released

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,6 @@
 # 4.4.0
 - Minimum Godot version changed to 4.2
+- Add pickable action_released signal
 
 # 4.3.3
 - Fix Viewport2Din3D property forwarding

--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -416,8 +416,10 @@ func _on_button_pressed(p_button) -> void:
 			picked_up_object.action()
 
 
-func _on_button_released(_p_button) -> void:
-	pass
+func _on_button_released(p_button) -> void:
+	if p_button == action_button_action:
+		if is_instance_valid(picked_up_object) and picked_up_object.has_method("action_release"):
+			picked_up_object.action_release()
 
 
 func _on_grip_pressed() -> void:

--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -30,6 +30,9 @@ signal released(pickable, by)
 # Signal emitted when the user presses the action button while holding this object
 signal action_pressed(pickable)
 
+# Signal emitted when the user releases the action button while holding this object
+signal action_released(pickable)
+
 # Signal emitted when the highlight state changes
 signal highlight_updated(pickable, enable)
 
@@ -172,7 +175,13 @@ func is_picked_up() -> bool:
 # action is called when user presses the action button while holding this object
 func action():
 	# let interested parties know
-	emit_signal("action_pressed", self)
+	action_pressed.emit(self)
+
+
+# action_release is called when user releases the action button while holding this object
+func action_release():
+	# let interested parties know
+	action_released.emit(self)
 
 
 ## This method requests highlighting of the [XRToolsPickable].
@@ -195,7 +204,7 @@ func request_highlight(from : Node, on : bool = true) -> void:
 
 	# Report any changes
 	if _highlighted != old_highlighted:
-		emit_signal("highlight_updated", self, _highlighted)
+		highlight_updated.emit(self, _highlighted)
 
 
 func drop():


### PR DESCRIPTION
This PR implements feature request #652, however due to the limitations of the single "action" button we may end up replacing/retiring this concept for either 4.4 or possibly the Godot-XR-Tools-2 rewrite.