### PR TITLE
Don't trigger haptics when primary interface is null

### DIFF
--- a/addons/godot-xr-tools/rumble/rumble_manager.gd
+++ b/addons/godot-xr-tools/rumble/rumble_manager.gd
@@ -100,7 +100,7 @@ func _process(delta: float) -> void:
 		magnitude *= XRToolsUserSettings.haptics_scale
 
 		# Make that tracker rumble
-		if magnitude > 0:
+		if magnitude > 0 and XRServer.primary_interface:
 			XRServer.primary_interface.trigger_haptic_pulse(
 				HAPTIC_ACTION,
 				tracker_name, # if the tracker name isn't valid, it will error but continue


### PR DESCRIPTION
Very tiny fix to avoid calling the trigger_haptic function when running from VR simulator mode and the xr interface is null.
 
BTW I'm using https://github.com/imjp94/gd-plug to manage this plugin into my project, so you can see how I use it to manage which version of these xr-tools I am pulling this from:  https://github.com/goatchurchprime/Godot_XR_networking/blob/networked-grabbing/plug.gd#L4

```GDScript
func _plugging():
	plug("goatchurchprime/godot-xr-tools", {"branch": "handle-missing-rumble", "include":["addons/godot-xr-tools"]})
```
