### PR TITLE
enable actions on hand snap points

### DIFF
--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -413,13 +413,13 @@ func _pick_up_object(target: Node3D) -> void:
 func _on_button_pressed(p_button) -> void:
 	if p_button == action_button_action:
 		if is_instance_valid(picked_up_object) and picked_up_object.has_method("action"):
-			picked_up_object.action()
+			picked_up_object.action(_controller)
 
 
 func _on_button_released(p_button) -> void:
 	if p_button == action_button_action:
 		if is_instance_valid(picked_up_object) and picked_up_object.has_method("action_release"):
-			picked_up_object.action_release()
+			picked_up_object.action_release(_controller)
 
 
 func _on_grip_pressed() -> void:

--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -411,16 +411,20 @@ func _pick_up_object(target: Node3D) -> void:
 
 
 func _on_button_pressed(p_button) -> void:
-	if p_button == action_button_action:
-		if is_instance_valid(picked_up_object) and picked_up_object.has_method("action"):
+	if p_button == action_button_action and is_instance_valid(picked_up_object):
+		if picked_up_object.has_method("action"):
 			picked_up_object.action()
+
+		if picked_up_object.has_method("controller_action"):
 			picked_up_object.controller_action(_controller)
 
 
 func _on_button_released(p_button) -> void:
-	if p_button == action_button_action:
-		if is_instance_valid(picked_up_object) and picked_up_object.has_method("action_release"):
+	if p_button == action_button_action and is_instance_valid(picked_up_object):
+		if picked_up_object.has_method("action_release"):
 			picked_up_object.action_release()
+
+		if picked_up_object.has_method("controller_action_release"):
 			picked_up_object.controller_action_release(_controller)
 
 

--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -413,13 +413,15 @@ func _pick_up_object(target: Node3D) -> void:
 func _on_button_pressed(p_button) -> void:
 	if p_button == action_button_action:
 		if is_instance_valid(picked_up_object) and picked_up_object.has_method("action"):
-			picked_up_object.action(_controller)
+			picked_up_object.action()
+			picked_up_object.controller_action(_controller)
 
 
 func _on_button_released(p_button) -> void:
 	if p_button == action_button_action:
 		if is_instance_valid(picked_up_object) and picked_up_object.has_method("action_release"):
-			picked_up_object.action_release(_controller)
+			picked_up_object.action_release()
+			picked_up_object.controller_action_release(_controller)
 
 
 func _on_grip_pressed() -> void:

--- a/addons/godot-xr-tools/objects/grab_points/grab_point.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grab_point.gd
@@ -9,6 +9,13 @@ extends Marker3D
 ## is grabbed from.
 
 
+# Signal emitted when the user presses the action button while holding this grab point
+signal action_pressed(pickable, grab_point)
+
+# Signal emitted when the user releases the action button while holding this grab point
+signal action_released(pickable, grab_point)
+
+
 ## If true, the grab point is enabled for grabbing
 @export var enabled : bool = true
 
@@ -26,3 +33,15 @@ func can_grab(grabber : Node3D, _current : XRToolsGrabPoint) -> float:
 func _weight(grabber : Node3D, max : float = 1.0) -> float:
 	var distance := global_position.distance_to(grabber.global_position)
 	return max / (1.0 + distance)
+
+
+# action is called when user presses the action button while holding this grab point
+func action(pickable : XRToolsPickable):
+	# let interested parties know
+	action_pressed.emit(pickable, self)
+
+
+# action_release is called when user releases the action button while holding this grab point
+func action_release(pickable : XRToolsPickable):
+	# let interested parties know
+	action_released.emit(pickable, self)

--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -173,8 +173,13 @@ func is_picked_up() -> bool:
 
 
 # action is called when user presses the action button while holding this object
-func action(controller : XRController3D = null):
+func action():
 	# let interested parties know
+	action_pressed.emit(self)
+
+
+func controller_action(controller : XRController3D):
+	# Let the grab points know about the action
 	if (
 		_grab_driver.primary and _grab_driver.primary.point
 		and _grab_driver.primary.controller == controller
@@ -187,12 +192,15 @@ func action(controller : XRController3D = null):
 	):
 		_grab_driver.secondary.point.action(self)
 
-	action_pressed.emit(self)
-
 
 # action_release is called when user releases the action button while holding this object
-func action_release(controller : XRController3D = null):
+func action_release():
 	# let interested parties know
+	action_released.emit(self)
+
+
+func controller_action_release(controller : XRController3D):
+	# Let the grab points know about the action release
 	if (
 		_grab_driver.primary and _grab_driver.primary.point
 		and _grab_driver.primary.controller == controller
@@ -204,8 +212,6 @@ func action_release(controller : XRController3D = null):
 		and _grab_driver.secondary.controller == controller
 	):
 		_grab_driver.secondary.point.action_release(self)
-
-	action_released.emit(self)
 
 
 ## This method requests highlighting of the [XRToolsPickable].

--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -173,14 +173,38 @@ func is_picked_up() -> bool:
 
 
 # action is called when user presses the action button while holding this object
-func action():
+func action(controller : XRController3D = null):
 	# let interested parties know
+	if (
+		_grab_driver.primary and _grab_driver.primary.point
+		and _grab_driver.primary.controller == controller
+	):
+		_grab_driver.primary.point.action(self)
+
+	if (
+		_grab_driver.secondary and _grab_driver.secondary.point
+		and _grab_driver.secondary.controller == controller
+	):
+		_grab_driver.secondary.point.action(self)
+
 	action_pressed.emit(self)
 
 
 # action_release is called when user releases the action button while holding this object
-func action_release():
+func action_release(controller : XRController3D = null):
 	# let interested parties know
+	if (
+		_grab_driver.primary and _grab_driver.primary.point
+		and _grab_driver.primary.controller == controller
+	):
+		_grab_driver.primary.point.action_release(self)
+
+	if (
+		_grab_driver.secondary and _grab_driver.secondary.point
+		and _grab_driver.secondary.controller == controller
+	):
+		_grab_driver.secondary.point.action_release(self)
+
 	action_released.emit(self)
 
 


### PR DESCRIPTION
Handling pickables like two handed guns where you only want the "trigger" hand to fire it [seems complex](https://github.com/GodotVR/godot-xr-tools/blob/master/assets/3dmodelscc0/models/sniper_rifle/firearm_trigger.gd#L58). I think it is simpler to add actions to the grab points instead of the pickable.