### PR TITLE
Better format and static type Jump

### DIFF
--- a/addons/godot-xr-tools/functions/movement_jump.gd
+++ b/addons/godot-xr-tools/functions/movement_jump.gd
@@ -2,55 +2,38 @@
 class_name XRToolsMovementJump
 extends XRToolsMovementProvider
 
-
 ## XR Tools Movement Provider for Jumping
 ##
 ## This script provides jumping mechanics for the player. This script works
-## with the [XRToolsPlayerBody] attached to the players [XROrigin3D].
+## with the [XRToolsPlayerBody] attached to the player's [XROrigin3D].
 ##
 ## The player enables jumping by attaching an [XRToolsMovementJump] as a
 ## child of the appropriate [XRController3D], then configuring the jump button
 ## and jump velocity.
 
 
-## Movement provider order
-@export var order : int = 20
+## Order which movement is processed
+@export var order: int = 20
 
-## Button to trigger jump
-@export var jump_button_action : String = "trigger_click"
-
-
-# Node references
-var _controller : XRController3D
+## Input action to trigger jump
+@export var jump_button_action := "trigger_click"
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsMovementJump" or super(xr_name)
+# The player's [XRController3D]
+var _controller: XRController3D
 
 
-# Called when our node is added to our scene tree
-func _enter_tree():
+# When our node is added to our scene tree
+func _enter_tree() -> void:
 	_controller = XRHelpers.get_xr_controller(self)
 
 
-# Called when our node is removed from our scene tree
-func _exit_tree():
+# When our node is removed from our scene tree
+func _exit_tree() -> void:
 	_controller = null
 
 
-# Perform jump movement
-func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
-	# Skip if the jump controller isn't active
-	if not _controller or not _controller.get_is_active():
-		return
-
-	# Request jump if the button is pressed
-	if _controller.is_button_pressed(jump_button_action):
-		player_body.request_jump()
-
-
-# This method verifies the movement provider has a valid configuration.
+# Verifies the movement provider has a valid configuration.
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := super()
 
@@ -60,3 +43,25 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 	# Return warnings
 	return warnings
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsMovementJump" or super(xr_name)
+
+
+## Performs jump movement
+func physics_movement(
+		_delta: float,
+		player_body: XRToolsPlayerBody,
+		_disabled: bool,
+) -> bool:
+	# Skip if the jump controller isn't active
+	if not _controller or not _controller.get_is_active():
+		return false
+
+	# Request jump if the button is pressed
+	if _controller.is_button_pressed(jump_button_action):
+		player_body.request_jump()
+
+	return false


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to one function
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
# Testing
The **Basic Movement** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.