### PR TITLE
Better format and static type Sprint

### DIFF
--- a/addons/godot-xr-tools/functions/movement_sprint.gd
+++ b/addons/godot-xr-tools/functions/movement_sprint.gd
@@ -2,21 +2,20 @@
 class_name XRToolsMovementSprint
 extends XRToolsMovementProvider
 
-
 ## XR Tools Movement Provider for Sprinting
 ##
 ## This script provides sprinting movement for the player. It assumes there is
-## a direct movement node in the scene otherwise it will not be functional.
+## a direct movement node in the scene, otherwise it will not be functional.
 ##
-## There will not be an error, there just will not be any reason for it to
-## have any impact on the player.  This node should be a direct child of
-## the [XROrigin3D] node rather than to a specific [XRController3D].
+## There will not be an error, but there will not be any reason for it to
+## have any impact on the player. This node should be a direct child of
+## the [XROrigin3D] node, rather than a specific [XRController3D].
 
 
-## Signal emitted when sprinting starts
+## Emitted when sprinting starts
 signal sprinting_started()
 
-## Signal emitted when sprinting finishes
+## Emitted when sprinting finishes
 signal sprinting_finished()
 
 
@@ -35,48 +34,42 @@ enum SprintType {
 
 
 ## Type of sprinting
-@export var sprint_type : SprintType = SprintType.HOLD_TO_SPRINT
+@export var sprint_type := SprintType.HOLD_TO_SPRINT
 
-## Sprint speed multiplier (multiplier from speed set by direct movement node(s))
-@export_range(1.0, 4.0) var sprint_speed_multiplier : float = 2.0
+## Sprint multiplier of speed set by direct movement node(s)
+@export_range(1.0, 4.0, 1.0, "or_less", "or_greater") var sprint_speed_multiplier := 2.0
 
-## Movement provider order
-@export var order : int = 11
+## Order in which movement is processed
+@export var order: int = 11
 
-## Sprint controller
-@export var controller : SprintController = SprintController.LEFT
+## Controller can activate sprinting
+@export var controller := SprintController.LEFT
 
-## Sprint button
-@export var sprint_button : String = "primary_click"
+## Input action that activates sprinting
+@export var sprint_button := "primary_click"
 
 
 # Sprint controller
-var _controller : XRController3D
+var _controller: XRController3D
 
 # Sprint button down state
-var _sprint_button_down : bool = false
+var _sprint_button_down := false
 
-# Variable to hold left controller direct movement node original max speed
-var _left_controller_original_max_speed : float = 0.0
+# Holds left controller's direct movement node's original max speed
+var _left_controller_original_max_speed := 0.0
 
-# Variable to hold right controller direct movement node original max speed
-var _right_controller_original_max_speed : float = 0.0
+# Holds right controller's direct movement node's original max speed
+var _right_controller_original_max_speed := 0.0
 
 
-# Variable used to cache left controller direct movement function, if any
+# Caches left controller's direct movement function, if any
 @onready var _left_controller_direct_move := XRToolsMovementDirect.find_left(self)
 
-# Variable used to cache right controller direct movement function, if any
+# Caches right controller's direct movement function, if any
 @onready var _right_controller_direct_move := XRToolsMovementDirect.find_right(self)
 
 
-
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsMovementSprint" or super(xr_name)
-
-
-func _ready():
+func _ready() -> void:
 	# In Godot 4 we must now manually call our super class ready function
 	super()
 
@@ -87,36 +80,65 @@ func _ready():
 		_controller = XRHelpers.get_right_controller(self)
 
 
-# Perform sprinting
-func physics_movement(_delta: float, _player_body: XRToolsPlayerBody, disabled: bool):
+# Verifies the movement provider has a valid configuration.
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := super()
+
+	# Make sure player has at least one direct movement node
+	if (
+			not XRToolsMovementDirect.find_left(self)
+			and not XRToolsMovementDirect.find_right(self)
+	):
+		warnings.append("Player missing XRToolsMovementDirect nodes")
+
+	# Return warnings
+	return warnings
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsMovementSprint" or super(xr_name)
+
+
+## Performs sprinting
+func physics_movement(
+		_delta: float,
+		_player_body: XRToolsPlayerBody,
+		disabled: bool,
+) -> bool:
 	# Skip if the controller isn't active or is not enabled
-	if !_controller.get_is_active() or disabled == true or !enabled:
+	if not _controller.get_is_active() or disabled == true or not enabled:
 		set_sprinting(false)
-		return
+		return false
 
 	# Detect sprint button down and pressed states
-	var sprint_button_down := _controller.is_button_pressed(sprint_button)
-	var sprint_button_pressed := sprint_button_down and !_sprint_button_down
-	_sprint_button_down = sprint_button_down
+	var is_sprint_button_down := _controller.is_button_pressed(sprint_button)
+	var sprint_button_pressed := (
+			is_sprint_button_down
+			and not _sprint_button_down
+	)
+	_sprint_button_down = is_sprint_button_down
 
 	# Calculate new sprinting state
 	var sprinting := is_active
 	match sprint_type:
 		SprintType.HOLD_TO_SPRINT:
 			# Sprint when button down
-			sprinting = sprint_button_down
+			sprinting = is_sprint_button_down
 
 		SprintType.TOGGLE_SPRINT:
 			# Toggle when button pressed
 			if sprint_button_pressed:
-				sprinting = !sprinting
+				sprinting = not sprinting
 
 	# Update sprinting state
 	if sprinting != is_active:
 		set_sprinting(sprinting)
 
+	return false
 
-# Public function used to set sprinting active or not active
+
+# Toggles sprinting
 func set_sprinting(active: bool) -> void:
 	# Skip if no change
 	if active == is_active:
@@ -128,7 +150,7 @@ func set_sprinting(active: bool) -> void:
 	# Handle state change
 	if is_active:
 		# We are sprinting
-		emit_signal("sprinting_started")
+		sprinting_started.emit()
 
 		# Since max speeds could be changed while game is running, check
 		# now for original max speeds of left and right nodes
@@ -147,7 +169,7 @@ func set_sprinting(active: bool) -> void:
 					_right_controller_original_max_speed * sprint_speed_multiplier
 	else:
 		# We are not sprinting
-		emit_signal("sprinting_finished")
+		sprinting_finished.emit()
 
 		# Set both controllers' direct movement functions, if applicable, to
 		# their original speeds
@@ -155,15 +177,3 @@ func set_sprinting(active: bool) -> void:
 			_left_controller_direct_move.max_speed = _left_controller_original_max_speed
 		if _right_controller_direct_move:
 			_right_controller_direct_move.max_speed = _right_controller_original_max_speed
-
-
-# This method verifies the movement provider has a valid configuration.
-func _get_configuration_warnings() -> PackedStringArray:
-	var warnings := super()
-
-	# Make sure player has at least one direct movement node
-	if !XRToolsMovementDirect.find_left(self) and !XRToolsMovementDirect.find_right(self):
-		warnings.append("Player missing XRToolsMovementDirect nodes")
-
-	# Return warnings
-	return warnings


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to two functions
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Replace exclamation marks with `not` keyword
- Replace `connect(signal, Callable)` with `signal.connect(Callable)`
# Testing
The **Sprinting** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.