### PR TITLE
Better format and static type Physical Jump

### DIFF
--- a/addons/godot-xr-tools/functions/movement_physical_jump.gd
+++ b/addons/godot-xr-tools/functions/movement_physical_jump.gd
@@ -2,51 +2,54 @@
 class_name XRToolsMovementPhysicalJump
 extends XRToolsMovementProvider
 
-
 ## XR Tools Movement Provider for Player Physical Jump Detection
 ##
-## This script can detect jumping based on either the players body jumping,
+## This script can detect jumping based on either the player's body jumping,
 ## or by the player swinging their arms up.
 ##
-## The player body jumping is detected by putting the cameras instantaneous
-## Y velocity (in the tracking space) into a sliding-window averager. If the
-## average Y velocity exceeds a threshold parameter then the player has
+## The player body jumping is detected by putting the camera's instantaneous
+## Y-velocity (in the tracking space) into a sliding-window averager. If the
+## average Y-velocity exceeds a threshold parameter then the player has
 ## jumped.
 ##
-## The player arms jumping is detected by putting both controllers instantaneous
-## Y velocity (in the tracking space) into a sliding-window averager. If both
-## average Y velocities exceed a threshold parameter then the player has
+## The player's arms jumping is detected by putting both controllers instantaneous
+## Y-velocity (in the tracking space) into a sliding-window averager. If both
+## average Y-velocities exceed a threshold parameter, then the player has
 ## jumped.
 
 
-## Movement provider order
-@export var order : int = 20
+## Order in which movement is processed
+@export var order: int = 20
 
-## If true, jumps are detected via the players body (through the camera)
-@export var body_jump_enable : bool = true
+@export_group("Body Jump")
 
-## If true, the player jump is as high as the physical jump(no ground physics)
-@export var body_jump_player_only : bool = false
+## Whether jumps are detected via the player's body (through the camera)
+@export var body_jump_enable := true
 
-## Body jump detection threshold (M/S^2)
-@export var body_jump_threshold : float = 2.5
+## Whether the player's jump is as high as the physical jump (no ground physics)
+@export var body_jump_player_only := false
 
-## If true, jumps are detected via the players arms (through the controllers)
-@export var arms_jump_enable : bool = false
+## Body jump detection threshold (m/s^2)
+@export_custom(PROPERTY_HINT_NONE, "suffix:m/s^2") var body_jump_threshold := 2.5
 
-## Arms jump detection threshold (M/S^2)
-@export var arms_jump_threshold : float = 5.0
+@export_group("Arms Jump")
+
+## Whether jumps are detected via the player's arms (through the controllers)
+@export var arms_jump_enable := false
+
+## Arms' jump detection threshold (M/S^2)
+@export_custom(PROPERTY_HINT_NONE, "suffix:m/s^2") var arms_jump_threshold := 5.0
 
 
 # Node Positions
-var _camera_position : float = 0.0
-var _controller_left_position : float = 0.0
-var _controller_right_position : float = 0.0
+var _camera_position := 0.0
+var _controller_left_position := 0.0
+var _controller_right_position := 0.0
 
 # Node Velocities
-var _camera_velocity : SlidingAverage = SlidingAverage.new(5)
-var _controller_left_velocity : SlidingAverage = SlidingAverage.new(5)
-var _controller_right_velocity : SlidingAverage = SlidingAverage.new(5)
+var _camera_velocity := SlidingAverage.new(5)
+var _controller_left_velocity := SlidingAverage.new(5)
+var _controller_right_velocity := SlidingAverage.new(5)
 
 
 # Node references
@@ -56,48 +59,41 @@ var _controller_right_velocity : SlidingAverage = SlidingAverage.new(5)
 @onready var _controller_right_node := XRHelpers.get_right_controller(self)
 
 
-# Sliding Average class
-class SlidingAverage:
-	# Sliding window size
-	var _size: int
+# Verifies the movement provider has a valid configuration.
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := super()
 
-	# Sum of items in the window
-	var _sum := 0.0
+	# Verify the camera
+	if not XRHelpers.get_xr_origin(self):
+		warnings.append("This node must be within a branch of an XROrigin3D node")
 
-	# Position
-	var _pos := 0
+	# Verify the camera
+	if not XRHelpers.get_xr_camera(self):
+		warnings.append("Unable to find XRCamera3D")
 
-	# Data window
-	var _data := Array()
+	# Verify the left controller
+	if not XRHelpers.get_left_controller(self):
+		warnings.append("Unable to find left XRController3D node")
 
-	# Constructor
-	func _init(size: int):
-		# Set the size and fill the array
-		_size = size
-		for i in size:
-			_data.push_back(0.0)
+	# Verify the right controller
+	if not XRHelpers.get_right_controller(self):
+		warnings.append("Unable to find left XRController3D node")
 
-	# Update the average
-	func update(entry: float) -> float:
-		# Add the new entry and subtract the old
-		_sum += entry
-		_sum -= _data[_pos]
-
-		# Store the new entry in the array and circularly advance the index
-		_data[_pos] = entry
-		_pos = (_pos + 1) % _size
-
-		# Return the average
-		return _sum / _size
+	# Return warnings
+	return warnings
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
 	return xr_name == "XRToolsMovementPhysicalJump" or super(xr_name)
 
 
-# Perform jump detection
-func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
+## Performs jump detection
+func physics_movement(
+		delta: float,
+		player_body: XRToolsPlayerBody,
+		_disabled: bool,
+) -> bool:
 	# Handle detecting body jump
 	if body_jump_enable:
 		_detect_body_jump(delta, player_body)
@@ -106,32 +102,10 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: b
 	if arms_jump_enable:
 		_detect_arms_jump(delta, player_body)
 
-
-# This method verifies the movement provider has a valid configuration.
-func _get_configuration_warnings() -> PackedStringArray:
-	var warnings := super()
-
-	# Verify the camera
-	if !XRHelpers.get_xr_origin(self):
-		warnings.append("This node must be within a branch of an XROrigin3D node")
-
-	# Verify the camera
-	if !XRHelpers.get_xr_camera(self):
-		warnings.append("Unable to find XRCamera3D")
-
-	# Verify the left controller
-	if !XRHelpers.get_left_controller(self):
-		warnings.append("Unable to find left XRController3D node")
-
-	# Verify the right controller
-	if !XRHelpers.get_right_controller(self):
-		warnings.append("Unable to find left XRController3D node")
-
-	# Return warnings
-	return warnings
+	return false
 
 
-# Detect the player jumping with their body (using the headset camera)
+# Detects the player jumping with their body (using the headset camera)
 func _detect_body_jump(delta: float, player_body: XRToolsPlayerBody) -> void:
 	# Get the camera instantaneous velocity
 	var new_camera_pos := _camera_node.transform.origin.y
@@ -146,7 +120,11 @@ func _detect_body_jump(delta: float, player_body: XRToolsPlayerBody) -> void:
 	camera_vel /= XRServer.world_scale
 
 	# Clamp the camera instantaneous velocity to +/- 2x the jump threshold
-	camera_vel = clamp(camera_vel, -2.0 * body_jump_threshold, 2.0 * body_jump_threshold)
+	camera_vel = clampf(
+			camera_vel,
+			-2.0 * body_jump_threshold,
+			2.0 * body_jump_threshold
+	)
 
 	# Get the averaged velocity
 	camera_vel = _camera_velocity.update(camera_vel)
@@ -156,17 +134,26 @@ func _detect_body_jump(delta: float, player_body: XRToolsPlayerBody) -> void:
 		player_body.request_jump(body_jump_player_only)
 
 
-# Detect the player jumping with their arms (using the controllers)
+# Detects the player jumping with their arms (using the controllers)
 func _detect_arms_jump(delta: float, player_body: XRToolsPlayerBody) -> void:
 	# Skip if either of the controllers is disabled
-	if !_controller_left_node.get_is_active() or !_controller_right_node.get_is_active():
+	if (
+			not _controller_left_node.get_is_active()
+			or not _controller_right_node.get_is_active()
+	):
 		return
 
 	# Get the controllers instantaneous velocity
 	var new_controller_left_pos := _controller_left_node.transform.origin.y
 	var new_controller_right_pos := _controller_right_node.transform.origin.y
-	var controller_left_vel := (new_controller_left_pos - _controller_left_position) / delta
-	var controller_right_vel := (new_controller_right_pos - _controller_right_position) / delta
+
+	var controller_left_vel := (
+			new_controller_left_pos - _controller_left_position
+	) / delta
+	var controller_right_vel := (
+			new_controller_right_pos - _controller_right_position
+	) / delta
+
 	_controller_left_position = new_controller_left_pos
 	_controller_right_position = new_controller_right_pos
 
@@ -182,16 +169,58 @@ func _detect_arms_jump(delta: float, player_body: XRToolsPlayerBody) -> void:
 	controller_left_vel = clamp(
 			controller_left_vel,
 			-2.0 * arms_jump_threshold,
-			2.0 * arms_jump_threshold)
+			2.0 * arms_jump_threshold,
+	)
 	controller_right_vel = clamp(
 			controller_right_vel,
 			-2.0 * arms_jump_threshold,
-			2.0 * arms_jump_threshold)
+			2.0 * arms_jump_threshold,
+	)
 
 	# Get the averaged velocity
 	controller_left_vel = _controller_left_velocity.update(controller_left_vel)
 	controller_right_vel = _controller_right_velocity.update(controller_right_vel)
 
 	# Detect a jump
-	if controller_left_vel >= arms_jump_threshold and controller_right_vel >= arms_jump_threshold:
+	if (
+			controller_left_vel >= arms_jump_threshold
+			and controller_right_vel >= arms_jump_threshold
+	):
 		player_body.request_jump()
+
+
+# Sliding Average class
+class SlidingAverage:
+	# Sliding window size
+	var _size: int
+
+	# Sum of items in the window
+	var _sum := 0.0
+
+	# Position
+	var _pos: int = 0
+
+	# Data window
+	var _data := Array()
+
+
+	# Constructor
+	func _init(size: int) -> void:
+		# Set the size and fill the array
+		_size = size
+		for i: int in size:
+			_data.push_back(0.0)
+
+
+	# Update the average
+	func update(entry: float) -> float:
+		# Add the new entry and subtract the old
+		_sum += entry
+		_sum -= _data[_pos]
+
+		# Store the new entry in the array and circularly advance the index
+		_data[_pos] = entry
+		_pos = (_pos + 1) % _size
+
+		# Return the average
+		return _sum / _size


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to one function
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Add suffixes to two exported variables
- Add more punctuation to class doc 
- Replace exclamation marks with `not` keyword
# Testing
After adding the `MovementPhysicalJump` as a child scene, the **Basic Movement** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.