### PR TITLE
Better format and static type Pose Detector

### DIFF
--- a/addons/godot-xr-tools/functions/function_pose_detector.gd
+++ b/addons/godot-xr-tools/functions/function_pose_detector.gd
@@ -3,55 +3,49 @@
 class_name XRToolsFunctionPoseDetector
 extends XRToolsHandPalmOffset
 
-
 ## XR Tools Function Pose Area
 ##
-## This area works with the XRToolsHandPoseArea to control the pose
+## This area works with the [XRToolsHandPoseArea] to control the pose
 ## of the VR hands.
 
 
-# Default pose detector collision mask of 22:pose-area
+## Default pose detector collision mask of 22:pose-area
 const DEFAULT_MASK := 0b0000_0000_0010_0000_0000_0000_0000_0000
 
 
 ## Collision mask to detect hand pose areas
-@export_flags_3d_physics var collision_mask : int = DEFAULT_MASK: set = set_collision_mask
+@export_flags_3d_physics var collision_mask := DEFAULT_MASK: set = set_collision_mask
 
 
 ## Hand to control
-var _hand : XRToolsHand
+var _hand: XRToolsHand
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsFunctionPoseDetector"
+@onready var _sense_area: Area3D = $SenseArea
 
 
 # Called when we enter our tree
-func _enter_tree():
+func _enter_tree() -> void:
 	super._enter_tree()
 
 	_hand = XRToolsHand.find_instance(self)
 
 	# Connect signals (if controller and hand are valid)
+	await get_tree().process_frame
+
 	if _controller and _hand:
-		if $SenseArea.area_entered.connect(_on_area_entered):
+		if _sense_area.area_entered.connect(_on_area_entered):
 			push_error("Unable to connect area_entered signal")
-		if $SenseArea.area_exited.connect(_on_area_exited):
+		if _sense_area.area_exited.connect(_on_area_exited):
 			push_error("Unable to connect area_exited signal")
 
 	# Update collision mask
 	_update_collision_mask()
 
 
-func _exit_tree():
-	# Disconnect signals (if controller and hand are valid)
-	if _controller and _hand:
-		$SenseArea.area_entered.disconnect(_on_area_entered)
-		$SenseArea.area_exited.disconnect(_on_area_exited)
-
-	_hand = null
-	super._exit_tree()
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsFunctionPoseDetector"
 
 
 # This method verifies the pose area has a valid configuration.
@@ -59,28 +53,35 @@ func _get_configuration_warnings() -> PackedStringArray:
 	var warnings : PackedStringArray = super._get_configuration_warnings()
 
 	# Verify hand can be found
-	if !XRToolsHand.find_instance(self):
+	if not XRToolsHand.find_instance(self):
 		warnings.append("Node must be a within a branch of an XRController node with a hand")
 
 	# Pass basic validation
 	return warnings
 
 
-func set_collision_mask(mask : int) -> void:
+func _exit_tree() -> void:
+	# Disconnect signals (if controller and hand are valid)
+	if _controller and _hand:
+		_sense_area.area_entered.disconnect(_on_area_entered)
+		_sense_area.area_exited.disconnect(_on_area_exited)
+
+	_hand = null
+	super._exit_tree()
+
+
+## Sets what collision layers to detect Hand Pose Areas in
+func set_collision_mask(mask: int) -> void:
 	collision_mask = mask
 	if is_inside_tree():
 		_update_collision_mask()
 
 
-func _update_collision_mask() -> void:
-	$SenseArea.collision_mask = collision_mask
-
-
-## Signal handler called when this XRToolsFunctionPoseArea enters an area
-func _on_area_entered(area : Area3D) -> void:
+# When this XRToolsFunctionPoseArea enters an area
+func _on_area_entered(area: Area3D) -> void:
 	# Igjnore if the area is not a hand-pose area
 	var pose_area := area as XRToolsHandPoseArea
-	if !pose_area:
+	if not pose_area:
 		return
 
 	# Get the positional tracker
@@ -91,23 +92,27 @@ func _on_area_entered(area : Area3D) -> void:
 		_hand.add_pose_override(
 				pose_area,
 				pose_area.pose_priority,
-				pose_area.left_pose)
+				pose_area.left_pose,
+		)
+
 		# Disable grabpoints in this pose_area
 		pose_area.disable_grab_points()
 	elif tracker.hand == XRPositionalTracker.TRACKER_HAND_RIGHT and pose_area.right_pose:
 		_hand.add_pose_override(
 				pose_area,
 				pose_area.pose_priority,
-				pose_area.right_pose)
+				pose_area.right_pose,
+		)
+
 		# Disable grabpoints in this pose_area
 		pose_area.disable_grab_points()
 
 
-## Signal handler called when this XRToolsFunctionPoseArea leaves an area
-func _on_area_exited(area : Area3D) -> void:
+# When this XRToolsFunctionPoseArea leaves an area
+func _on_area_exited(area: Area3D) -> void:
 	# Ignore if the area is not a hand-pose area
 	var pose_area := area as XRToolsHandPoseArea
-	if !pose_area:
+	if not pose_area:
 		return
 
 	# Remove any overrides set from this hand-pose area
@@ -115,3 +120,7 @@ func _on_area_exited(area : Area3D) -> void:
 
 	# Enable previously disabled grabpoints
 	pose_area.enable_grab_points()
+
+
+func _update_collision_mask() -> void:
+	_sense_area.collision_mask = collision_mask


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Replace exclamation mark with `not` keyword
- Add return type to several functions
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Replace a repeated node path with a variable
# Testing
Similar to #807, I had to add an `await` to avoid bugs. I doubt this causes issues, but this will require wider testing. The Interactables demo had no issues whatsoever.
# Disclaimer
No generative AI was used to enhance or create the code given here.