### PR TITLE
Clean up and add footstep demo to main menu

### DIFF
--- a/assets/meshes/plate/surface_objects.tscn
+++ b/assets/meshes/plate/surface_objects.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=22 format=3 uid="uid://54qovguk25i5"]
+[gd_scene load_steps=27 format=3 uid="uid://54qovguk25i5"]
 
 [ext_resource type="Texture2D" uid="uid://cqgdloakbawp" path="res://assets/wahooney.itch.io/white_grid.png" id="1"]
 [ext_resource type="PackedScene" uid="uid://c8jtmtuihfujs" path="res://addons/godot-xr-tools/audio/surface_audio.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://cegpwqy2053ct" path="res://assets/meshes/plate/plate.glb" id="3"]
-[ext_resource type="Material" path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" id="4"]
+[ext_resource type="Material" uid="uid://coj0ouho8vphv" path="res://assets/wahooney.itch.io/brown_grid_triplanar.tres" id="4"]
 [ext_resource type="AudioStream" uid="uid://dkladw5jiqfnb" path="res://assets/footsteps/puddle_footstep.wav" id="4_ql6qg"]
 [ext_resource type="Material" path="res://assets/wahooney.itch.io/green_grid_triplanar.tres" id="5"]
 [ext_resource type="Material" path="res://assets/wahooney.itch.io/blue_grid.tres" id="6"]
@@ -64,6 +64,29 @@ walk_pitch_maximum = 1.2
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_qcyph"]
 albedo_texture = ExtResource("1")
 
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_dvc4m"]
+shading_mode = 0
+
+[sub_resource type="TextMesh" id="TextMesh_dvc4m"]
+material = SubResource("StandardMaterial3D_dvc4m")
+text = "Puddle"
+font_size = 64
+
+[sub_resource type="TextMesh" id="TextMesh_28klg"]
+material = SubResource("StandardMaterial3D_dvc4m")
+text = "Snow"
+font_size = 64
+
+[sub_resource type="TextMesh" id="TextMesh_71bbu"]
+material = SubResource("StandardMaterial3D_dvc4m")
+text = "Mud"
+font_size = 64
+
+[sub_resource type="TextMesh" id="TextMesh_0d7bu"]
+material = SubResource("StandardMaterial3D_dvc4m")
+text = "Grass"
+font_size = 64
+
 [node name="surface_objects" type="Node3D"]
 transform = Transform3D(1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0)
 
@@ -82,7 +105,7 @@ shape = SubResource("1")
 surface_audio_type = SubResource("Resource_rpp4f")
 
 [node name="plate_mud_s" parent="." instance=ExtResource("3")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 0, -5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, -5)
 
 [node name="Plane" parent="plate_mud_s" index="0"]
 material_override = ExtResource("4")
@@ -96,7 +119,7 @@ shape = SubResource("2")
 surface_audio_type = SubResource("Resource_rwibv")
 
 [node name="plate_grass_s" parent="." instance=ExtResource("3")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, -5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 0, -5)
 
 [node name="Plane" parent="plate_grass_s" index="0"]
 material_override = ExtResource("5")
@@ -178,6 +201,22 @@ shape = SubResource("5")
 
 [node name="SurfaceAudio" parent="plate_snow/Plane/StaticBody" instance=ExtResource("2")]
 surface_audio_type = SubResource("Resource_58enk")
+
+[node name="PuddleText" type="MeshInstance3D" parent="."]
+transform = Transform3D(0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, -11, 2.5, -17)
+mesh = SubResource("TextMesh_dvc4m")
+
+[node name="SnowText" type="MeshInstance3D" parent="."]
+transform = Transform3D(0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, 0.707107, 11, 2.5, -17)
+mesh = SubResource("TextMesh_28klg")
+
+[node name="MudText" type="MeshInstance3D" parent="."]
+transform = Transform3D(-0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, -0.707107, 11, 2.5, 5)
+mesh = SubResource("TextMesh_71bbu")
+
+[node name="GrassText" type="MeshInstance3D" parent="."]
+transform = Transform3D(-0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, -0.707107, -11, 2.5, 5)
+mesh = SubResource("TextMesh_0d7bu")
 
 [editable path="plate_puddle_s"]
 [editable path="plate_mud_s"]

--- a/assets/wahooney.itch.io/brown_grid_triplanar.tres
+++ b/assets/wahooney.itch.io/brown_grid_triplanar.tres
@@ -1,8 +1,9 @@
-[gd_resource type="StandardMaterial3D" load_steps=2 format=2]
+[gd_resource type="StandardMaterial3D" load_steps=2 format=3 uid="uid://coj0ouho8vphv"]
 
-[ext_resource path="res://assets/wahooney.itch.io/brown_grid.png" type="Texture2D" id=1]
+[ext_resource type="Texture2D" uid="uid://bskwc0drdadnd" path="res://assets/wahooney.itch.io/brown_grid.png" id="1"]
 
 [resource]
-albedo_texture = ExtResource( 1 )
-uv1_scale = Vector3( 0.5, 0.5, 0.5 )
+albedo_color = Color(0.490196, 0.45098, 1, 1)
+albedo_texture = ExtResource("1")
+uv1_scale = Vector3(0.5, 0.5, 0.5)
 uv1_triplanar = true

--- a/scenes/footstep_movement_demo/footstep_movement_demo.tscn
+++ b/scenes/footstep_movement_demo/footstep_movement_demo.tscn
@@ -75,7 +75,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 7)
 title = ExtResource("10")
 
 [node name="Instructions" parent="." index="2" instance=ExtResource("3_8248t")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, -12)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, -11.99)
 
 [node name="surface_objects" parent="." index="3" instance=ExtResource("12")]
 transform = Transform3D(1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 6)

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=54 format=3 uid="uid://037lluf8eoy6"]
+[gd_scene load_steps=55 format=3 uid="uid://037lluf8eoy6"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="Script" uid="uid://dlriiyt84wd6" path="res://scenes/main_menu/main_menu_level.gd" id="2_taoax"]
@@ -40,67 +40,68 @@
 [ext_resource type="Texture2D" uid="uid://6wveqdhqbg5b" path="res://scenes/rumble_demo/rumble demo.png" id="26_sg1pa"]
 [ext_resource type="Texture2D" uid="uid://v4807nasx1dc" path="res://scenes/sprinting_demo/sprinting_demo.png" id="29_h1jn0"]
 [ext_resource type="Texture2D" uid="uid://cr1l4g7btdyht" path="res://scenes/origin_gravity_demo/origin_gravity_demo.png" id="32_c4n1q"]
+[ext_resource type="Texture2D" uid="uid://dwryn8mjdj86m" path="res://scenes/footstep_movement_demo/footstep movement demo.png" id="32_ygen5"]
 [ext_resource type="Texture2D" uid="uid://dhd30j0xpcxoi" path="res://scenes/sphere_world_demo/sphere_world_demo.png" id="34_xw8ig"]
-
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_d4clr"]
-animation = &"Grip"
 
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ygen5"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_nk0ku"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_nk0ku"]
+animation = &"Grip"
+
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_cgnj2"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_cgnj2"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_k3ty7"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_k3ty7"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_jtxsw"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_jtxsw"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_rkt36"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_d4clr")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_ygen5")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_ygen5")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_nk0ku")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_nk0ku")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_cgnj2")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_cgnj2")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_k3ty7")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_k3ty7")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_jtxsw")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
-
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rkt36"]
-animation = &"Grip"
 
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_mb0pc"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_wky3a"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_wky3a"]
+animation = &"Grip"
+
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_htmm3"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_htmm3"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_8mn04"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_8mn04"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_5r445"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_5r445"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_khn6w"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_rkt36")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_mb0pc")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_mb0pc")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_wky3a")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_wky3a")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_htmm3")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_htmm3")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_8mn04")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_8mn04")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_5r445")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -137,7 +138,7 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_jtxsw")
+tree_root = SubResource("AnimationNodeBlendTree_rkt36")
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("7_kl172")]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
@@ -172,7 +173,7 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_5r445")
+tree_root = SubResource("AnimationNodeBlendTree_khn6w")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5_xgcrx")]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
@@ -212,67 +213,72 @@ scene = "res://scenes/basic_movement_demo/basic_movement_demo.tscn"
 title = ExtResource("10")
 
 [node name="ToAudioDemo" parent="Demos" index="1" instance=ExtResource("9")]
-transform = Transform3D(0.900969, 0, 0.433884, 0, 1, 0, -0.433884, 0, 0.900969, -4.33884, 0, -9.00969)
+transform = Transform3D(0.913545, 0, 0.406737, 0, 1, 0, -0.406737, 0, 0.913545, -4.06737, 0, -9.13545)
 scene = "res://scenes/audio_demo/audio_demo.tscn"
 title = ExtResource("14_gocl4")
 
 [node name="ToTeleportDemo" parent="Demos" index="2" instance=ExtResource("9")]
-transform = Transform3D(0.62349, 0, 0.781832, 0, 1, 0, -0.781832, 0, 0.62349, -7.81832, 0, -6.2349)
+transform = Transform3D(0.669131, 0, 0.743145, 0, 1, 0, -0.743145, 0, 0.669131, -7.43145, 0, -6.69131)
 scene = "res://scenes/teleport_demo/teleport_demo.tscn"
 title = ExtResource("12")
 
 [node name="ToWorldGrabDemo" parent="Demos" index="3" instance=ExtResource("9")]
-transform = Transform3D(0.222521, 0, 0.974928, 0, 1, 0, -0.974928, 0, 0.222521, -9.74928, 0, -2.22521)
+transform = Transform3D(0.309017, 0, 0.951057, 0, 1, 0, -0.951057, 0, 0.309017, -9.51057, 0, -3.09017)
 scene = "res://scenes/world_grab_demo/world_grab_demo.tscn"
 title = ExtResource("19_atnye")
 
 [node name="ToClimbingGlidingDemo" parent="Demos" index="4" instance=ExtResource("9")]
-transform = Transform3D(-0.222521, 0, 0.974928, 0, 1, 0, -0.974928, 0, -0.222521, -9.74928, 0, 2.22521)
+transform = Transform3D(-0.104529, 0, 0.994522, 0, 1, 0, -0.994522, 0, -0.104529, -9.94522, 0, 1.04529)
 scene = "res://scenes/climbing_gliding_demo/climbing_gliding_demo.tscn"
 title = ExtResource("13")
 
-[node name="ToGrapplingDemo" parent="Demos" index="5" instance=ExtResource("9")]
-transform = Transform3D(-0.62349, 0, 0.781832, 0, 1, 0, -0.781832, 0, -0.62349, -7.81832, 0, 6.2349)
+[node name="ToFootstepMovementDemo" parent="Demos" index="5" instance=ExtResource("9")]
+transform = Transform3D(-0.5, 0, 0.866025, 0, 1, 0, -0.866025, 0, -0.5, -8.66025, 0, 5)
+scene = "uid://dt5jsm43uk88b"
+title = ExtResource("32_ygen5")
+
+[node name="ToGrapplingDemo" parent="Demos" index="6" instance=ExtResource("9")]
+transform = Transform3D(-0.809017, 0, 0.587785, 0, 1, 0, -0.587785, 0, -0.809017, -5.87785, 0, 8.09017)
 scene = "res://scenes/grappling_demo/grappling_demo.tscn"
 title = ExtResource("16")
 
-[node name="ToInteractablesDemo" parent="Demos" index="6" instance=ExtResource("9")]
-transform = Transform3D(-0.900969, 0, 0.433884, 0, 1, 0, -0.433884, 0, -0.900969, -4.33884, 0, 9.00969)
+[node name="ToInteractablesDemo" parent="Demos" index="7" instance=ExtResource("9")]
+transform = Transform3D(-0.978148, 0, 0.207912, 0, 1, 0, -0.207912, 0, -0.978148, -2.07912, 0, 9.78148)
 scene = "res://scenes/interactables_demo/interactables_demo.tscn"
 title = ExtResource("17")
 
-[node name="ToPointerDemo" parent="Demos" index="7" instance=ExtResource("9")]
-transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 8.74228e-07, 0, 10)
+[node name="ToPointerDemo" parent="Demos" index="8" instance=ExtResource("9")]
+transform = Transform3D(-0.978148, 0, -0.207912, 0, 1, 0, 0.207912, 0, -0.978148, 2.07912, 0, 9.78148)
 scene = "res://scenes/pointer_demo/pointer_demo.tscn"
 title = ExtResource("20")
 
-[node name="ToPickableDemo" parent="Demos" index="8" instance=ExtResource("9")]
-transform = Transform3D(-0.900969, 0, -0.433884, 0, 1, 0, 0.433884, 0, -0.900969, 4.33884, 0, 9.00969)
+[node name="ToPickableDemo" parent="Demos" index="9" instance=ExtResource("9")]
+transform = Transform3D(-0.809017, 0, -0.587785, 0, 1, 0, 0.587785, 0, -0.809017, 5.87785, 0, 8.09017)
 scene = "res://scenes/pickable_demo/pickable_demo.tscn"
 title = ExtResource("22")
 
-[node name="ToPokeDemo" parent="Demos" index="9" instance=ExtResource("9")]
-transform = Transform3D(-0.62349, 0, -0.781832, 0, 1, 0, 0.781832, 0, -0.62349, 7.81832, 0, 6.2349)
+[node name="ToPokeDemo" parent="Demos" index="10" instance=ExtResource("9")]
+transform = Transform3D(-0.5, 0, -0.866025, 0, 1, 0, 0.866025, 0, -0.5, 8.66025, 0, 5)
 scene = "res://scenes/poke_demo/poke_demo.tscn"
 title = ExtResource("25_rg3rn")
 
-[node name="ToRumbleDemo" parent="Demos" index="10" instance=ExtResource("9")]
-transform = Transform3D(-0.222521, 0, -0.974928, 0, 1, 0, 0.974928, 0, -0.222521, 9.74928, 0, 2.22521)
+[node name="ToRumbleDemo" parent="Demos" index="11" instance=ExtResource("9")]
+transform = Transform3D(-0.104528, 0, -0.994522, 0, 1, 0, 0.994522, 0, -0.104528, 9.94522, 0, 1.04528)
 scene = "res://scenes/rumble_demo/rumble_demo.tscn"
 title = ExtResource("26_sg1pa")
 
-[node name="ToSprintDemo" parent="Demos" index="11" instance=ExtResource("9")]
-transform = Transform3D(0.222521, 0, -0.974928, 0, 1, 0, 0.974928, 0, 0.222521, 9.74928, 0, -2.22521)
+[node name="ToSprintDemo" parent="Demos" index="12" instance=ExtResource("9")]
+transform = Transform3D(0.309017, 0, -0.951056, 0, 1, 0, 0.951056, 0, 0.309017, 9.51056, 0, -3.09017)
 scene = "res://scenes/sprinting_demo/sprinting_demo.tscn"
 title = ExtResource("29_h1jn0")
 
-[node name="ToOriginGravityDemo" parent="Demos" index="12" instance=ExtResource("9")]
-transform = Transform3D(0.62349, 0, -0.781832, 0, 1, 0, 0.781832, 0, 0.62349, 7.81832, 0, -6.2349)
+[node name="ToOriginGravityDemo" parent="Demos" index="13" instance=ExtResource("9")]
+transform = Transform3D(0.669131, 0, -0.743145, 0, 1, 0, 0.743145, 0, 0.669131, 7.43145, 0, -6.69131)
 scene = "res://scenes/origin_gravity_demo/origin_gravity_demo.tscn"
 title = ExtResource("32_c4n1q")
 
-[node name="ToSphereWorldDemo" parent="Demos" index="13" instance=ExtResource("9")]
-transform = Transform3D(0.900969, 0, -0.433884, 0, 1, 0, 0.433884, 0, 0.900969, 4.33884, 0, -9.00969)
+[node name="ToSphereWorldDemo" parent="Demos" index="14" instance=ExtResource("9")]
+transform = Transform3D(0.913546, 0, -0.406736, 0, 1, 0, 0.406736, 0, 0.913546, 4.06736, 0, -9.13546)
 scene = "res://scenes/sphere_world_demo/sphere_world_demo.tscn"
 title = ExtResource("34_xw8ig")
 


### PR DESCRIPTION
This PR does the following:
- Adds a portal to the main menu that leads to the footstep movement demo
- Swapped two of the small tiles around to be closer to their bigger counterparts
- Added text atop the big tiles that describes what the surfaces are supposed to be
- Changed the mud tile to be more brown
- Moved the instructions closer to the centre to fix the flickering issue
# Testing
The **Footstep Movement** demo had no issues not present in `master`. However, the texture used for the portal was used as is, and does not match the other portal textures. Should we change it to be more in line?
# Disclaimer
No generative AI was used to enhance or create the code given here.