### PR TITLE
Better format and static type Crouch

### DIFF
--- a/addons/godot-xr-tools/functions/movement_crouch.gd
+++ b/addons/godot-xr-tools/functions/movement_crouch.gd
@@ -2,7 +2,6 @@
 class_name XRToolsMovementCrouch
 extends XRToolsMovementProvider
 
-
 ## XR Tools Movement Provider for Crouching
 ##
 ## This script works with the [XRToolsPlayerBody] attached to the players
@@ -20,77 +19,39 @@ enum CrouchType {
 
 
 ## Movement provider order
-@export var order : int = 10
+@export var order: int = 10
 
-## Crouch height
-@export var crouch_height : float = 1.0
+## Player height when crouching
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var crouch_height := 1.0
 
 ## Crouch button
-@export var crouch_button_action : String = "primary_click"
+@export var crouch_button_action := "primary_click"
 
 ## Type of crouching
-@export var crouch_type : CrouchType = CrouchType.HOLD_TO_CROUCH
+@export var crouch_type := CrouchType.HOLD_TO_CROUCH
 
 
-## Crouching flag
-var _crouching : bool = false
+# Whether the player is currently crouching
+var _crouching := false
 
-## Crouch button down state
-var _crouch_button_down : bool = false
-
+# Whether the player is trying to crouch
+var _crouch_button_down := false
 
 # Controller node
-var _controller : XRController3D
+var _controller: XRController3D
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsMovementCrouch" or super(xr_name)
-
-
-# Called when our node is added to our scene tree
-func _enter_tree():
+# When our node is added to our scene tree
+func _enter_tree() -> void:
 	_controller = XRHelpers.get_xr_controller(self)
 
 
-# Called when our node is removed from our scene tree
-func _exit_tree():
+# When our node is removed from our scene tree
+func _exit_tree() -> void:
 	_controller = null
 
 
-# Perform jump movement
-func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
-	# Skip if the controller isn't active
-	if not _controller or not _controller.get_is_active():
-		return
-
-	# Detect crouch button down and pressed states
-	var crouch_button_down := _controller.is_button_pressed(crouch_button_action)
-	var crouch_button_pressed := crouch_button_down and !_crouch_button_down
-	_crouch_button_down = crouch_button_down
-
-	# Calculate new crouching state
-	var crouching := _crouching
-	match crouch_type:
-		CrouchType.HOLD_TO_CROUCH:
-			# Crouch when button down
-			crouching = crouch_button_down
-
-		CrouchType.TOGGLE_CROUCH:
-			# Toggle when button pressed
-			if crouch_button_pressed:
-				crouching = !crouching
-
-	# Update crouching state
-	if crouching != _crouching:
-		_crouching = crouching
-		if crouching:
-			player_body.override_player_height(self, crouch_height)
-		else:
-			player_body.override_player_height(self)
-
-
-# This method verifies the movement provider has a valid configuration.
+# Verifies the movement provider has a valid configuration.
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := super()
 
@@ -100,3 +61,46 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 	# Return warnings
 	return warnings
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsMovementCrouch" or super(xr_name)
+
+
+## Performs crouch movement
+func physics_movement(
+		_delta: float,
+		player_body: XRToolsPlayerBody,
+		_disabled: bool,
+) -> bool:
+	# Skip if the controller isn't active
+	if not _controller or not _controller.get_is_active():
+		return false
+
+	# Detect crouch button down and pressed states
+	var is_crouch_button_down := _controller.is_button_pressed(crouch_button_action)
+	var crouch_button_pressed := is_crouch_button_down and not _crouch_button_down
+	_crouch_button_down = is_crouch_button_down
+
+	# Calculate new crouching state
+	var crouching := _crouching
+	match crouch_type:
+		CrouchType.HOLD_TO_CROUCH:
+			# Crouch when button down
+			crouching = is_crouch_button_down
+
+		CrouchType.TOGGLE_CROUCH:
+			# Toggle when button pressed
+			if crouch_button_pressed:
+				crouching = not crouching
+
+	# Update crouching state
+	if crouching != _crouching:
+		_crouching = crouching
+		if crouching:
+			player_body.override_player_height(self, crouch_height)
+		else:
+			player_body.override_player_height(self)
+
+	return false


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Replace exclamation mark with `not` keyword
- Add return type to several functions
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Rename one local variable for better clarity
- Add suffix to exported property
# Testing
The Basic Movement demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.