### PR TITLE
Rework interactables

### DIFF
--- a/addons/godot-xr-tools/interactables/interactable_handle.gd
+++ b/addons/godot-xr-tools/interactables/interactable_handle.gd
@@ -23,13 +23,13 @@ extends XRToolsPickable
 @export var snap_distance : float = 0.3
 
 
-# Handle origin spatial node
-@onready var handle_origin: Node3D = get_parent()
+## Transform3D that ignores driven behavior
+var _is_driven_change  := false
+var _private_transform : Transform3D
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsInteractableHandle" or super(name)
+func _enter_tree() -> void:
+	set_notify_local_transform(true)
 
 
 # Called when this handle is added to the scene
@@ -37,8 +37,11 @@ func _ready() -> void:
 	# In Godot 4 we must now manually call our super class ready function
 	super()
 
-	# Ensure we start at our origin
-	transform = Transform3D.IDENTITY
+	# freeze when not activated
+	freeze = true
+
+	# Set our Origin
+	_private_transform = transform
 
 	# Turn off processing - it will be turned on only when held
 	set_process(false)
@@ -51,10 +54,23 @@ func _process(_delta: float) -> void:
 		return
 
 	# If too far from the origin then drop the handle
-	var origin_pos = handle_origin.global_transform.origin
+	var origin_pos = _private_transform.origin
 	var handle_pos = global_transform.origin
 	if handle_pos.distance_to(origin_pos) > snap_distance:
 		drop()
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
+		# If change NOT from driven behavior (handle being grabbed/ moved)
+		if !_is_driven_change:
+			_private_transform = transform
+		_is_driven_change = false
+
+
+# Add support for is_xr_class on XRTools classes
+func is_xr_class(name : String) -> bool:
+	return name == "XRToolsInteractableHandle" or super(name)
 
 
 # Called when the handle is picked up
@@ -63,6 +79,7 @@ func pick_up(by) -> void:
 	super(by)
 
 	# Enable the process function while held
+	_is_driven_change = true
 	set_process(true)
 
 
@@ -75,14 +92,4 @@ func let_go(by: Node3D, _p_linear_velocity: Vector3, _p_angular_velocity: Vector
 	set_process(false)
 
 	# Snap the handle back to the origin
-	transform = Transform3D.IDENTITY
-
-
-# Check handle configurationv
-func _get_configuration_warnings() -> PackedStringArray:
-	var warnings := PackedStringArray()
-
-	if !transform.is_equal_approx(Transform3D.IDENTITY):
-		warnings.append("Interactable handle must have no transform from its parent handle origin")
-
-	return warnings
+	transform = _private_transform

--- a/addons/godot-xr-tools/interactables/interactable_handle.gd
+++ b/addons/godot-xr-tools/interactables/interactable_handle.gd
@@ -23,8 +23,7 @@ extends XRToolsPickable
 @export var snap_distance : float = 0.3
 
 
-## Transform3D that ignores driven behavior
-var _is_driven_change  := false
+## Transform3D that ignores changes when grabbed
 var _private_transform : Transform3D
 
 
@@ -62,10 +61,8 @@ func _process(_delta: float) -> void:
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
-		# If change NOT from driven behavior (handle being grabbed/ moved)
-		if !_is_driven_change:
-			_private_transform = transform
-		_is_driven_change = false
+		# Save Origin from any local changes (handle movements are global)
+		_private_transform = transform
 
 
 # Add support for is_xr_class on XRTools classes
@@ -79,7 +76,6 @@ func pick_up(by) -> void:
 	super(by)
 
 	# Enable the process function while held
-	_is_driven_change = true
 	set_process(true)
 
 

--- a/addons/godot-xr-tools/interactables/interactable_handle_driven.gd
+++ b/addons/godot-xr-tools/interactables/interactable_handle_driven.gd
@@ -24,18 +24,36 @@ signal released(interactable)
 var grabbed_handles := Array()
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsInteractableHandleDriven"
+## Transform3D that ignores driven behavior
+var _private_transform : Transform3D
+var _is_driven_change := false
 
 
-# Called when the node enters the scene tree for the first time.
+func _enter_tree() -> void:
+	set_notify_local_transform(true)  
+
+
 func _ready():
+	_private_transform = transform
+
 	# Hook picked_up and dropped signals from all child handles
 	_hook_child_handles(self)
 
 	# Turn off processing until a handle is grabbed
 	set_process(false)
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
+		# If change NOT from driven behavior
+		if !_is_driven_change:
+			_private_transform = transform
+		_is_driven_change = false
+
+
+# Add support for is_xr_class on XRTools classes
+func is_xr_class(name : String) -> bool:
+	return name == "XRToolsInteractableHandleDriven"
 
 
 # Called when a handle is picked up

--- a/addons/godot-xr-tools/interactables/interactable_slider.gd
+++ b/addons/godot-xr-tools/interactables/interactable_slider.gd
@@ -5,31 +5,58 @@ extends XRToolsInteractableHandleDriven
 
 ## XR Tools Interactable Slider script
 ##
-## The interactable slider is a slider transform node controlled by the
-## player through [XRToolsInteractableHandle] instances.
+## A transform node controlled by the user through [XRToolsInteractableHandle] instances.
 ##
-## The slider translates itelf along its local X axis, and so should be
-## placed as a child of a node to translate and rotate as appropriate.
+## An example scene may be setup in the following way:
+## XRSlider
+##     SliderModel (A Firearm Bolt, or Door Handle)
+##         GrabPointHandLeft
+##     InteractableHandle
+##         CollisionShape3D
+##         GrabPointRedirectLeft (set to 'GrabPointHandLeft')
 ##
 ## The interactable slider is not a [RigidBody3D], and as such will not react
 ## to any collisions.
 
 
+signal slider_moved(offset: float)
+
+
+## Start position for slide, can be positiv and negativ in values
+@export var slider_limit_min : float = 0.0:
+	set(v):
+		slider_limit_min = minf(v, slider_limit_max)
+		slider_position = slider_position
+
+## End position for slide, can be positiv and negativ in values
+@export var slider_limit_max : float = 1.0:
+	set(v):
+		slider_limit_max = maxf(v, slider_limit_min)
+		slider_position = slider_position
+
 ## Signal for slider moved
-signal slider_moved(position)
-
-
-## Slider minimum limit
-@export var slider_limit_min : float = 0.0
-
-## Slider maximum limit
-@export var slider_limit_max : float = 1.0
-
 ## Slider step size (zero for no steps)
 @export var slider_steps : float = 0.0
 
-## Slider position
-@export var slider_position : float = 0.0: set = _set_slider_position
+## Slider position - move to test the position setup
+@export var slider_position : float = 0.0:
+	set(v):
+		# Apply slider step-quantization
+		if is_zero_approx(slider_steps):
+			v = roundf(v / slider_steps) * slider_steps
+
+		# Clamp position
+		v = clampf(v, slider_limit_min, slider_limit_max)
+
+		# No change
+		if is_equal_approx(slider_position, v):
+			return
+
+		# Set, Emit
+		_is_driven_change = true
+		position = _private_transform.origin - (v * get_slider_direction())
+		slider_position = v
+		slider_moved.emit(v)
 
 ## Default position
 @export var default_position : float = 0.0
@@ -39,82 +66,37 @@ signal slider_moved(position)
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsInteractableSlider" or super(name)
+func is_xr_class(_name : String) -> bool:
+	return _name == "XRToolsInteractableSlider" or super(_name)
 
 
-# Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	# In Godot 4 we must now manually call our super class ready function
 	super()
 
-	# Set the initial position to match the initial slider position value
-	transform = Transform3D(
-		Basis.IDENTITY,
-		Vector3(slider_position, 0.0, 0.0)
-	)
-
 	# Connect signals
-	if released.connect(_on_slider_released):
+	if released.connect(_on_released):
 		push_error("Cannot connect slider released signal")
 
 
-# Called every frame when one or more handles are held by the player
 func _process(_delta: float) -> void:
-	# Get the total handle offsets
-	var offset_sum := Vector3.ZERO
-	for item in grabbed_handles:
-		var handle := item as XRToolsInteractableHandle
-		offset_sum += handle.global_transform.origin - handle.handle_origin.global_transform.origin
-
-	# Rotate the offset sum vector from global into local coordinate space
-	offset_sum = offset_sum * global_transform.basis
-
-	# Get the average displacement in the X axis
-	var offset := offset_sum.x / grabbed_handles.size()
-
-	# Move the slider by the requested offset
-	move_slider(slider_position + offset)
-
-
-# Move the slider to the specified position
-func move_slider(position: float) -> void:
-	# Do the slider move
-	position = _do_move_slider(position)
-	if position == slider_position:
+	if grabbed_handles.is_empty():
 		return
 
-	# Update the current position
-	slider_position = position
+	# Get the total handle offsets
+	var offset_sum := 0.0
+	for item in grabbed_handles:
+		var handle := item as XRToolsInteractableHandle
+		var hlocal := to_local(handle.global_position)
+		offset_sum = hlocal.dot(get_slider_direction())
 
-	# Emit the moved signal
-	emit_signal("slider_moved", position)
+	slider_position -= offset_sum / grabbed_handles.size()
 
 
-# Handle release of slider
-func _on_slider_released(_interactable: XRToolsInteractableSlider):
+## Returns a Unit Vector3 pointing backwards relative to the current transform
+func get_slider_direction() -> Vector3:
+		return (Vector3.BACK * _private_transform.basis.inverse()).normalized()
+
+
+func _on_released(_interactable: Variant) -> void:
 	if default_on_release:
-		move_slider(default_position)
-
-
-# Called when the slider position is set externally
-func _set_slider_position(position: float) -> void:
-	position = _do_move_slider(position)
-	slider_position = position
-
-
-# Do the slider move
-func _do_move_slider(position: float) -> float:
-	# Apply slider step-quantization
-	if slider_steps:
-		position = round(position / slider_steps) * slider_steps
-
-	# Apply slider limits
-	position = clamp(position, slider_limit_min, slider_limit_max)
-
-	# Move if necessary
-	if position != slider_position:
-		transform.origin.x = position
-
-	# Return the updated position
-	return position
+		slider_position = default_position


### PR DESCRIPTION
Interactables use an empty Node3D as a parent and 'origin' node to set up both handles and interactable_handle_driven scenes. This was unintuitive for new users (me). This PR will attempt to make the scenes stand alone and more intuitive. Sliders can be orientated in the editor and slide along their rotated axis. Hinges can do the same and offer 'hinge_axis' as a variable to allow the user to specify an axis to rotate around.

These are breaking changes and a work in progress. Joysticks must be incorporated and handles tested. I'll adjust the interactable_demo_scene to feature the final changes.