### PR TITLE
Better format and static type Glide

### DIFF
--- a/addons/godot-xr-tools/functions/movement_glide.gd
+++ b/addons/godot-xr-tools/functions/movement_glide.gd
@@ -2,82 +2,87 @@
 class_name XRToolsMovementGlide
 extends XRToolsMovementProvider
 
-
 ## XR Tools Movement Provider for Gliding
 ##
 ## This script provides glide mechanics for the player. This script works
-## with the [XRToolsPlayerBody] attached to the players [XROrigin3D].
+## with the [XRToolsPlayerBody] attached to the player's [XROrigin3D].
 ##
 ## The player enables flying by moving the controllers apart further than
-## 'glide_detect_distance'.
+## [member glide_detect_distance].
 ##
-## When gliding, the players fall speed will slew to 'glide_fall_speed' and
-## the velocity will slew to 'glide_forward_speed' in the direction the
-## player is facing.
+## When gliding, the player's fall speed will slew to [member glide_fall_speed]
+## and the velocity will slew to [member glide_forward_speed] in the direction
+## the player is facing.
 ##
 ## Gliding is an exclusive motion operation, and so gliding should be ordered
-## after any Direct movement providers responsible for turning.
+## after any movement providers responsible for turning.
 
 
-## Signal invoked when the player starts gliding
+## Emitted when the player starts gliding
 signal player_glide_start
 
-## Signal invoked when the player ends gliding
+## Emitted when the player ends gliding
 signal player_glide_end
 
-## Signal invoked when the player flaps
+## Emitted when the player flaps
 signal player_flapped
 
-## Movement provider order
-@export var order : int = 35
+## Order in which movement is processed
+@export var order: int = 35
 
-## Controller separation distance to register as glide
-@export var glide_detect_distance : float = 1.0
+## How far apart controllers should be to register as gliding
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var glide_detect_distance := 1.0
 
 ## Minimum falling speed to be considered gliding
-@export var glide_min_fall_speed : float = -1.5
+@export_custom(PROPERTY_HINT_NONE, "suffix:m/s") var glide_min_fall_speed := -1.5
 
 ## Glide falling speed
-@export var glide_fall_speed : float = -2.0
+@export_custom(PROPERTY_HINT_NONE, "suffix:m/s") var glide_fall_speed := -2.0
 
 ## Glide forward speed
-@export var glide_forward_speed : float = 12.0
+@export_custom(PROPERTY_HINT_NONE, "suffix:m/s") var glide_forward_speed := 12.0
 
 ## Slew rate to transition to gliding
-@export var horizontal_slew_rate : float = 1.0
+@export var horizontal_slew_rate := 1.0
 
 ## Slew rate to transition to gliding
-@export var vertical_slew_rate : float = 2.0
+@export var vertical_slew_rate := 2.0
 
-## glide rotate with roll angle
-@export var turn_with_roll : bool = false
+@export_group("Turning")
 
-## Smooth turn speed in radians per second
-@export var roll_turn_speed : float = 1
+## Whether to turn if the player banks their arms
+@export var turn_with_roll := false
 
-## Add vertical impulse by flapping controllers
-@export var wings_impulse : bool = false
+## Smooth turn speed in radians per second for bank turns
+@export_range(0, 2 * PI, 0.1, "or_greater", "suffix:rad/s") var roll_turn_speed := 1.0
 
-## Minimum velocity for flapping
-@export var flap_min_speed : float = 0.3
+@export_group("Flapping")
+
+## Whether to add vertical impulse by flapping controllers
+@export var wings_impulse := false
+
+## Minimum velocity for arms to register as flapping
+@export_custom(PROPERTY_HINT_NONE, "suffix:m/s") var flap_min_speed := 0.3
 
 ## Flapping force multiplier
-@export var wings_force : float = 1.0
+@export var wings_force := 1.0
 
 ## Minimum distance from controllers to ARVRCamera to rearm flaps.
-## if set to 0, you need to reach head level with hands to rearm flaps
-@export var rearm_distance_offset : float = 0.2
+## If set to 0, you need to reach head level with hands to rearm flaps
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var rearm_distance_offset := 0.2
 
 
-## Flap activated (when both controllers are near the ARVRCamera height)
-var flap_armed : bool = false
+## Whether the flap is activated (when both controllers are near the ARVRCamera height)
+var flap_armed := false
 
-## Last controllers position to calculate flapping velocity
-var last_local_left_position : Vector3
-var last_local_right_position : Vector3
+## Last left controller's position to calculate flapping velocity
+var last_local_left_position: Vector3
 
-# True if the controller positions are valid
-var _has_controller_positions : bool = false
+## Last right controller's position to calculate flapping velocity
+var last_local_right_position: Vector3
+
+# Whether the controller positions are valid
+var _has_controller_positions := false
 
 
 # Left controller
@@ -90,23 +95,55 @@ var _has_controller_positions : bool = false
 @onready var _camera_node := XRHelpers.get_xr_camera(self)
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
+# Verifies the movement provider has a valid configuration.
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := super()
+
+	# Verify the left controller
+	if not XRHelpers.get_left_controller(self):
+		warnings.append("Unable to find left XRController3D node")
+
+	# Verify the right controller
+	if not XRHelpers.get_right_controller(self):
+		warnings.append("Unable to find right XRController3D node")
+
+	# Check glide parameters
+	if glide_min_fall_speed > 0:
+		warnings.append("Glide minimum fall speed must be zero or less")
+	if glide_fall_speed > 0:
+		warnings.append("Glide fall speed must be zero or less")
+	if glide_min_fall_speed < glide_fall_speed:
+		warnings.append("Glide fall speed must be faster than minimum fall speed")
+
+	# Return warnings
+	return warnings
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
 	return xr_name == "XRToolsMovementGlide" or super(xr_name)
 
 
-func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bool):
+## Performs gliding movement
+func physics_movement(
+		delta: float,
+		player_body: XRToolsPlayerBody,
+		disabled: bool,
+) -> bool:
 	# Skip if disabled or either controller is off
-	if disabled or !enabled or \
-		!_left_controller.get_is_active() or \
-		!_right_controller.get_is_active():
+	if (
+			disabled
+			or not enabled
+			or not _left_controller.get_is_active()
+			or not _right_controller.get_is_active()
+	):
 		_set_gliding(false)
-		return
+		return false
 
 	# If on the ground, then not gliding
 	if player_body.on_ground:
 		_set_gliding(false)
-		return
+		return false
 
 	# Get the controller left and right global horizontal positions
 	var left_position := _left_controller.global_transform.origin
@@ -119,8 +156,8 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	if wings_impulse:
 		# Check controllers position relative to head
 		var cam_local_y := _camera_node.position.y
-		var left_hand_over_head = cam_local_y < _left_controller.position.y + rearm_distance_offset
-		var right_hand_over_head = cam_local_y < _right_controller.position.y + rearm_distance_offset
+		var left_hand_over_head := cam_local_y < _left_controller.position.y + rearm_distance_offset
+		var right_hand_over_head := cam_local_y < _right_controller.position.y + rearm_distance_offset
 		if left_hand_over_head && right_hand_over_head:
 			flap_armed = true
 
@@ -136,8 +173,8 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 				last_local_right_position = local_right_position
 
 			# Calculate controllers velocity only when flapping downwards
-			var left_wing_velocity = 0.0
-			var right_wing_velocity = 0.0
+			var left_wing_velocity := 0.0
+			var right_wing_velocity := 0.0
 			if local_left_position.y < last_local_left_position.y:
 				left_wing_velocity = local_left_position.distance_to(last_local_left_position) / delta
 			if local_right_position.y < last_local_right_position.y:
@@ -147,7 +184,7 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 			if left_wing_velocity > flap_min_speed && right_wing_velocity > flap_min_speed:
 				wings_impulse_velocity = (left_wing_velocity + right_wing_velocity) / 2
 				wings_impulse_velocity = wings_impulse_velocity * wings_force * delta * 50
-				emit_signal("player_flapped")
+				player_flapped.emit()
 				flap_armed = false
 
 			# Store controller position for next frame
@@ -158,7 +195,7 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	var left_to_right := right_position - left_position
 
 	if turn_with_roll:
-		var angle = -left_to_right.dot(player_body.up_player)
+		var angle: float = -left_to_right.dot(player_body.up_player)
 		player_body.rotate_player(roll_turn_speed * delta * angle)
 
 	# If not falling, then not gliding
@@ -166,18 +203,22 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	vertical_velocity += wings_impulse_velocity
 	if vertical_velocity >= glide_min_fall_speed && wings_impulse_velocity == 0.0:
 		_set_gliding(false)
-		return
+		return false
 
 	# Set gliding based on hand separation
 	var separation := left_to_right.length() / XRServer.world_scale
 	_set_gliding(separation >= glide_detect_distance)
 
 	# Skip if not gliding
-	if !is_active:
-		return
+	if not is_active:
+		return false
 
 	# Lerp the vertical velocity to glide_fall_speed
-	vertical_velocity = lerp(vertical_velocity, glide_fall_speed, vertical_slew_rate * delta)
+	vertical_velocity = lerpf(
+			vertical_velocity,
+			glide_fall_speed,
+			vertical_slew_rate * delta,
+	)
 
 	# Lerp the horizontal velocity towards forward_speed
 	var horizontal_velocity := player_body.velocity.slide(player_body.up_gravity)
@@ -186,7 +227,10 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 			.slide(player_body.up_gravity) \
 			.normalized()
 	var forward_velocity := dir_forward * glide_forward_speed
-	horizontal_velocity = horizontal_velocity.lerp(forward_velocity, horizontal_slew_rate * delta)
+	horizontal_velocity = horizontal_velocity.lerp(
+			forward_velocity,
+			horizontal_slew_rate * delta,
+	)
 
 	# Perform the glide
 	var glide_velocity := horizontal_velocity + vertical_velocity * player_body.up_gravity
@@ -196,7 +240,7 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	return true
 
 
-# Set the gliding state and fire any signals
+# Sets the gliding state and fire any signals
 func _set_gliding(active: bool) -> void:
 	# Skip if no change
 	if active == is_active:
@@ -207,30 +251,6 @@ func _set_gliding(active: bool) -> void:
 
 	# Report transition
 	if is_active:
-		emit_signal("player_glide_start")
+		player_glide_start.emit()
 	else:
-		emit_signal("player_glide_end")
-
-
-# This method verifies the movement provider has a valid configuration.
-func _get_configuration_warnings() -> PackedStringArray:
-	var warnings := super()
-
-	# Verify the left controller
-	if !XRHelpers.get_left_controller(self):
-		warnings.append("Unable to find left XRController3D node")
-
-	# Verify the right controller
-	if !XRHelpers.get_right_controller(self):
-		warnings.append("Unable to find right XRController3D node")
-
-	# Check glide parameters
-	if glide_min_fall_speed > 0:
-		warnings.append("Glide minimum fall speed must be zero or less")
-	if glide_fall_speed > 0:
-		warnings.append("Glide fall speed must be zero or less")
-	if glide_min_fall_speed < glide_fall_speed:
-		warnings.append("Glide fall speed must be faster than minimum fall speed")
-
-	# Return warnings
-	return warnings
+		player_glide_end.emit()


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add BBCode to the class documentation
- Add return type to the function `physics_movement()`
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Add two export groups
- Replace exclamation marks with `not` keyword
- Add suffixes to exported properties where appropriate
# Note
If we ever push the minimum version for XR Tools to 4.6+, we could use `PROPERTY_HINT_GROUP_ENABLE` for the export groups.
# Testing
The **Climbing & Gliding** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.