### PR TITLE
Add end_xr support

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@
 - Fix custom hand poses calling legacy remove_animation
 - Cleaned up StartXR
 - Allow grab-points and poses to work with different types of hand trackers
+- Add end_xr support to StartXR
 
 # 4.3.3
 - Fix Viewport2Din3D property forwarding

--- a/addons/godot-xr-tools/staging/scene_base.gd
+++ b/addons/godot-xr-tools/staging/scene_base.gd
@@ -30,6 +30,10 @@ signal request_load_scene(p_scene_path, user_data)
 ## The [param user_data] parameter is passed through staging to the new scenes.
 signal request_reset_scene(user_data)
 
+## This signal is used to request the staging quit the XR experience. Developers
+## should use [method quit] rather than emitting this signal directly.
+signal request_quit
+
 
 # This file contains methods with parameters that are unused; however they are
 # documented and intended to be overridden in derived classes. As such unused
@@ -192,3 +196,12 @@ func load_scene(p_scene_path : String, user_data = null) -> void:
 ## Any [param user_data] provided is passed into the new scene.
 func reset_scene(user_data = null) -> void:
 	emit_signal("request_reset_scene", user_data)
+
+
+## This function is used to quit the XR experience. The default
+## implementation sends the [signal request_quit] which triggers
+## the XR experience to end.
+##
+## Custom scene classes can override this method to add their logic.
+func quit() -> void:
+	emit_signal("request_quit")

--- a/addons/godot-xr-tools/staging/staging.gd
+++ b/addons/godot-xr-tools/staging/staging.gd
@@ -275,12 +275,14 @@ func _add_signals(p_scene : XRToolsSceneBase):
 	p_scene.connect("request_exit_to_main_menu", _on_exit_to_main_menu)
 	p_scene.connect("request_load_scene", _on_load_scene)
 	p_scene.connect("request_reset_scene", _on_reset_scene)
+	p_scene.connect("request_quit", _on_quit)
 
 
 func _remove_signals(p_scene : XRToolsSceneBase):
 	p_scene.disconnect("request_exit_to_main_menu", _on_exit_to_main_menu)
 	p_scene.disconnect("request_load_scene", _on_load_scene)
 	p_scene.disconnect("request_reset_scene", _on_reset_scene)
+	p_scene.disconnect("request_quit", _on_quit)
 
 
 func _on_exit_to_main_menu():
@@ -293,6 +295,10 @@ func _on_load_scene(p_scene_path : String, user_data):
 
 func _on_reset_scene(user_data):
 	load_scene(current_scene_path, user_data)
+
+
+func _on_quit():
+	$StartXR.end_xr()
 
 
 func _on_StartXR_xr_started():

--- a/addons/godot-xr-tools/xr/start_xr.gd
+++ b/addons/godot-xr-tools/xr/start_xr.gd
@@ -47,14 +47,15 @@ signal xr_failed_to_initialize
 ## Current XR interface
 var xr_interface : XRInterface
 
-## XR active flag
-var xr_active : bool = false
-
 ## XR frame rate
 var xr_frame_rate : float = 0
 
+
 # Is a WebXR is_session_supported query running
 var _webxr_session_query : bool = false
+
+## XR active flag
+static var _xr_active : bool = false
 
 
 # Handle auto-initialization when ready
@@ -80,6 +81,23 @@ func _initialize() -> bool:
 	print("No XR interface detected")
 	xr_failed_to_initialize.emit()
 	return false
+
+
+## End the XR experience
+func end_xr() -> void:
+	# For WebXR drop the interactive experience and go back to the web page
+	if xr_interface is WebXRInterface:
+		# Uninitialize the WebXR interface
+		xr_interface.uninitialize()
+		return
+
+	# Terminate the application
+	get_tree().quit()
+
+
+## Test if XR is active
+static func is_xr_active() -> bool:
+	return _xr_active
 
 
 ## Get the XR viewport
@@ -148,18 +166,18 @@ func _on_openxr_session_begun() -> void:
 # Handle OpenXR visible state
 func _on_openxr_visible_state() -> void:
 	# Report the XR ending
-	if xr_active:
+	if _xr_active:
 		print("OpenXR: XR ended (visible_state)")
-		xr_active = false
+		_xr_active = false
 		xr_ended.emit()
 
 
 # Handle OpenXR focused state
 func _on_openxr_focused_state() -> void:
 	# Report the XR starting
-	if not xr_active:
+	if not _xr_active:
 		print("OpenXR: XR started (focused_state)")
-		xr_active = true
+		_xr_active = true
 		xr_started.emit()
 
 
@@ -237,7 +255,7 @@ func _on_webxr_session_started() -> void:
 	get_xr_viewport().use_xr = true
 
 	# Report the XR starting
-	xr_active = true
+	_xr_active = true
 	xr_started.emit()
 
 
@@ -251,7 +269,7 @@ func _on_webxr_session_ended() -> void:
 	get_xr_viewport().use_xr = false
 
 	# Report the XR ending
-	xr_active = false
+	_xr_active = false
 	xr_ended.emit()
 
 

--- a/assets/meshes/control_pad/control_pad.gd
+++ b/assets/meshes/control_pad/control_pad.gd
@@ -13,6 +13,7 @@ func _ready():
 	# Connect signals
 	$Viewport2Din3D.connect_scene_signal("switch_hand", _on_switch_hand)
 	$Viewport2Din3D.connect_scene_signal("main_scene", _on_main_scene)
+	$Viewport2Din3D.connect_scene_signal("quit", _on_quit)
 
 	# Update the control pad location
 	_update_location.call_deferred()
@@ -38,6 +39,19 @@ func _on_main_scene() -> void:
 	# Return to the main menu
 	if base:
 		base.exit_to_main_menu()
+
+
+# Handle request to quit
+func _on_quit() -> void:
+	# Find the scene base
+	var base := XRTools.find_xr_ancestor(
+		self,
+		"*",
+		"XRToolsSceneBase") as XRToolsSceneBase
+
+	# Return to the main menu
+	if base:
+		base.quit()
 
 
 # Update the location of this control pad

--- a/assets/meshes/control_pad/control_pad.tscn
+++ b/assets/meshes/control_pad/control_pad.tscn
@@ -17,3 +17,4 @@ update_mode = 2
 throttle_fps = 15.0
 transparent = 0
 unshaded = true
+scene_properties_keys = PackedStringArray("control_pad_display.gd")

--- a/assets/meshes/control_pad/control_pad_display.gd
+++ b/assets/meshes/control_pad/control_pad_display.gd
@@ -7,6 +7,9 @@ signal switch_hand(hand)
 ## Signal emitted when requested to go to the main scene
 signal main_scene
 
+## Signal emitted when requested to quit
+signal quit
+
 
 var _tween : Tween
 
@@ -63,7 +66,10 @@ func _on_main_scene_pressed():
 	main_scene.emit()
 
 
+func _on_quit_pressed():
+	quit.emit()
+
+
 # Called by the tweening to change the world scale
 func _set_world_scale(scale : float) -> void:
 	XRServer.world_scale = scale
-

--- a/assets/meshes/control_pad/control_pad_display.tscn
+++ b/assets/meshes/control_pad/control_pad_display.tscn
@@ -6,6 +6,7 @@
 offset_right = 400.0
 offset_bottom = 200.0
 tab_alignment = 1
+current_tab = 1
 script = ExtResource("1_iqtwx")
 
 [node name="RefreshTimer" type="Timer" parent="."]
@@ -89,35 +90,54 @@ size_flags_horizontal = 3
 alignment = 1
 
 [node name="Left" type="Button" parent="Settings/VBoxContainer/Panel/Container"]
-custom_minimum_size = Vector2(80, 0)
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Left"
 
+[node name="Padding" type="Control" parent="Settings/VBoxContainer/Panel/Container"]
+custom_minimum_size = Vector2(20, 0)
+layout_mode = 2
+
 [node name="Right" type="Button" parent="Settings/VBoxContainer/Panel/Container"]
-custom_minimum_size = Vector2(80, 0)
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Right
 "
 
-[node name="Demo" type="HBoxContainer" parent="Settings/VBoxContainer"]
+[node name="Padding" type="Control" parent="Settings/VBoxContainer"]
+custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Settings/VBoxContainer/Demo"]
+[node name="Scene" type="HBoxContainer" parent="Settings/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Settings/VBoxContainer/Scene"]
 custom_minimum_size = Vector2(90, 0)
 layout_mode = 2
-text = "Main:"
+text = "Scene:"
 
-[node name="Container" type="HBoxContainer" parent="Settings/VBoxContainer/Demo"]
+[node name="Container" type="HBoxContainer" parent="Settings/VBoxContainer/Scene"]
 layout_mode = 2
 size_flags_horizontal = 3
 alignment = 1
 
-[node name="MainScene" type="Button" parent="Settings/VBoxContainer/Demo/Container"]
+[node name="Main" type="Button" parent="Settings/VBoxContainer/Scene/Container"]
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
-text = "Return to Main Scene"
+text = "Main"
+
+[node name="Padding" type="Control" parent="Settings/VBoxContainer/Scene/Container"]
+custom_minimum_size = Vector2(20, 0)
+layout_mode = 2
+
+[node name="Quit" type="Button" parent="Settings/VBoxContainer/Scene/Container"]
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+text = "Quit"
 
 [connection signal="timeout" from="RefreshTimer" to="." method="_on_refresh_timer_timeout"]
 [connection signal="value_changed" from="Body/VBoxContainer/Scale/BodyScaleSlider" to="." method="_on_body_scale_slider_value_changed"]
 [connection signal="pressed" from="Settings/VBoxContainer/Panel/Container/Left" to="." method="_on_panel_left_pressed"]
 [connection signal="pressed" from="Settings/VBoxContainer/Panel/Container/Right" to="." method="_on_panel_right_pressed"]
-[connection signal="pressed" from="Settings/VBoxContainer/Demo/Container/MainScene" to="." method="_on_main_scene_pressed"]
+[connection signal="pressed" from="Settings/VBoxContainer/Scene/Container/Main" to="." method="_on_main_scene_pressed"]
+[connection signal="pressed" from="Settings/VBoxContainer/Scene/Container/Quit" to="." method="_on_quit_pressed"]


### PR DESCRIPTION
This PR adds the end_xr() method to StartXR. This can be called directly, or can be triggered using a quit request routed through staging. The example wrist control-pad now includes a Quit button which triggers this staging-quit.

Note: Also added the is_xr_active() static method.

Note: As of Godot 4.3-beta3 this triggers a stack-overflow in WebXR, but the overflow seems to occur even when using the web-browser quit button.