### PR TITLE
Better format and static type Direct Movement

### DIFF
--- a/addons/godot-xr-tools/functions/movement_direct.gd
+++ b/addons/godot-xr-tools/functions/movement_direct.gd
@@ -2,7 +2,6 @@
 class_name XRToolsMovementDirect
 extends XRToolsMovementProvider
 
-
 ## XR Tools Movement Provider for Direct Movement
 ##
 ## This script provides direct movement for the player. This script works
@@ -12,55 +11,50 @@ extends XRToolsMovementProvider
 ## different controllers to provide different types of direct movement.
 
 
-## Movement provider order
-@export var order : int = 10
+## Order in which movement is processed
+@export var order: int = 10
 
 ## Movement speed
-@export var max_speed : float = 3.0
+@export_custom(PROPERTY_HINT_NONE, "suffix:m/s") var max_speed := 3.0
 
-## If true, the player can strafe
-@export var strafe : bool = false
+## Whether the player can strafe
+@export var strafe := false
 
 ## Input action for movement direction
-@export var input_action : String = "primary"
+@export var input_action := "primary"
 
 
 # Controller node
-var _controller : XRController3D
+var _controller: XRController3D
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsMovementDirect" or super(xr_name)
+## Finds the left [XRToolsMovementDirect] node.
+##
+## This function searches from the specified node for the left controller
+## [XRToolsMovementDirect] assuming the node is a sibling of the [XROrigin3D].
+static func find_left(node: Node) -> XRToolsMovementDirect:
+	return XRTools.find_xr_child(
+			XRHelpers.get_left_controller(node),
+			"*",
+			"XRToolsMovementDirect",
+	) as XRToolsMovementDirect
 
 
-# Called when our node is added to our scene tree
-func _enter_tree():
+## Finds the right [XRToolsMovementDirect] node.
+##
+## This function searches from the specified node for the right controller
+## [XRToolsMovementDirect] assuming the node is a sibling of the [XROrigin3D].
+static func find_right(node: Node) -> XRToolsMovementDirect:
+	return XRTools.find_xr_child(
+			XRHelpers.get_right_controller(node),
+			"*",
+			"XRToolsMovementDirect",
+	) as XRToolsMovementDirect
+
+
+# When our node is added to our scene tree
+func _enter_tree() -> void:
 	_controller = XRHelpers.get_xr_controller(self)
-
-
-# Called when our node is removed from our scene tree
-func _exit_tree():
-	_controller = null
-
-
-# Perform jump movement
-func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
-	# Skip if the controller isn't active
-	if not _controller or not _controller.get_is_active():
-		return
-
-	## get input action with deadzone correction applied
-	var dz_input_action = XRToolsUserSettings.get_adjusted_vector2(_controller, input_action)
-
-	player_body.ground_control_velocity.y += dz_input_action.y * max_speed
-	if strafe:
-		player_body.ground_control_velocity.x += dz_input_action.x * max_speed
-
-	# Clamp ground control
-	var length := player_body.ground_control_velocity.length()
-	if length > max_speed:
-		player_body.ground_control_velocity *= max_speed / length
 
 
 # This method verifies the movement provider has a valid configuration.
@@ -75,23 +69,39 @@ func _get_configuration_warnings() -> PackedStringArray:
 	return warnings
 
 
-## Find the left [XRToolsMovementDirect] node.
-##
-## This function searches from the specified node for the left controller
-## [XRToolsMovementDirect] assuming the node is a sibling of the [XROrigin3D].
-static func find_left(node : Node) -> XRToolsMovementDirect:
-	return XRTools.find_xr_child(
-		XRHelpers.get_left_controller(node),
-		"*",
-		"XRToolsMovementDirect") as XRToolsMovementDirect
+# When our node is removed from our scene tree
+func _exit_tree() -> void:
+	_controller = null
 
 
-## Find the right [XRToolsMovementDirect] node.
-##
-## This function searches from the specified node for the right controller
-## [XRToolsMovementDirect] assuming the node is a sibling of the [XROrigin3D].
-static func find_right(node : Node) -> XRToolsMovementDirect:
-	return XRTools.find_xr_child(
-		XRHelpers.get_right_controller(node),
-		"*",
-		"XRToolsMovementDirect") as XRToolsMovementDirect
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsMovementDirect" or super(xr_name)
+
+
+## Performs jump movement
+func physics_movement(
+		_delta: float,
+		player_body: XRToolsPlayerBody,
+		_disabled: bool,
+) -> bool:
+	# Skip if the controller isn't active
+	if not _controller or not _controller.get_is_active():
+		return false
+
+	# Get input action with deadzone correction applied
+	var dz_input_action: Vector2 = XRToolsUserSettings.get_adjusted_vector2(
+			_controller,
+			input_action,
+	)
+
+	player_body.ground_control_velocity.y += dz_input_action.y * max_speed
+	if strafe:
+		player_body.ground_control_velocity.x += dz_input_action.x * max_speed
+
+	# Clamp ground control
+	var length := player_body.ground_control_velocity.length()
+	if length > max_speed:
+		player_body.ground_control_velocity *= max_speed / length
+
+	return false


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to several functions
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Add suffix to exported property
# Testing
The **Basic Movement** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.