### PR TITLE
Better format Pointer Event

### DIFF
--- a/addons/godot-xr-tools/events/pointer_event.gd
+++ b/addons/godot-xr-tools/events/pointer_event.gd
@@ -1,5 +1,9 @@
 class_name XRToolsPointerEvent
 
+## XR Tools Pointer Event
+##
+## Event caused by XR Tools Pointer Function
+
 ## Types of pointer events
 enum Type {
 	## Pointer entered target
@@ -8,39 +12,40 @@ enum Type {
 	## Pointer exited target
 	EXITED,
 
-	## Pointer pressed target
+	## Action button pressed while on target
 	PRESSED,
 
-	## Pointer released target
+	## Action button released while on target
 	RELEASED,
 
 	## Pointer moved on target
-	MOVED
+	MOVED,
 }
 
 ## Type of pointer event
-var event_type : Type
+var event_type: Type
 
 ## Pointer generating event
-var pointer : Node3D
+var pointer: Node3D
 
 ## Target of pointer
-var target : Node3D
+var target: Node3D
 
 ## Point position
-var position : Vector3
+var position: Vector3
 
 ## Last point position
-var last_position : Vector3
+var last_position: Vector3
 
 
 ## Initialize a new instance of the XRToolsPointerEvent class
 func _init(
-		p_event_type : Type,
-		p_pointer : Node3D,
-		p_target : Node3D,
-		p_position : Vector3,
-		p_last_position : Vector3) -> void:
+		p_event_type: Type,
+		p_pointer: Node3D,
+		p_target: Node3D,
+		p_position: Vector3,
+		p_last_position: Vector3,
+) -> void:
 	event_type = p_event_type
 	pointer = p_pointer
 	target = p_target
@@ -50,77 +55,82 @@ func _init(
 
 ## Report a pointer entered event
 static func entered(
-		pointer : Node3D,
-		target : Node3D,
-		at : Vector3) -> void:
-	report(
-		XRToolsPointerEvent.new(
+		pointer: Node3D,
+		target: Node3D,
+		at: Vector3,
+) -> void:
+	report(XRToolsPointerEvent.new(
 			Type.ENTERED,
 			pointer,
 			target,
 			at,
-			at))
-
-
-## Report pointer moved event
-static func moved(
-		pointer : Node3D,
-		target : Node3D,
-		to : Vector3,
-		from : Vector3) -> void:
-	report(
-		XRToolsPointerEvent.new(
-			Type.MOVED,
-			pointer,
-			target,
-			to,
-			from))
-
-
-## Report pointer pressed event
-static func pressed(
-		pointer : Node3D,
-		target : Node3D,
-		at : Vector3) -> void:
-	report(
-		XRToolsPointerEvent.new(
-			Type.PRESSED,
-			pointer,
-			target,
 			at,
-			at))
-
-
-## Report pointer released event
-static func released(
-		pointer : Node3D,
-		target : Node3D,
-		at : Vector3) -> void:
-	report(
-		XRToolsPointerEvent.new(
-			Type.RELEASED,
-			pointer,
-			target,
-			at,
-			at))
+	))
 
 
 ## Report a pointer exited event
 static func exited(
-		pointer : Node3D,
-		target : Node3D,
-		last : Vector3) -> void:
-	report(
-		XRToolsPointerEvent.new(
+		pointer: Node3D,
+		target: Node3D,
+		last: Vector3,
+) -> void:
+	report(XRToolsPointerEvent.new(
 			Type.EXITED,
 			pointer,
 			target,
 			last,
-			last))
+			last,
+	))
+
+
+## Report pointer moved event
+static func moved(
+		pointer: Node3D,
+		target: Node3D,
+		to: Vector3,
+		from: Vector3,
+) -> void:
+	report(XRToolsPointerEvent.new(
+			Type.MOVED,
+			pointer,
+			target,
+			to,
+			from,
+	))
+
+
+## Report pointer pressed event
+static func pressed(
+		pointer: Node3D,
+		target: Node3D,
+		at: Vector3,
+) -> void:
+	report(XRToolsPointerEvent.new(
+			Type.PRESSED,
+			pointer,
+			target,
+			at,
+			at,
+	))
+
+
+## Report pointer released event
+static func released(
+		pointer: Node3D,
+		target: Node3D,
+		at: Vector3,
+) -> void:
+	report(XRToolsPointerEvent.new(
+			Type.RELEASED,
+			pointer,
+			target,
+			at,
+			at,
+	))
 
 
 ## Report a pointer event
-static func report(event : XRToolsPointerEvent) -> void:
+static func report(event: XRToolsPointerEvent) -> void:
 	# Fire event on pointer
 	if is_instance_valid(event.pointer):
 		if event.pointer.has_signal("pointing_event"):


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons
- Add class doc comment
- Clarify two pointer events' comments
- Reorder functions

## Disclaimer
No generative AI was used to enhance or create the code given here.