### PR TITLE
Better format and static type Pointer

### DIFF
--- a/addons/godot-xr-tools/functions/function_pointer.gd
+++ b/addons/godot-xr-tools/functions/function_pointer.gd
@@ -3,19 +3,17 @@
 class_name XRToolsFunctionPointer
 extends XRToolsHandAimOffset
 
-
 ## XR Tools Function Pointer Script
 ##
 ## This script implements a pointer function for a players controller. Pointer
-## events (entered, exited, pressed, release, and movement) are delivered by
-## invoking signals on the target node.
+## events are delivered by invoking signals on the target node.
 ##
 ## Pointer target nodes commonly extend from [XRToolsInteractableArea] or
 ## [XRToolsInteractableBody].
 
 
-## Signal emitted when this object points at another object
-signal pointing_event(event)
+## Emitted when this object points at another object
+signal pointing_event(event: XRToolsPointerEvent)
 
 
 ## Enumeration of laser show modes
@@ -41,92 +39,97 @@ const SUPPRESS_MASK := 0b0000_0000_0100_0000_0000_0000_0000_0000
 
 @export_group("General")
 
-## Pointer enabled
-@export var enabled : bool = true: set = set_enabled
+## Whether the pointer is enabled
+@export var enabled := true: set = set_enabled
 
-## Y Offset for pointer
-@export var y_offset : float = -0.013: set = set_y_offset
+## Y-offset for pointer
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var y_offset := -0.013:
+		set = set_y_offset
 
-## Pointer distance
-@export var distance : float = 10: set = set_distance
+## How far the pointer checks for collisions
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var distance := 10.0:
+		set = set_distance
 
-## Active button action
-@export var active_button_action : String = "trigger_click"
+## Action that triggers a [XRToolsPointerEvent] at an object being pointed at
+@export var active_button_action := "trigger_click"
 
 @export_group("Laser")
 
-## Controls when the laser is visible
-@export var show_laser : LaserShow = LaserShow.SHOW: set = set_show_laser
+## When the laser is visible
+@export var show_laser := LaserShow.SHOW: set = set_show_laser
 
-## Controls the length of the laser
-@export var laser_length : LaserLength = LaserLength.FULL: set = set_laser_length
+## Length of the laser
+@export var laser_length := LaserLength.FULL: set = set_laser_length
 
 ## Laser pointer material
-@export var laser_material : StandardMaterial3D = null : set = set_laser_material
+@export var laser_material: StandardMaterial3D = null : set = set_laser_material
 
 ## Laser pointer material when hitting target
-@export var laser_hit_material : StandardMaterial3D = null : set = set_laser_hit_material
+@export var laser_hit_material: StandardMaterial3D = null : set = set_laser_hit_material
 
 @export_group("Target")
 
-## If true, the pointer target is shown
-@export var show_target : bool = false: set = set_show_target
+## Whether the hit indicator is shown
+@export var show_target := false: set = set_show_target
 
-## Controls the target radius
-@export var target_radius : float = 0.05: set = set_target_radius
+## Radius of the hit indicator
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var target_radius := 0.05:
+		set = set_target_radius
 
-## Target material
-@export var target_material : StandardMaterial3D = null : set = set_target_material
+## Material of the hit indicator
+@export var target_material: StandardMaterial3D = null : set = set_target_material
 
 @export_group("Collision")
 
-## Pointer collision mask
-@export_flags_3d_physics var collision_mask : int = DEFAULT_MASK: set = set_collision_mask
+## Physics layers that the laser can collide with
+@export_flags_3d_physics var collision_mask := DEFAULT_MASK: set = set_collision_mask
 
-## Enable pointer collision with bodies
-@export var collide_with_bodies : bool = true: set = set_collide_with_bodies
+## Whether the pointer can collide with Physics Bodies
+@export var collide_with_bodies := true: set = set_collide_with_bodies
 
-## Enable pointer collision with areas
-@export var collide_with_areas : bool = false: set = set_collide_with_areas
+## Whether the pointer can collide with Areas
+@export var collide_with_areas := false: set = set_collide_with_areas
 
 @export_group("Suppression")
 
-## Suppress radius
-@export var suppress_radius : float = 0.2: set = set_suppress_radius
+## Radius within which we suppress collisions
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var suppress_radius := 0.2:
+		set = set_suppress_radius
 
-## Suppress mask
-@export_flags_3d_physics var suppress_mask : int = SUPPRESS_MASK: set = set_suppress_mask
+## Physics layers that we suppress within the radius
+@export_flags_3d_physics var suppress_mask := SUPPRESS_MASK: set = set_suppress_mask
 
 
 ## Current target node
-var target : Node3D = null
+var target: Node3D = null
 
 ## Last target node
-var last_target : Node3D = null
+var last_target: Node3D = null
 
 ## Last collision point
-var last_collided_at : Vector3 = Vector3.ZERO
+var last_collided_at := Vector3.ZERO
 
 # World scale
-var _world_scale : float = 1.0
+var _world_scale := 1.0
 
 # Left controller node
-var _controller_left_node : XRController3D
+var _controller_left_node: XRController3D
 
 # Right controller node
-var _controller_right_node : XRController3D
+var _controller_right_node: XRController3D
 
-# The currently active controller
-var _active_controller : XRController3D
+# Currently active controller
+var _active_controller: XRController3D
 
-
-## Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsFunctionPointer"
+@onready var _laser: MeshInstance3D = $Laser
+@onready var _ray: RayCast3D = $RayCast
+@onready var _suppress_area: Area3D = $SuppressArea
+@onready var _suppress_collider: CollisionShape3D = $SuppressArea/CollisionShape3D
+@onready var _target: MeshInstance3D = $Target
 
 
 # Called when the node enters the scene tree for the first time.
-func _enter_tree():
+func _enter_tree() -> void:
 	super._enter_tree()
 
 	# Do not initialise if in the editor
@@ -157,15 +160,20 @@ func _enter_tree():
 
 		# Get button press feedback from both left and right controllers
 		_controller_left_node.button_pressed.connect(
-				_on_button_pressed.bind(_controller_left_node))
+				_on_button_pressed.bind(_controller_left_node)
+		)
 		_controller_left_node.button_released.connect(
-				_on_button_released.bind(_controller_left_node))
+				_on_button_released.bind(_controller_left_node)
+		)
 		_controller_right_node.button_pressed.connect(
-				_on_button_pressed.bind(_controller_right_node))
+				_on_button_pressed.bind(_controller_right_node)
+		)
 		_controller_right_node.button_released.connect(
-				_on_button_released.bind(_controller_right_node))
+				_on_button_released.bind(_controller_right_node)
+		)
 
 	# init our state
+	await get_tree().process_frame
 	_update_y_offset()
 	_update_distance()
 	_update_pointer()
@@ -177,41 +185,13 @@ func _enter_tree():
 	_update_suppress_radius()
 	_update_suppress_mask()
 
-func _exit_tree():
-	_active_controller = null
-
-	if _controller and not Engine.is_editor_hint():
-		_controller.button_pressed.disconnect(_on_button_pressed.bind(_controller))
-		_controller.button_released.disconnect(_on_button_released.bind(_controller))
-
-		# This will be unset in our superclass method
-
-	if _controller_left_node:
-		if not Engine.is_editor_hint():
-			_controller_left_node.button_pressed.disconnect(
-					_on_button_pressed.bind(_controller_left_node))
-			_controller_left_node.button_released.disconnect(
-					_on_button_released.bind(_controller_left_node))
-
-		_controller_left_node = null
-
-	if _controller_right_node:
-		if not Engine.is_editor_hint():
-			_controller_right_node.button_pressed.disconnect(
-					_on_button_pressed.bind(_controller_right_node))
-			_controller_right_node.button_released.disconnect(
-					_on_button_released.bind(_controller_right_node))
-
-		_controller_right_node = null
-
-	super._exit_tree()
 
 # Called on each frame to update the pickup
-func _process(delta):
+func _process(delta: float) -> void:
 	super._process(delta)
 
 	# Do not process if in the editor
-	if Engine.is_editor_hint() or !is_inside_tree():
+	if Engine.is_editor_hint() or not is_inside_tree():
 		return
 
 	# Track the active controller (if this pointer is not childed to a controller)
@@ -225,20 +205,22 @@ func _process(delta):
 		_update_y_offset()
 
 	# Find the new pointer target
-	var new_target : Node3D
-	var new_at : Vector3
-	var suppress_area := $SuppressArea
-	if (enabled and
-		not $SuppressArea.has_overlapping_bodies() and
-		not $SuppressArea.has_overlapping_areas() and
-		$RayCast.is_colliding()):
-		new_at = $RayCast.get_collision_point()
+	var new_target: Node3D
+	var new_at: Vector3
+	var suppress_area := _suppress_area
+	if (
+			enabled
+			and not _suppress_area.has_overlapping_bodies()
+			and not _suppress_area.has_overlapping_areas()
+			and _ray.is_colliding()
+	):
+		new_at = _ray.get_collision_point()
 		if target:
 			# Locked to 'target' even if we're colliding with something else
 			new_target = target
 		else:
 			# Target is whatever the raycast is colliding with
-			new_target = $RayCast.get_collider()
+			new_target = _ray.get_collider()
 
 	# If no current or previous collisions then skip
 	if not new_target and not last_target:
@@ -284,176 +266,156 @@ func _process(delta):
 	last_collided_at = new_at
 
 
-# Set pointer enabled property
-func set_enabled(p_enabled : bool) -> void:
-	enabled = p_enabled
-	if is_inside_tree():
-		_update_pointer()
+func _exit_tree() -> void:
+	_active_controller = null
+
+	if _controller and not Engine.is_editor_hint():
+		_controller.button_pressed.disconnect(_on_button_pressed.bind(_controller))
+		_controller.button_released.disconnect(_on_button_released.bind(_controller))
+
+		# This will be unset in our superclass method
+
+	if _controller_left_node:
+		if not Engine.is_editor_hint():
+			_controller_left_node.button_pressed.disconnect(
+					_on_button_pressed.bind(_controller_left_node))
+			_controller_left_node.button_released.disconnect(
+					_on_button_released.bind(_controller_left_node))
+
+		_controller_left_node = null
+
+	if _controller_right_node:
+		if not Engine.is_editor_hint():
+			_controller_right_node.button_pressed.disconnect(
+					_on_button_pressed.bind(_controller_right_node))
+			_controller_right_node.button_released.disconnect(
+					_on_button_released.bind(_controller_right_node))
+
+		_controller_right_node = null
+
+	super._exit_tree()
 
 
-# Set pointer y_offset property
-func set_y_offset(p_offset : float) -> void:
-	y_offset = p_offset
-	if is_inside_tree():
-		_update_y_offset()
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsFunctionPointer"
 
 
-# Set pointer distance property
-func set_distance(p_new_value : float) -> void:
-	distance = p_new_value
-	if is_inside_tree():
-		_update_distance()
-
-
-# Set pointer show_laser property
-func set_show_laser(p_show : LaserShow) -> void:
-	show_laser = p_show
-	if is_inside_tree():
-		_update_pointer()
-
-
-# Set pointer laser_length property
-func set_laser_length(p_laser_length : LaserLength) -> void:
-	laser_length = p_laser_length
-	if is_inside_tree():
-		_update_pointer()
-
-
-# Set pointer laser_material property
-func set_laser_material(p_laser_material : StandardMaterial3D) -> void:
-	laser_material = p_laser_material
-	if is_inside_tree():
-		_update_pointer()
-
-
-# Set pointer laser_hit_material property
-func set_laser_hit_material(p_laser_hit_material : StandardMaterial3D) -> void:
-	laser_hit_material = p_laser_hit_material
-	if is_inside_tree():
-		_update_pointer()
-
-
-# Set pointer show_target property
-func set_show_target(p_show_target : bool) -> void:
-	show_target = p_show_target
-	if is_inside_tree():
-		$Target.visible = enabled and show_target and last_target
-
-
-# Set pointer target_radius property
-func set_target_radius(p_target_radius : float) -> void:
-	target_radius = p_target_radius
-	if is_inside_tree():
-		_update_target_radius()
-
-
-# Set pointer target_material property
-func set_target_material(p_target_material : StandardMaterial3D) -> void:
-	target_material = p_target_material
-	if is_inside_tree():
-		_update_target_material()
-
-
-# Set pointer collision_mask property
-func set_collision_mask(p_new_mask : int) -> void:
-	collision_mask = p_new_mask
-	if is_inside_tree():
-		_update_collision_mask()
-
-
-# Set pointer collide_with_bodies property
-func set_collide_with_bodies(p_new_value : bool) -> void:
-	collide_with_bodies = p_new_value
-	if is_inside_tree():
-		_update_collide_with_bodies()
-
-
-# Set pointer collide_with_areas property
-func set_collide_with_areas(p_new_value : bool) -> void:
+## Updates whether the pointer can collide with Areas
+func set_collide_with_areas(p_new_value: bool) -> void:
 	collide_with_areas = p_new_value
 	if is_inside_tree():
 		_update_collide_with_areas()
 
 
-# Set suppress radius property
-func set_suppress_radius(p_suppress_radius : float) -> void:
-	suppress_radius = p_suppress_radius
+## Updates whether the pointer can collide with Physics Bodies
+func set_collide_with_bodies(p_new_value: bool) -> void:
+	collide_with_bodies = p_new_value
 	if is_inside_tree():
-		_update_suppress_radius()
+		_update_collide_with_bodies()
 
 
-func set_suppress_mask(p_suppress_mask : int) -> void:
+## Sets the physics layers within which the pointer can collide with objects
+func set_collision_mask(p_new_mask: int) -> void:
+	collision_mask = p_new_mask
+	if is_inside_tree():
+		_update_collision_mask()
+
+
+## Sets how far the pointer can check for collisions
+func set_distance(p_new_value: float) -> void:
+	distance = p_new_value
+	if is_inside_tree():
+		_update_distance()
+
+
+## Sets whether the pointer is enabled
+func set_enabled(p_enabled: bool) -> void:
+	enabled = p_enabled
+	if is_inside_tree():
+		_update_pointer()
+
+
+## Sets the material of the laser when hitting an object
+func set_laser_hit_material(p_laser_hit_material: StandardMaterial3D) -> void:
+	laser_hit_material = p_laser_hit_material
+	if is_inside_tree():
+		_update_pointer()
+
+
+## Sets the length of the laser
+func set_laser_length(p_laser_length: LaserLength) -> void:
+	laser_length = p_laser_length
+	if is_inside_tree():
+		_update_pointer()
+
+
+## Sets the material of the laser
+func set_laser_material(p_laser_material: StandardMaterial3D) -> void:
+	laser_material = p_laser_material
+	if is_inside_tree():
+		_update_pointer()
+
+
+## Sets when the laser should show
+func set_show_laser(p_show: LaserShow) -> void:
+	show_laser = p_show
+	if is_inside_tree():
+		_update_pointer()
+
+
+## Sets whether the hit indicator should show
+func set_show_target(p_show_target: bool) -> void:
+	show_target = p_show_target
+	if is_inside_tree():
+		_target.visible = enabled and show_target and last_target
+
+
+## Sets the physics layers in which we should suppress collisions
+func set_suppress_mask(p_suppress_mask: int) -> void:
 	suppress_mask = p_suppress_mask
 	if is_inside_tree():
 		_update_suppress_mask()
 
 
-# Pointer Y offset update handler
-func _update_y_offset() -> void:
-	$Laser.position.y = y_offset * _world_scale
-	$RayCast.position.y = y_offset * _world_scale
+## Sets the radius in which we should suppress collisions
+func set_suppress_radius(p_suppress_radius: float) -> void:
+	suppress_radius = p_suppress_radius
+	if is_inside_tree():
+		_update_suppress_radius()
 
 
-# Pointer distance update handler
-func _update_distance() -> void:
-	$RayCast.target_position.z = -distance
-	_update_pointer()
+## Sets the material of the hit indicator
+func set_target_material(p_target_material: StandardMaterial3D) -> void:
+	target_material = p_target_material
+	if is_inside_tree():
+		_update_target_material()
 
 
-# Pointer target radius update handler
-func _update_target_radius() -> void:
-	$Target.mesh.radius = target_radius
-	$Target.mesh.height = target_radius * 2
+## Sets the radius of the hit indicator
+func set_target_radius(p_target_radius: float) -> void:
+	target_radius = p_target_radius
+	if is_inside_tree():
+		_update_target_radius()
 
 
-# Pointer target_material update handler
-func _update_target_material() -> void:
-	$Target.set_surface_override_material(0, target_material)
+## Sets the y-offset of the pointer
+func set_y_offset(p_offset: float) -> void:
+	y_offset = p_offset
+	if is_inside_tree():
+		_update_y_offset()
 
 
-# Pointer collision_mask update handler
-func _update_collision_mask() -> void:
-	$RayCast.collision_mask = collision_mask
-
-
-# Pointer collide_with_bodies update handler
-func _update_collide_with_bodies() -> void:
-	$RayCast.collide_with_bodies = collide_with_bodies
-
-
-# Pointer collide_with_areas update handler
-func _update_collide_with_areas() -> void:
-	$RayCast.collide_with_areas = collide_with_areas
-
-
-# Pointer suppress_radius update handler
-func _update_suppress_radius() -> void:
-	$SuppressArea/CollisionShape3D.shape.radius = suppress_radius
-
-
-# Pointer suppress_mask update handler
-func _update_suppress_mask() -> void:
-	$SuppressArea.collision_mask = suppress_mask
-
-
-# Pointer visible artifacts update handler
-func _update_pointer() -> void:
-	if enabled and last_target:
-		_visible_hit(last_collided_at)
-	else:
-		_visible_miss()
-
-
-# Pointer-activation button pressed handler
+# Sends a pressed XRToolsPointerEvent to an object we're pointing at
 func _button_pressed() -> void:
-	if $RayCast.is_colliding():
+	if _ray.is_colliding():
 		# Report pressed
-		target = $RayCast.get_collider()
-		last_collided_at = $RayCast.get_collision_point()
+		target = _ray.get_collider()
+		last_collided_at = _ray.get_collision_point()
 		XRToolsPointerEvent.pressed(self, target, last_collided_at)
 
 
-# Pointer-activation button released handler
+# Sends a released XRToolsPointerEvent to an object we're pointing at
 func _button_released() -> void:
 	if target:
 		# Report release
@@ -462,8 +424,8 @@ func _button_released() -> void:
 		last_collided_at = Vector3(0, 0, 0)
 
 
-# Button pressed handler
-func _on_button_pressed(p_button : String, controller : XRController3D) -> void:
+# When a button of an XR Controller is pressed
+func _on_button_pressed(p_button: String, controller: XRController3D) -> void:
 	if p_button == active_button_action and enabled:
 		if controller == _active_controller:
 			_button_pressed()
@@ -471,26 +433,82 @@ func _on_button_pressed(p_button : String, controller : XRController3D) -> void:
 			_active_controller = controller
 
 
-# Button released handler
-func _on_button_released(p_button : String, _controller : XRController3D) -> void:
+# When a button of an XR Controller is released
+func _on_button_released(p_button: String, _controller: XRController3D) -> void:
 	if p_button == active_button_action and target:
 		_button_released()
 
 
-# Update the laser active material
-func _update_laser_active_material(hit : bool) -> void:
+# Sets whether the Ray Cast can collide with Areas
+func _update_collide_with_areas() -> void:
+	_ray.collide_with_areas = collide_with_areas
+
+
+# Sets whether the Ray Cast can collide with Physics Bodies
+func _update_collide_with_bodies() -> void:
+	_ray.collide_with_bodies = collide_with_bodies
+
+
+# Sets the physics layers the Ray Cast can collide with
+func _update_collision_mask() -> void:
+	_ray.collision_mask = collision_mask
+
+
+# Sets the target position of the Ray Cast
+func _update_distance() -> void:
+	_ray.target_position.z = -distance
+	_update_pointer()
+
+
+# Sets the laser's current material
+func _update_laser_active_material(hit: bool) -> void:
 	if hit and laser_hit_material:
-		$Laser.set_surface_override_material(0, laser_hit_material)
+		_laser.set_surface_override_material(0, laser_hit_material)
 	else:
-		$Laser.set_surface_override_material(0, laser_material)
+		_laser.set_surface_override_material(0, laser_material)
 
 
-# Update the visible artifacts to show a hit
-func _visible_hit(at : Vector3) -> void:
+# Changes the visuals of the pointer
+func _update_pointer() -> void:
+	if enabled and last_target:
+		_visible_hit(last_collided_at)
+	else:
+		_visible_miss()
+
+
+# Sets the physics layers in which we suppress collisions within the radius
+func _update_suppress_mask() -> void:
+	_suppress_area.collision_mask = suppress_mask
+
+
+# Sets the radius in which we suppress collisions
+func _update_suppress_radius() -> void:
+	_suppress_collider.shape.radius = suppress_radius
+
+
+# Sets the material of the hit indicator
+func _update_target_material() -> void:
+	_target.set_surface_override_material(0, target_material)
+
+
+# Sets the radius of the hit indicator
+func _update_target_radius() -> void:
+	_target.mesh.radius = target_radius
+	_target.mesh.height = target_radius * 2
+
+
+# Sets the y-offset of the laser and Ray Cast
+func _update_y_offset() -> void:
+	_laser.position.y = y_offset * _world_scale
+	_ray.position.y = y_offset * _world_scale
+
+
+# Changes the visuals to show a hit
+func _visible_hit(at: Vector3) -> void:
 	# Show target if enabled
 	if show_target:
-		$Target.global_transform.origin = at
-		$Target.visible = true
+		_target.global_transform.origin = at
+		_target.visible = true
 
 	# Control laser visibility
 	if show_laser != LaserShow.HIDE:
@@ -499,44 +517,44 @@ func _visible_hit(at : Vector3) -> void:
 
 		# Adjust laser length
 		if laser_length == LaserLength.COLLIDE:
-			var collide_len : float = at.distance_to(global_transform.origin)
-			$Laser.mesh.size.z = collide_len
-			$Laser.position.z = collide_len * -0.5
+			var collide_len: float = at.distance_to(global_transform.origin)
+			_laser.mesh.size.z = collide_len
+			_laser.position.z = collide_len * -0.5
 		else:
-			$Laser.mesh.size.z = distance
-			$Laser.position.z = distance * -0.5
+			_laser.mesh.size.z = distance
+			_laser.position.z = distance * -0.5
 
 		# Show laser
-		$Laser.visible = true
+		_laser.visible = true
 	else:
 		# Ensure laser is hidden
-		$Laser.visible = false
+		_laser.visible = false
 
 
-# Move the visible pointer artifacts to the target
-func _visible_move(at : Vector3) -> void:
-	# Move target if configured
-	if show_target:
-		$Target.global_transform.origin = at
-
-	# Adjust laser length if set to collide-length
-	if laser_length == LaserLength.COLLIDE:
-		var collide_len : float = at.distance_to(global_transform.origin)
-		$Laser.mesh.size.z = collide_len
-		$Laser.position.z = collide_len * -0.5
-
-
-# Update the visible artifacts to show a miss
+# Changes the visuals to show a miss
 func _visible_miss() -> void:
 	# Ensure target is hidden
-	$Target.visible = false
+	_target.visible = false
 
 	# Ensure the correct laser material is set
 	_update_laser_active_material(false)
 
 	# Hide laser if not set to show always
-	$Laser.visible = show_laser == LaserShow.SHOW
+	_laser.visible = show_laser == LaserShow.SHOW
 
 	# Restore laser length if set to collide-length
-	$Laser.mesh.size.z = distance
-	$Laser.position.z = distance * -0.5
+	_laser.mesh.size.z = distance
+	_laser.position.z = distance * -0.5
+
+
+# Change the visuals if we hit a target and then move
+func _visible_move(at: Vector3) -> void:
+	# Move target if configured
+	if show_target:
+		_target.global_transform.origin = at
+
+	# Adjust laser length if set to collide-length
+	if laser_length == LaserLength.COLLIDE:
+		var collide_len: float = at.distance_to(global_transform.origin)
+		_laser.mesh.size.z = collide_len
+		_laser.position.z = collide_len * -0.5


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Replace exclamation mark with `not` keyword
- Add return type to several functions
- Add type to signal `pointing_event` parameter
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Replace repeated node paths with variables
- Add suffixes to three exported properties

## Testing
The Pointer demo was used for testing. Everything works as intended, although I used an await in the `_enter_tree()` method, otherwise this throws an error. AFAIK, this should not change anything. However, I should note that the keyboard in the Pointer demo does not do anything, even in `master`, due to issue #792.

## Disclaimer
No generative AI was used to enhance or create the code given here.