### PR TITLE
Better format and static type Footstep

### DIFF
--- a/addons/godot-xr-tools/functions/movement_footstep.gd
+++ b/addons/godot-xr-tools/functions/movement_footstep.gd
@@ -2,7 +2,6 @@
 class_name XRToolsMovementFootstep
 extends XRToolsMovementProvider
 
-
 ## XR Tools Movement Provider for Footsteps
 ##
 ## This movement provider detects walking on different surfaces.
@@ -10,56 +9,64 @@ extends XRToolsMovementProvider
 ## currently walking on.
 
 
-## Signal emitted when a footstep is generated
-signal footstep(name)
+## Emitted when a footstep is generated
+signal footstep(surface: String)
 
 
-# Number of audio players to pool
+## Number of audio players to pool
 const AUDIO_POOL_SIZE := 3
 
 
-## Movement provider order
-@export var order : int = 1001
+## Order in which movement is processed
+@export var order: int = 1001
 
 ## Default XRToolsSurfaceAudioType when not overridden
-@export var default_surface_audio_type : XRToolsSurfaceAudioType
+@export var default_surface_audio_type: XRToolsSurfaceAudioType
 
 ## Speed at which the player is considered walking
-@export var walk_speed := 0.4
+@export_custom(PROPERTY_HINT_NONE, "suffix:m/s") var walk_speed := 0.4
 
-## Step per meter by time
-@export var steps_per_meter = 1.0
+## Time between steps per meter
+@export_custom(PROPERTY_HINT_NONE, "suffix:s") var steps_per_meter := 1.0
 
 
-# step time
-var step_time = 0.0
+# Time since the last footstep
+var step_time := 0.0
 
 # Last on_ground state of the player
 var _old_on_ground := true
 
 # Node representing the location of the players foot
-var _foot_spatial : Node3D
+var _foot_spatial: Node3D
 
 # Pool of idle AudioStreamPlayer3D nodes
-var _audio_pool_idle : Array[AudioStreamPlayer3D]
+var _audio_pool_idle: Array[AudioStreamPlayer3D]
 
 # Last ground node
-var _ground_node : Node
+var _ground_node: Node
 
 # Surface audio type associated with last ground node
-var _ground_node_audio_type : XRToolsSurfaceAudioType
+var _ground_node_audio_type: XRToolsSurfaceAudioType
 
 
 ## PlayerBody - Player Physics Body Script
 @onready var player_body := XRToolsPlayerBody.find_instance(self)
+@onready var _player_settings: AudioStreamPlayer3D = $PlayerSettings
 
 
-# Add support for is_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsMovementFootstep" or super(xr_name)
+## Find an [XRToolsMovementFootstep] node.
+##
+## This function searches from the specified node for an [XRToolsMovementFootstep]
+## assuming the node is a sibling of the body under an [ARVROrigin].
+static func find_instance(node: Node) -> XRToolsMovementFootstep:
+	return XRTools.find_xr_child(
+			XRHelpers.get_xr_origin(node),
+			"*",
+			"XRToolsMovementFootstep",
+	) as XRToolsMovementFootstep
 
 
-func _ready():
+func _ready() -> void:
 	# In Godot 4 we must now manually call our super class ready function
 	super()
 
@@ -69,8 +76,8 @@ func _ready():
 	add_child(_foot_spatial)
 
 	# Make the array of players in _audio_pool_idle
-	for i in AUDIO_POOL_SIZE:
-		var player = $PlayerSettings.duplicate()
+	for i: int in AUDIO_POOL_SIZE:
+		var player = _player_settings.duplicate()
 		player.name = "PlayerCopy%d" % (i + 1)
 		_foot_spatial.add_child(player)
 		_audio_pool_idle.append(player)
@@ -83,19 +90,29 @@ func _ready():
 	player_body.player_jumped.connect(_on_player_jumped)
 
 
-# This method checks for configuration issues.
+# Checks for configuration issues.
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := super()
 
 	# Verify player settings node exists
-	if not $PlayerSettings:
+	if not _player_settings:
 		warnings.append("Missing player settings node")
 
 	# Return warnings
 	return warnings
 
 
-func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsMovementFootstep" or super(xr_name)
+
+
+## Checks if the player is on the ground to play footstep sounds
+func physics_movement(
+		_delta: float,
+		player_body: XRToolsPlayerBody,
+		_disabled: bool,
+) -> bool:
 	# Update the spatial location of the foot
 	_update_foot_spatial()
 
@@ -105,7 +122,7 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 	# Skip if footsteps have been disabled
 	if not enabled:
 		step_time = 0
-		return
+		return false
 
 	# Detect landing on ground
 	if not _old_on_ground and player_body.on_ground:
@@ -116,12 +133,12 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 	_old_on_ground = player_body.on_ground
 	if not player_body.on_ground:
 		step_time = 0 	# Reset when not on ground
-		return
+		return false
 
 	# Handle slow/stopped
 	if player_body.ground_control_velocity.length() < walk_speed:
 		step_time = 0	# Reset when slow/stopped
-		return
+		return false
 
 	# Count up the step timer, and skip if not take a step yet
 	step_time += _delta * player_body.ground_control_velocity.length()
@@ -129,8 +146,10 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 		_play_step_sound()
 		step_time = 0
 
+	return false
 
-# Update the foot spatial to be where the players foot is
+
+# Updates the foot spatial to be where the players foot is
 func _update_foot_spatial() -> void:
 	# Project the players camera down to the XZ plane (real-world space)
 	var local_foot := player_body.camera_node.position.slide(Vector3.UP)
@@ -139,7 +158,7 @@ func _update_foot_spatial() -> void:
 	_foot_spatial.global_position = player_body.origin_node.global_transform * local_foot
 
 
-# Update the ground audio information
+# Updates the ground audio information
 func _update_ground_audio() -> void:
 	# Skip if no change
 	if player_body.ground_node == _ground_node:
@@ -154,15 +173,18 @@ func _update_ground_audio() -> void:
 		return
 
 	# Find the surface audio for the ground (if any)
-	var ground_audio : XRToolsSurfaceAudio = XRTools.find_xr_child(
-		_ground_node, "*", "XRToolsSurfaceAudio")
+	var ground_audio: XRToolsSurfaceAudio = XRTools.find_xr_child(
+			_ground_node,
+			"*",
+			"XRToolsSurfaceAudio",
+	)
 	if ground_audio:
 		_ground_node_audio_type = ground_audio.surface_audio_type
 	else:
 		_ground_node_audio_type = default_surface_audio_type
 
 
-# Called when the player jumps
+# When the player jumps
 func _on_player_jumped() -> void:
 	# Skip if no jump sound
 	if not _ground_node_audio_type:
@@ -171,10 +193,11 @@ func _on_player_jumped() -> void:
 	# Play the jump sound
 	_play_sound(
 			_ground_node_audio_type.name,
-			_ground_node_audio_type.jump_sound)
+			_ground_node_audio_type.jump_sound,
+	)
 
 
-# Play the hit sound made when the player lands on the ground
+# Plays the hit sound made when the player lands on the ground
 func _play_ground_hit() -> void:
 	# Skip if no hit sound
 	if not _ground_node_audio_type:
@@ -183,10 +206,11 @@ func _play_ground_hit() -> void:
 	# Play the hit sound
 	_play_sound(
 			_ground_node_audio_type.name,
-			_ground_node_audio_type.hit_sound)
+			_ground_node_audio_type.hit_sound,
+	)
 
 
-# Play a step sound for the current ground
+# Plays a step sound for the current ground
 func _play_step_sound() -> void:
 	# Skip if no walk audio
 	if not _ground_node_audio_type or _ground_node_audio_type.walk_sounds.size() == 0:
@@ -204,18 +228,19 @@ func _play_step_sound() -> void:
 	_play_sound(
 			_ground_node_audio_type.name,
 			_ground_node_audio_type.walk_sounds[idx],
-			pitch)
+			pitch,
+	)
 
 
-# Play the specified audio stream at the requested pitch using an
+# Plays the specified audio stream at the requested pitch using an
 # AudioStreamPlayer3D in the idle pool of players.
-func _play_sound(name : String, stream : AudioStream, pitch : float = 1.0) -> void:
+func _play_sound(surface: String, stream: AudioStream, pitch: float = 1.0) -> void:
 	# Skip if no stream provided
 	if not stream:
 		return
 
 	# Emit the footstep signal
-	footstep.emit(name)
+	footstep.emit(surface)
 
 	# Verify we have an audio player
 	if _audio_pool_idle.size() == 0:
@@ -223,23 +248,12 @@ func _play_sound(name : String, stream : AudioStream, pitch : float = 1.0) -> vo
 		return
 
 	# Play the sound
-	var player : AudioStreamPlayer3D = _audio_pool_idle.pop_front()
+	var player: AudioStreamPlayer3D = _audio_pool_idle.pop_front()
 	player.stream = stream
 	player.pitch_scale = pitch
 	player.play()
 
 
 # Called when an AudioStreamPlayer3D in our pool finishes playing its sound
-func _on_player_finished(player : AudioStreamPlayer3D) -> void:
+func _on_player_finished(player: AudioStreamPlayer3D) -> void:
 	_audio_pool_idle.append(player)
-
-
-## Find an [XRToolsMovementFootstep] node.
-##
-## This function searches from the specified node for an [XRToolsMovementFootstep]
-## assuming the node is a sibling of the body under an [ARVROrigin].
-static func find_instance(node: Node) -> XRToolsMovementFootstep:
-	return XRTools.find_xr_child(
-		XRHelpers.get_xr_origin(node),
-		"*",
-		"XRToolsMovementFootstep") as XRToolsMovementFootstep


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to two functions
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Rename a signal parameter and defines its type as `String`
- Change the parameter `name` in `_play_sound()` to `surface` for better clarity
- Add suffixes to two exported properties
# Note
A portal to the **Footstep Movement** demo is not available in the main menu scene. A PR (#818) to add this has already been opened.
# Testing
The **Footstep Movement** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.