### PR TITLE
Add XRToolsViewport2DIn3D script name.

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -1,4 +1,5 @@
 @tool
+class_name XRToolsViewport2DIn3D
 extends Node3D
 
 
@@ -119,6 +120,11 @@ var viewport_texture : ViewportTexture
 var time_since_last_update : float = 0.0
 var _screen_material : StandardMaterial3D
 var _dirty := _DIRTY_ALL
+
+
+# Add support for is_xr_class on XRTools classes
+func is_xr_class(p_name : String) -> bool:
+	return p_name == "XRToolsViewport2DIn3D"
 
 
 # Called when the node enters the scene tree for the first time.


### PR DESCRIPTION
This change adds gives the Viewport2Din3D script the name "XRToolsViewport2DIn3D" so it can be more easily extended, and supports being found by type using the XRTools helper functions.