### PR TITLE
Add support for alternate hand-trackers

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,6 +3,7 @@
 - Add pickable action_released signal
 - Fix custom hand poses calling legacy remove_animation
 - Cleaned up StartXR
+- Allow grab-points and poses to work with different types of hand trackers
 
 # 4.3.3
 - Fix Viewport2Din3D property forwarding

--- a/addons/godot-xr-tools/functions/function_pose_detector.gd
+++ b/addons/godot-xr-tools/functions/function_pose_detector.gd
@@ -75,15 +75,18 @@ func _on_area_entered(area : Area3D) -> void:
 	if !pose_area:
 		return
 
+	# Get the positional tracker
+	var tracker := XRServer.get_tracker(_controller.tracker) as XRPositionalTracker
+
 	# Set the appropriate poses
-	if _controller.tracker == "left_hand" and pose_area.left_pose:
+	if tracker.hand == XRPositionalTracker.TRACKER_HAND_LEFT and pose_area.left_pose:
 		_hand.add_pose_override(
 				pose_area,
 				pose_area.pose_priority,
 				pose_area.left_pose)
 		# Disable grabpoints in this pose_area
 		pose_area.disable_grab_points()
-	elif _controller.tracker == "right_hand" and pose_area.right_pose:
+	elif tracker.hand == XRPositionalTracker.TRACKER_HAND_RIGHT and pose_area.right_pose:
 		_hand.add_pose_override(
 				pose_area,
 				pose_area.pose_priority,

--- a/addons/godot-xr-tools/objects/grab_points/grab_point_hand.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grab_point_hand.gd
@@ -163,12 +163,15 @@ func _is_correct_hand(grabber : Node3D) -> bool:
 	if not controller:
 		return false
 
+	# Get the positional tracker
+	var tracker := XRServer.get_tracker(controller.tracker) as XRPositionalTracker
+
 	# If left hand then verify left controller
-	if hand == Hand.LEFT and controller.tracker != "left_hand":
+	if hand == Hand.LEFT and tracker.hand != XRPositionalTracker.TRACKER_HAND_LEFT:
 		return false
 
 	# If right hand then verify right controller
-	if hand == Hand.RIGHT and controller.tracker != "right_hand":
+	if hand == Hand.RIGHT and tracker.hand != XRPositionalTracker.TRACKER_HAND_RIGHT:
 		return false
 
 	# Controller matches hand


### PR DESCRIPTION
This PR allows hand-poses and grab-points to work with XRController3D nodes driven by alternate sources such as virtual controllers created from hand-trackers.