### PR TITLE
Better format and static type Teleport

### DIFF
--- a/addons/godot-xr-tools/functions/function_teleport.gd
+++ b/addons/godot-xr-tools/functions/function_teleport.gd
@@ -3,7 +3,6 @@
 class_name XRToolsFunctionTeleport
 extends XRToolsHandPalmOffset
 
-
 ## XR Tools Function Teleport Script
 ##
 ## This script provides teleport functionality.
@@ -12,127 +11,145 @@ extends XRToolsHandPalmOffset
 ## a teleport function on that controller.
 
 
-# Default teleport collision mask of all
+## Default teleport collision mask of all
 const DEFAULT_MASK := 0b1111_1111_1111_1111_1111_1111_1111_1111
 
-# Default material
+## Default material
 # gdlint:ignore = load-constant-name
-const _DefaultMaterial := preload("res://addons/godot-xr-tools/materials/capsule.tres")
+const _DEFAULT_MATERIAL := preload("res://addons/godot-xr-tools/materials/capsule.tres")
 
 
-## If true, teleporting is enabled
-@export var enabled : bool = true: set = set_enabled
+## Whether teleporting is enabled
+@export var enabled := true: set = set_enabled
 
-## Teleport button action
-@export var teleport_button_action : String = "trigger_click"
+## Action that triggers the teleport
+@export var teleport_button_action := "trigger_click"
 
-## Teleport rotation action
-@export var rotation_action : String = "primary"
+## Action that rotates the player's teleport location
+@export var rotation_action := "primary"
 
 # Teleport Path Group
 @export_group("Visuals")
 
-## Teleport allowed color property
-@export var can_teleport_color : Color = Color(0.0, 1.0, 0.0, 1.0)
+## Arc color when the arc lands somewhere the player can teleport to
+@export var can_teleport_color := Color(0.0, 1.0, 0.0, 1.0)
 
-## Teleport denied color property
-@export var cant_teleport_color : Color = Color(1.0, 0.0, 0.0, 1.0)
+## Arc color when the arc lands somewhere the player can [u][b]not[/b][/u] teleport to
+@export var cant_teleport_color := Color(1.0, 0.0, 0.0, 1.0)
 
-## Teleport no-collision color property
-@export var no_collision_color : Color = Color(45.0 / 255.0, 80.0 / 255.0, 220.0 / 255.0, 1.0)
+## Arc color when the arc collides with nothing
+@export var no_collision_color := Color(45.0 / 255.0, 80.0 / 255.0, 220.0 / 255.0, 1.0)
 
-## Teleport-arc strength
-@export var strength : float = 5.0
+## How far the arc extends
+@export var strength := 5.0
 
-## Teleport texture
-@export var arc_texture : Texture2D \
-	= preload("res://addons/godot-xr-tools/images/teleport_arrow.png") \
-	: set = set_arc_texture
+## Texture of arc
+@export var arc_texture: Texture2D = preload(
+		"res://addons/godot-xr-tools/images/teleport_arrow.png"
+): set = set_arc_texture
 
-## Target texture
-@export var target_texture : Texture2D \
-	= preload("res://addons/godot-xr-tools/images/teleport_target.png") \
-	: set = set_target_texture
+## Texture of player's teleport location
+@export var target_texture: Texture2D = preload(
+		"res://addons/godot-xr-tools/images/teleport_target.png"
+): set = set_target_texture
 
 # Player Group
 @export_group("Player")
 
-## Player height property
-@export var player_height : float = 1.8: set = set_player_height
+## Height of player capsule[br][br]
+##[b]NOTE[/b]: Ignored when [i]Player Scene[/i] is not null
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var player_height := 1.8:
+		set = set_player_height
 
-## Player radius property
-@export var player_radius : float = 0.4: set = set_player_radius
+## Radius of player capsule[br][br]
+##[b]NOTE[/b]: Ignored when [i]Player Scene[/i] is not null
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var player_radius := 0.4:
+		set = set_player_radius
 
-## Player scene
-@export var player_scene : PackedScene: set = set_player_scene
+## Scene that represents the player
+@export var player_scene: PackedScene: set = set_player_scene
 
 # Target Group
 @export_group("Collision")
 
-## Maximum floor slope
-@export var max_slope : float = 20.0
+## Maximum angle our surface can be at for us to teleport onto it
+@export_range(0, 360, 1.0, "degrees") var max_slope := 20.0
 
-## Collision mask
-@export_flags_3d_physics var collision_mask : int = 1023
+## Physics layers that arc can collide with
+@export_flags_3d_physics var collision_mask: int = 1023
 
-## Valid teleport layer mask
-@export_flags_3d_physics var valid_teleport_mask : int = DEFAULT_MASK
-
-
-## Player capsule material (ignored for custom player scenes)
-var player_material : StandardMaterial3D = _DefaultMaterial :  set = set_player_material
+## Physics layers for valid teleportation targets
+@export_flags_3d_physics var valid_teleport_mask := DEFAULT_MASK
 
 
-var is_on_floor : bool = true
-var is_teleporting : bool = false
-var can_teleport : bool = true
-var teleport_rotation : float = 0.0
-var floor_normal : Vector3 = Vector3.UP
-var last_target_transform : Transform3D = Transform3D()
-var collision_shape : Shape3D
-var step_size : float = 0.5
+## Material of player capsule[br][br]
+##[b]NOTE[/b]: Ignored when [i]Player Scene[/i] is not null
+var player_material: StandardMaterial3D = _DEFAULT_MATERIAL : set = set_player_material
+
+## Whether the arc has landed on the floor
+var is_on_floor := true
+
+## Whether the player is teleporting
+var is_teleporting := false
+
+## Whether the player is able to teleport to the location they're pointing at
+var can_teleport := true
+
+## Rotation of the teleport location
+var teleport_rotation := 0.0
+
+## Normal of a flat surface
+var floor_normal := Vector3.UP
+
+## Transform of the last target location
+var last_target_transform := Transform3D()
+
+## [CollisionShape] to use when testing for collisions
+var collision_shape: Shape3D
+
+## How far to step forward when casting [RayCast]s
+var step_size := 0.5
+
+## Custom player scene
+var player: Node3D
 
 
-# Custom player scene
-var player : Node3D
-
-
-# World scale
-@onready var ws : float = XRServer.world_scale
+## World scale
+@onready var ws := XRServer.world_scale
 
 ## Capsule shown when not using a custom player mesh
-@onready var capsule : MeshInstance3D = $Target/Player_figure/Capsule
+@onready var capsule: MeshInstance3D = $Target/Player_figure/Capsule
 
 ## [XRToolsPlayerBody] node.
 @onready var player_body := XRToolsPlayerBody.find_instance(self)
 
+@onready var _player_figure: Marker3D = $Target/Player_figure
+@onready var _target: MeshInstance3D = $Target
+@onready var _teleport: MeshInstance3D = $Teleport
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsFunctionTeleport"
 
-
-func _enter_tree():
-	var bt:= Transform3D()
+func _enter_tree() -> void:
+	var bt := Transform3D()
 	bt.origin = Vector3(0.0, 0.0, -0.1)
 	set_base_transform(bt)
 
 	super._enter_tree()
 
+
 # Called when the node enters the scene tree for the first time.
-func _ready():
+func _ready() -> void:
 	# Do not initialise if in the editor
 	if Engine.is_editor_hint():
 		return
 
 	# It's inactive when we start
-	$Teleport.visible = false
-	$Target.visible = false
+	_teleport.visible = false
+	_target.visible = false
 
 	# Scale to our world scale
-	$Teleport.mesh.size = Vector2(0.05 * ws, 1.0)
-	$Target.mesh.size = Vector2(ws, ws)
-	$Target/Player_figure.scale = Vector3(ws, ws, ws)
+	_teleport.mesh.size = Vector2(0.05 * ws, 1.0)
+	_target.mesh.size = Vector2(ws, ws)
+	_player_figure.scale = Vector3(ws, ws, ws)
 
 	# get our capsule shape
 	collision_shape = CapsuleShape3D.new()
@@ -146,21 +163,21 @@ func _ready():
 	_update_player_material()
 
 
-func _physics_process(delta):
+func _physics_process(delta: float) -> void:
 	# Do not process physics if in the editor
 	if Engine.is_editor_hint():
 		return
 
 	# Skip if required nodes are missing
-	if !player_body or !_controller:
+	if not player_body or not _controller:
 		return
 
 	# if we're not enabled no point in doing mode
-	if !enabled:
+	if not enabled:
 		# reset these
 		is_teleporting = false
-		$Teleport.visible = false
-		$Target.visible = false
+		_teleport.visible = false
+		_target.visible = false
 
 		# and stop this from running until we enable again
 		set_physics_process(false)
@@ -170,16 +187,19 @@ func _physics_process(delta):
 	var new_ws := XRServer.world_scale
 	if ws != new_ws:
 		ws = new_ws
-		$Teleport.mesh.size = Vector2(0.05 * ws, 1.0)
-		$Target.mesh.size = Vector2(ws, ws)
-		$Target/Player_figure.scale = Vector3(ws, ws, ws)
+		_teleport.mesh.size = Vector2(0.05 * ws, 1.0)
+		_target.mesh.size = Vector2(ws, ws)
+		_player_figure.scale = Vector3(ws, ws, ws)
 
-	if _controller and _controller.get_is_active() and \
-			_controller.is_button_pressed(teleport_button_action):
-		if !is_teleporting:
+	if (
+			_controller
+			and _controller.get_is_active()
+			and _controller.is_button_pressed(teleport_button_action)
+	):
+		if not is_teleporting:
 			is_teleporting = true
-			$Teleport.visible = true
-			$Target.visible = true
+			_teleport.visible = true
+			_target.visible = true
 			teleport_rotation = 0.0
 
 		# get our physics engine state
@@ -195,10 +215,11 @@ func _physics_process(delta):
 		# lying on its side by default...
 		var shape_transform := Transform3D(
 				Basis(),
-				Vector3(0.0, player_height / 2.0, 0.0))
+				Vector3(0.0, player_height / 2.0, 0.0),
+		)
 
 		# update location
-		var teleport_global_transform : Transform3D = $Teleport.global_transform
+		var teleport_global_transform: Transform3D = _teleport.global_transform
 		var target_global_origin := teleport_global_transform.origin
 		var up := player_body.up_player
 		var down := -up.normalized() / ws
@@ -206,14 +227,15 @@ func _physics_process(delta):
 		############################################################
 		# New teleport logic
 		# We're going to use test move in steps to find out where we hit something...
-		# This can be optimised loads by determining the lenght based on the angle
+		# This can be optimised loads by determining the length based on the angle
 		# between sections extending the length when we're in a flat part of the arch
-		# Where we do get a collission we may want to fine tune the collision
+		# Where we do get a collision we may want to fine tune the collision
 		var cast_length := 0.0
 		var fine_tune := 1.0
 		var hit_something := false
 		var max_slope_cos := cos(deg_to_rad(max_slope))
-		for i in range(1,26):
+
+		for i: int in range(1,26):
 			var new_cast_length := cast_length + (step_size / fine_tune)
 			var global_target := Vector3(0.0, 0.0, -new_cast_length)
 
@@ -229,9 +251,11 @@ func _physics_process(delta):
 
 			# test our new location for collisions
 			query.transform = Transform3D(
-				player_body.global_transform.basis,
-				global_target) * shape_transform
+					player_body.global_transform.basis,
+					global_target,
+			) * shape_transform
 			var cast_result := state.collide_shape(query, 10)
+
 			if cast_result.is_empty():
 				# we didn't collide with anything so check our next section...
 				cast_length = new_cast_length
@@ -245,6 +269,7 @@ func _physics_process(delta):
 
 				# check for collision
 				var step_delta := global_target - target_global_origin
+
 				if up.dot(step_delta) > 0:
 					# if we're moving up, we hit the ceiling of something, we
 					# don't really care what
@@ -271,13 +296,13 @@ func _physics_process(delta):
 
 						# Update our collision point if it's moved enough, this
 						# solves a little bit of jittering
-						var diff : Vector3 = collided_at - intersects["position"]
+						var diff: Vector3 = collided_at - intersects["position"]
 
 						if diff.length() > 0.1:
 							collided_at = intersects["position"]
 
 						# Fail if the hit target isn't in our valid mask
-						var collider_mask : int = intersects["collider"].collision_layer
+						var collider_mask: int = intersects["collider"].collision_layer
 						if not valid_teleport_mask & collider_mask:
 							is_on_floor = false
 
@@ -289,12 +314,14 @@ func _physics_process(delta):
 				break
 
 		# and just update our shader
-		$Teleport.get_surface_override_material(0).set_shader_parameter("scale_t", 1.0 / strength)
-		$Teleport.get_surface_override_material(0).set_shader_parameter("down", down)
-		$Teleport.get_surface_override_material(0).set_shader_parameter("length", cast_length)
+		_teleport.get_surface_override_material(0).set_shader_parameter("scale_t", 1.0 / strength)
+		_teleport.get_surface_override_material(0).set_shader_parameter("down", down)
+		_teleport.get_surface_override_material(0).set_shader_parameter("length", cast_length)
+
 		if hit_something:
 			var color := can_teleport_color
 			var normal := up
+
 			if is_on_floor:
 				# if we're on the floor we'll reorientate our target to match.
 				normal = floor_normal
@@ -313,20 +340,26 @@ func _physics_process(delta):
 			target_basis.z = target_basis.x.cross(target_basis.y)
 
 			target_basis = target_basis.rotated(normal, teleport_rotation)
+
 			last_target_transform.basis = target_basis
 			last_target_transform.origin = target_global_origin + up * 0.001
-			$Target.global_transform = last_target_transform
+			_target.global_transform = last_target_transform
 
-			$Teleport.get_surface_override_material(0).set_shader_parameter("mix_color", color)
-			$Target.get_surface_override_material(0).albedo_color = color
-			$Target.visible = can_teleport
+			_teleport.get_surface_override_material(0).set_shader_parameter(
+					"mix_color",
+					color,
+			)
+			_target.get_surface_override_material(0).albedo_color = color
+			_target.visible = can_teleport
 		else:
 			can_teleport = false
-			$Target.visible = false
-			$Teleport.get_surface_override_material(0).set_shader_parameter("mix_color", no_collision_color)
+			_target.visible = false
+			_teleport.get_surface_override_material(0).set_shader_parameter(
+					"mix_color",
+					no_collision_color,
+			)
 	elif is_teleporting:
 		if can_teleport:
-
 			# Make our target using the players up vector
 			var new_transform := last_target_transform
 			new_transform.basis.y = player_body.up_player
@@ -338,17 +371,19 @@ func _physics_process(delta):
 
 		# and disable
 		is_teleporting = false
-		$Teleport.visible = false
-		$Target.visible = false
+		_teleport.visible = false
+		_target.visible = false
 
 
 # This method verifies the teleport has a valid configuration.
 func _get_configuration_warnings() -> PackedStringArray:
-	var warnings : PackedStringArray = super._get_configuration_warnings()
+	var warnings: PackedStringArray = super._get_configuration_warnings()
 
 	# Verify we can find the XRToolsPlayerBody
-	if !XRToolsPlayerBody.find_instance(self):
-		warnings.append("This node must be within a branch of an XRToolsPlayerBody node")
+	if not XRToolsPlayerBody.find_instance(self):
+		warnings.append(
+				"This node must be within a branch of an XRToolsPlayerBody node"
+		)
 
 	# Return warnings
 	return warnings
@@ -357,104 +392,102 @@ func _get_configuration_warnings() -> PackedStringArray:
 # Provide custom property information
 func _get_property_list() -> Array[Dictionary]:
 	return [
-		{
-			"name" : "Player",
-			"type" : TYPE_NIL,
-			"usage" : PROPERTY_USAGE_GROUP
-		},
-		{
-			"name" : "player_material",
-			"class_name" : "StandardMaterial3D",
-			"type" : TYPE_OBJECT,
-			"usage" : PROPERTY_USAGE_NO_EDITOR if player_scene else PROPERTY_USAGE_DEFAULT,
-			"hint" : PROPERTY_HINT_RESOURCE_TYPE,
-			"hint_string" : "StandardMaterial3D"
-		}
+			{
+					"name": "Player",
+					"type": TYPE_NIL,
+					"usage": PROPERTY_USAGE_GROUP,
+			},
+			{
+					"name": "player_material",
+					"class_name": "StandardMaterial3D",
+					"type": TYPE_OBJECT,
+					"usage": PROPERTY_USAGE_NO_EDITOR if player_scene else PROPERTY_USAGE_DEFAULT,
+					"hint": PROPERTY_HINT_RESOURCE_TYPE,
+					"hint_string": "StandardMaterial3D",
+			},
 	]
 
 
 # Allow revert of custom properties
-func _property_can_revert(property : StringName) -> bool:
+func _property_can_revert(property: StringName) -> bool:
 	return property == "player_material"
 
 
 # Provide revert values for custom properties
-func _property_get_revert(property : StringName) -> Variant:
+func _property_get_revert(property: StringName) -> Variant:
 	if property == "player_material":
-		return _DefaultMaterial
+		return _DEFAULT_MATERIAL
 
 	return null
 
 
-# Set enabled property
-func set_enabled(new_value : bool) -> void:
-	enabled = new_value
-	if enabled:
-		# make sure our physics process is on
-		set_physics_process(true)
-	else:
-		# we turn this off in physics process just in case we want to do some cleanup
-		pass
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsFunctionTeleport"
 
 
-# Set the arc texture
-func set_arc_texture(p_arc_texture : Texture2D) -> void:
+## Sets the arc texture
+func set_arc_texture(p_arc_texture: Texture2D) -> void:
 	arc_texture = p_arc_texture
 	if is_inside_tree():
 		_update_arc_texture()
 
 
-# Set the target texture
-func set_target_texture(p_target_texture : Texture2D) -> void:
+## Sets whether teleporting is enabled
+func set_enabled(new_value: bool) -> void:
+	enabled = new_value
+
+	# make sure our physics process is on
+	set_physics_process(enabled)
+
+
+## Sets the texture that indicates where the player will teleport to
+func set_target_texture(p_target_texture: Texture2D) -> void:
 	target_texture = p_target_texture
 	if is_inside_tree():
 		_update_target_texture()
 
 
-# Set player height property
-func set_player_height(p_height : float) -> void:
+## Sets height of player capsule[br][br]
+## [b]NOTE[/b]: Ignored if [code]player_scene[/code] is not null
+func set_player_height(p_height: float) -> void:
 	player_height = p_height
 	if is_inside_tree():
 		_update_player_height()
 
 
-# Set player radius property
-func set_player_radius(p_radius : float) -> void:
+## Sets material of player capsule[br][br]
+## [b]NOTE[/b]: Ignored if [code]player_scene[/code] is not null
+func set_player_material(p_player_material: StandardMaterial3D) -> void:
+	player_material = p_player_material
+	if is_inside_tree():
+		_update_player_material()
+
+
+## Sets radius of player capsule[br][br]
+## [b]NOTE[/b]: Ignored if [code]player_scene[/code] is not null
+func set_player_radius(p_radius: float) -> void:
 	player_radius = p_radius
 	if is_inside_tree():
 		_update_player_radius()
 
 
-# Set the player scene
-func set_player_scene(p_player_scene : PackedScene) -> void:
+## Sets scene that represents the player
+func set_player_scene(p_player_scene: PackedScene) -> void:
 	player_scene = p_player_scene
 	notify_property_list_changed()
 	if is_inside_tree():
 		_update_player_scene()
 
 
-# Set the player material
-func set_player_material(p_player_material : StandardMaterial3D) -> void:
-	player_material = p_player_material
-	if is_inside_tree():
-		_update_player_material()
-
-
-# Update arc texture
-func _update_arc_texture():
-	var material : ShaderMaterial = $Teleport.get_surface_override_material(0)
+## Changes texture that repesents the arc from the player to the teleport location
+func _update_arc_texture() -> void:
+	var material: ShaderMaterial = _teleport.get_surface_override_material(0)
 	if material and arc_texture:
 		material.set_shader_parameter("arrow_texture", arc_texture)
 
 
-# Update target texture
-func _update_target_texture():
-	var material : StandardMaterial3D = $Target.get_surface_override_material(0)
-	if material and target_texture:
-		material.albedo_texture = target_texture
-
-
-# Player height update handler
+# Changes height of player capsule
 func _update_player_height() -> void:
 	if collision_shape:
 		collision_shape.height = player_height - (2.0 * player_radius)
@@ -464,8 +497,14 @@ func _update_player_height() -> void:
 		capsule.position = Vector3(0.0, player_height/2.0, 0.0)
 
 
-# Player radius update handler
-func _update_player_radius():
+# Changes material of player capsule
+func _update_player_material() -> void:
+	if player_material:
+		capsule.set_surface_override_material(0, player_material)
+
+
+# Changes radius of player capsule
+func _update_player_radius() -> void:
 	if collision_shape:
 		collision_shape.height = player_height
 		collision_shape.radius = player_radius
@@ -475,7 +514,7 @@ func _update_player_radius():
 		capsule.mesh.radius = player_radius
 
 
-# Update the player scene
+# Changes the scene that represents the player
 func _update_player_scene() -> void:
 	# Free the current player
 	if player:
@@ -485,13 +524,14 @@ func _update_player_scene() -> void:
 	# If specified, instantiate a new player
 	if player_scene:
 		player = player_scene.instantiate()
-		$Target/Player_figure.add_child(player)
+		_player_figure.add_child(player)
 
 	# Show the capsule mesh only if we have no player
 	capsule.visible = player == null
 
 
-# Update player material
-func _update_player_material():
-	if player_material:
-		capsule.set_surface_override_material(0, player_material)
+# Changes texture placed where the player will teleport to
+func _update_target_texture() -> void:
+	var material: StandardMaterial3D = _target.get_surface_override_material(0)
+	if material and target_texture:
+		material.albedo_texture = target_texture


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Replace exclamation mark with `not` keyword
- Add return type to several functions
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Replace a repeated node path with a variable
- Add spaces between lines for extra readability
- Fix two typos
- Add suffixes to three exported properties
# Testing
The Teleport demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.