### PR TITLE
Pass visibility changes on to the embedded 2d scene in viewport_2d_in_3d

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -1,4 +1,5 @@
 @tool
+class_name XRToolsViewport2DIn3D
 extends Node3D
 
 
@@ -127,6 +128,7 @@ func _ready():
 
 	# Listen for pointer events on the screen body
 	$StaticBody3D.connect("pointer_event", _on_pointer_event)
+	self.visibility_changed.connect(_on_visibility_changed)
 
 	# Apply physics properties
 	_update_screen_size()
@@ -612,3 +614,10 @@ func _update_render() -> void:
 		# Force a redraw of the viewport
 		if Engine.is_editor_hint() or update_mode == UpdateMode.UPDATE_ONCE:
 			$Viewport.render_target_update_mode = SubViewport.UPDATE_ONCE
+
+
+func _on_visibility_changed() -> void:
+	if not is_instance_valid(scene_node):
+		return
+
+	scene_node.visible = is_visible_in_tree()


### PR DESCRIPTION
I had some logic in a 2D scene that was checking "hey am i visible" and it was happily reporting "yes" even when the viewport was hidden.

Though maybe this change will cause issues if you have multiple 2d viewports hanging in 3d space sharing the same `scene_node`, if that's even possible?