### PR TITLE
Add visibility_changed notifications to Viewport2Din3D hosted scenes

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,6 +6,8 @@
 - Allow grab-points and poses to work with different types of hand trackers
 - Add end_xr support to StartXR
 - Fixed vignette shader
+- Add visibility_changed notifications to Viewport2Din3D hosted scenes
+- Invisible Viewport2Din3D now disable physics and viewport updates
 
 # 4.3.3
 - Fix Viewport2Din3D property forwarding


### PR DESCRIPTION
This PR triggers visibility_changed notifications to 2D scenes hosted in a Viewport2Din3D when the 3D visibility changes.

Additionally as requested, this PR also disable physics and viewport rendering when the Viewport2Din3D is invisible