### PR TITLE
Fix 'create_snap' desync

### DIFF
--- a/addons/godot-xr-tools/objects/grab_points/grab_driver.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grab_driver.gd
@@ -199,9 +199,8 @@ static func create_snap(
 	# Snapped to grab-point so report arrived
 	p_grab.set_arrived()
 
-	# Add the driver as a neighbor of the target as RemoteTransform3D nodes
-	# cannot be descendands of the targets they drive.
-	p_target.get_parent().add_child(driver)
+	# Add driver to child of grab node3d so p_target uses that transform
+	p_grab.by.add_child(driver)
 	driver.remote_path = driver.get_path_to(p_target)
 
 	# Return the driver


### PR DESCRIPTION
If the player drops then picks up a 'SnapZone' with a 'PickableObject' in it the 'PickableObject' will lag behind during Player or SnapZone movement due to calling 'create_snap'. Adding the driver as a direct child of the grabber prevents any desync. 'create_lerp' function is similar but has been left out until further testing.

Tested on Godot 4.3.stable