### PR TITLE
Fix #713: rename ControlerHider → ControllerHider

### DIFF
--- a/addons/godot-xr-tools/desktop-support/controler_hider.gd
+++ b/addons/godot-xr-tools/desktop-support/controler_hider.gd
@@ -1,11 +1,11 @@
 @tool
 @icon("res://addons/godot-xr-tools/editor/icons/function.svg")
-class_name XRToolsDesktopControlerHider
+class_name XRToolsDesktopControllerHider
 extends Node
 
-## XR Tools Controler Hider
+## XR Tools Controller Hider
 ##
-## This script hides controler if XR is not active.
+## This script hides controller if XR is not active.
 
 var _pointer_disabler := false
 var _last_xr_active := true
@@ -27,7 +27,7 @@ func _ready() -> void:
 
 # Add support for is_xr_class on XRTools classes
 func is_xr_class(name : String) -> bool:
-	return name == "XRToolsDesktopControlerHider"
+	return name == "XRToolsDesktopControllerHider"
 
 func _process(_delta: float) -> void:
 	if Engine.is_editor_hint() or !is_inside_tree():

--- a/addons/godot-xr-tools/desktop-support/controler_hider.tscn
+++ b/addons/godot-xr-tools/desktop-support/controler_hider.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" path="res://addons/godot-xr-tools/desktop-support/controler_hider.gd" id="1_6xusf"]
 
-[node name="ControlerHider" type="Node"]
+[node name="ControllerHider" type="Node"]
 script = ExtResource("1_6xusf")

--- a/addons/godot-xr-tools/desktop-support/controller_hider.tscn
+++ b/addons/godot-xr-tools/desktop-support/controller_hider.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://addons/godot-xr-tools/desktop-support/controler_hider.gd" id="1"]
+
+[node name="ControllerHider" type="Node"]
+script = ExtResource("1") 

--- a/addons/godot-xr-tools/desktop-support/mouse_capture.gd
+++ b/addons/godot-xr-tools/desktop-support/mouse_capture.gd
@@ -48,4 +48,3 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 	elif (!xr_start_node.is_xr_active() and capture):
 		Input.mouse_mode=Input.MOUSE_MODE_CAPTURED
 	return
-

--- a/assets/maps/holodeck/materials/holodeck_map_shader_with_alpha.tres
+++ b/assets/maps/holodeck/materials/holodeck_map_shader_with_alpha.tres
@@ -109,7 +109,7 @@ render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_s
 
 
 // Varyings
-varying vec3 world_pos;
+varying vec3 var_world_pos;
 
 uniform vec2 grid_scale = vec2(1.000000, 1.000000);
 uniform vec4 grid_color : source_color = vec4(1.000000, 0.891186, 0.000000, 1.000000);
@@ -154,7 +154,7 @@ void vertex() {
 
 
 // VaryingSetter:15
-	world_pos = n_out8p0;
+	var_world_pos = n_out8p0;
 
 
 }
@@ -174,7 +174,7 @@ void fragment() {
 
 
 // VaryingGetter:6
-	vec3 n_out6p0 = world_pos;
+	vec3 n_out6p0 = var_world_pos;
 
 
 // VectorDecompose:11

--- a/openxr_action_map.tres
+++ b/openxr_action_map.tres
@@ -450,7 +450,7 @@ action = SubResource("OpenXRAction_tbcxk")
 paths = PackedStringArray("/user/hand/left/output/haptic", "/user/hand/right/output/haptic")
 
 [sub_resource type="OpenXRInteractionProfile" id="OpenXRInteractionProfile_8ffkv"]
-interaction_profile_path = "/interaction_profiles/pico/neo3_controller"
+interaction_profile_path = "/interaction_profiles/bytedance/pico_neo3_controller"
 bindings = [SubResource("OpenXRIPBinding_831pi"), SubResource("OpenXRIPBinding_h488p"), SubResource("OpenXRIPBinding_3se5t"), SubResource("OpenXRIPBinding_sbsju"), SubResource("OpenXRIPBinding_o26w6"), SubResource("OpenXRIPBinding_dy2rf"), SubResource("OpenXRIPBinding_50ft1"), SubResource("OpenXRIPBinding_xdnnt"), SubResource("OpenXRIPBinding_o3yqq"), SubResource("OpenXRIPBinding_d2jet"), SubResource("OpenXRIPBinding_4is5v"), SubResource("OpenXRIPBinding_s01h2"), SubResource("OpenXRIPBinding_pnsof"), SubResource("OpenXRIPBinding_orb33"), SubResource("OpenXRIPBinding_535g8"), SubResource("OpenXRIPBinding_a4cuy"), SubResource("OpenXRIPBinding_hfsbe"), SubResource("OpenXRIPBinding_i7atc"), SubResource("OpenXRIPBinding_4p7yi")]
 
 [sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_1ri7l"]

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -42,65 +42,65 @@
 [ext_resource type="Texture2D" uid="uid://cr1l4g7btdyht" path="res://scenes/origin_gravity_demo/origin_gravity_demo.png" id="32_c4n1q"]
 [ext_resource type="Texture2D" uid="uid://dhd30j0xpcxoi" path="res://scenes/sphere_world_demo/sphere_world_demo.png" id="34_xw8ig"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_fhr03"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rrnau"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_j085u"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_8y8rw"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ig3ph"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_7uflh"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vt8vm"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_n8ag1"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_rl103"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_xgbum"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_32y8o"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_6w6wh"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_fhr03")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_rrnau")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_j085u")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_8y8rw")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_ig3ph")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_7uflh")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_vt8vm")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_n8ag1")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_rl103")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_xgbum")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_xw518"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_4gb0o"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_f0bph"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_32omk"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_s6bkv"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_w5va4"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_emhc7"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_shhb4"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_0xlcy"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_yby2s"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_fkgie"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_0df86"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_xw518")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_4gb0o")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_f0bph")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_32omk")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_s6bkv")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_w5va4")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_emhc7")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_shhb4")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_0xlcy")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_yby2s")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -120,8 +120,29 @@ auto_inner_radius = 0.5
 
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("23_pr05t")]
 
+[node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_low_L/Armature" index="0"]
+bones/1/rotation = Quaternion(0.323537, -2.56588e-05, -0.0272204, 0.945824)
+bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
+bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
+bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
+bones/6/rotation = Quaternion(0.102925, -0.00993208, -0.00794416, 0.994608)
+bones/7/rotation = Quaternion(-0.012859, -0.0236108, -0.323258, 0.945929)
+bones/8/rotation = Quaternion(0.0120575, -0.00929194, -0.247472, 0.968775)
+bones/10/rotation = Quaternion(-0.0357539, -0.000400032, 0.00636764, 0.99934)
+bones/11/rotation = Quaternion(-0.00264964, -0.00114471, -0.125992, 0.992027)
+bones/12/rotation = Quaternion(0.0394225, 0.00193393, -0.228074, 0.972843)
+bones/13/rotation = Quaternion(-0.0123395, -0.00881294, -0.280669, 0.959685)
+bones/15/rotation = Quaternion(-0.0702656, 0.0101908, -0.0243307, 0.99718)
+bones/16/rotation = Quaternion(-0.0320634, -0.00223624, -0.0686366, 0.997124)
+bones/17/rotation = Quaternion(0.0253452, 0.00812462, -0.249005, 0.968136)
+bones/18/rotation = Quaternion(0.00252232, 0.00788073, -0.243204, 0.96994)
+bones/20/rotation = Quaternion(-0.0917369, 0.0203027, -0.010183, 0.995524)
+bones/21/rotation = Quaternion(-0.0625182, -0.000225721, -0.115393, 0.991351)
+bones/22/rotation = Quaternion(0.0585786, 0.0216483, -0.269905, 0.96086)
+bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
+
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_low_L/Armature/Skeleton3D" index="1"]
-transform = Transform3D(0.54083, 0.840812, -0.0231736, -0.0826267, 0.0805244, 0.993322, 0.837063, -0.535304, 0.113024, 0.0399019, 0.0402829, -0.150096)
+transform = Transform3D(0.54083, 0.840813, -0.0231736, -0.0826267, 0.0805243, 0.993322, 0.837064, -0.535303, 0.113023, 0.039902, 0.0402828, -0.150096)
 bone_name = "Index_Tip_L"
 bone_idx = 9
 
@@ -130,7 +151,7 @@ transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
 root_node = NodePath("../Hand_low_L")
-tree_root = SubResource("AnimationNodeBlendTree_32y8o")
+tree_root = SubResource("AnimationNodeBlendTree_6w6wh")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("5_xgcrx")]
 
@@ -139,15 +160,36 @@ strafe = true
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("7_kl172")]
 
-[node name="ControlerHider" parent="XROrigin3D/LeftHand" index="4" instance=ExtResource("10_wu0kt")]
+[node name="ControllerHider" parent="XROrigin3D/LeftHand" index="4" instance=ExtResource("10_wu0kt")]
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("25_2b81d")]
+
+[node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_low_R/Armature" index="0"]
+bones/1/rotation = Quaternion(0.323537, 2.56588e-05, 0.0272204, 0.945824)
+bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
+bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
+bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
+bones/6/rotation = Quaternion(0.102925, 0.00993208, 0.00794419, 0.994608)
+bones/7/rotation = Quaternion(-0.012859, 0.0236108, 0.323258, 0.945929)
+bones/8/rotation = Quaternion(0.0120575, 0.00929193, 0.247472, 0.968775)
+bones/10/rotation = Quaternion(-0.0357539, 0.000400032, -0.00636763, 0.99934)
+bones/11/rotation = Quaternion(-0.00264964, 0.00114471, 0.125992, 0.992027)
+bones/12/rotation = Quaternion(0.0394225, -0.00193393, 0.228074, 0.972843)
+bones/13/rotation = Quaternion(-0.0123395, 0.00881294, 0.280669, 0.959685)
+bones/15/rotation = Quaternion(-0.0702656, -0.0101908, 0.0243307, 0.99718)
+bones/16/rotation = Quaternion(-0.0320634, 0.00223624, 0.0686366, 0.997124)
+bones/17/rotation = Quaternion(0.0253452, -0.00812462, 0.249005, 0.968136)
+bones/18/rotation = Quaternion(0.00252233, -0.00788073, 0.243204, 0.96994)
+bones/20/rotation = Quaternion(-0.0917369, -0.0203027, 0.010183, 0.995524)
+bones/21/rotation = Quaternion(-0.0625182, 0.000225722, 0.115393, 0.991351)
+bones/22/rotation = Quaternion(0.0585786, -0.0216483, 0.269905, 0.96086)
+bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 
 [node name="mesh_Hand_low_R" parent="XROrigin3D/RightHand/RightHand/Hand_low_R/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("26_id1x7")
 
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="XROrigin3D/RightHand/RightHand/Hand_low_R/Armature/Skeleton3D" index="1"]
-transform = Transform3D(0.54083, -0.840812, 0.0231736, 0.0826267, 0.0805244, 0.993322, -0.837063, -0.535304, 0.113024, -0.0399019, 0.0402829, -0.150096)
+transform = Transform3D(0.540829, -0.840813, 0.0231736, 0.0826268, 0.0805242, 0.993322, -0.837064, -0.535303, 0.113024, -0.039902, 0.0402828, -0.150096)
 bone_name = "Index_Tip_R"
 bone_idx = 9
 
@@ -156,7 +198,7 @@ transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
 root_node = NodePath("../Hand_low_R")
-tree_root = SubResource("AnimationNodeBlendTree_fkgie")
+tree_root = SubResource("AnimationNodeBlendTree_0df86")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5_xgcrx")]
 
@@ -166,7 +208,7 @@ tree_root = SubResource("AnimationNodeBlendTree_fkgie")
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="4" instance=ExtResource("12_pwgp0")]
 
-[node name="ControlerHider" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("10_wu0kt")]
+[node name="ControllerHider" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("10_wu0kt")]
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("8")]
 


### PR DESCRIPTION
Renamed ControlerHider to Controller Hider

Tested this by importing it to Godot 4.3. No output errors and the editor compiles successfully. 

XRToolsDesktopControllerHider is compiled as seen in the screenshot. 


<img width="841" height="374" alt="godot#173" src="https://github.com/user-attachments/assets/29643d20-394a-402f-97b5-ad77b9a4c76e" />

