### PR TITLE
Fix _property_get_revert() throwing error

### DIFF
--- a/addons/godot-xr-tools/functions/function_teleport.gd
+++ b/addons/godot-xr-tools/functions/function_teleport.gd
@@ -379,9 +379,11 @@ func _property_can_revert(property : StringName) -> bool:
 
 
 # Provide revert values for custom properties
-func _property_get_revert(property : StringName): # Variant
+func _property_get_revert(property : StringName) -> Variant:
 	if property == "player_material":
 		return _DefaultMaterial
+
+	return null
 
 
 # Set enabled property

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -256,7 +256,7 @@ func _property_can_revert(property : StringName) -> bool:
 
 
 # Provide revert values for custom properties
-func _property_get_revert(property : StringName): # Variant
+func _property_get_revert(property : StringName) -> Variant:
 	match property:
 		"alpha_scissor_threshold":
 			return 0.25
@@ -264,6 +264,8 @@ func _property_get_revert(property : StringName): # Variant
 			return false
 		"filter":
 			return true
+		_:
+			return null
 
 
 # When the scene_node changes, update the property list

--- a/assets/meshes/teleport/teleport.gd
+++ b/assets/meshes/teleport/teleport.gd
@@ -138,7 +138,7 @@ func _property_can_revert(property : StringName) -> bool:
 
 
 # Provide revert values for custom properties
-func _property_get_revert(property : StringName): # Variant
+func _property_get_revert(property : StringName) -> Variant:
 	match property:
 		"spawn_point_name":
 			return ""
@@ -146,6 +146,8 @@ func _property_get_revert(property : StringName): # Variant
 			return Vector3.ZERO
 		"spawn_point_transform":
 			return Transform3D.IDENTITY
+		_:
+			return null
 
 
 func set_collision_disabled(p_disable : bool) -> void:


### PR DESCRIPTION
I added an `else` clause for every time _property_get_revert() is called. This should fix Godot 4.7rc1 throwing an error whenever XRToolsFunctionTeleport or Viewport2Din3D is used. The demo should work as normal (although I did encounter one weird bug where teleporting onto a slope causes you to slide **up** a slope, rather than down it, but this behaviour occurs in `master` anyway).