### PR TITLE
Improve performance by avoiding force_update_transform on grab driver

### DIFF
--- a/addons/godot-xr-tools/objects/grab_points/grab_driver.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grab_driver.gd
@@ -92,6 +92,9 @@ func _physics_process(delta : float) -> void:
 				if primary: primary.set_arrived()
 				if secondary: secondary.set_arrived()
 
+	if global_transform.is_equal_approx(destination):
+		return
+
 	# Apply the destination transform
 	global_transform = destination
 	force_update_transform()


### PR DESCRIPTION
I have a scene with hundreds of pickables tucked away in snap zones waiting for the player do do something with them. The repeated calls to `force_update_transform()` every physics step keeps them from sleeping and the performance tanks.

This change improves it from <10fps to 90fps on the XR2. A quick test in the pickables demo shows no changes to behaviour.