### PR TITLE
Better format and static type Turn

### DIFF
--- a/addons/godot-xr-tools/functions/movement_turn.gd
+++ b/addons/godot-xr-tools/functions/movement_turn.gd
@@ -2,11 +2,10 @@
 class_name XRToolsMovementTurn
 extends XRToolsMovementProvider
 
-
 ## XR Tools Movement Provider for Turning
 ##
 ## This script provides turning support for the player. This script works
-## with the PlayerBody attached to the players XROrigin3D.
+## with the [XRToolsPlayerBody] attached to the player's [XROrigin3D].
 
 
 ## Movement mode
@@ -17,87 +16,44 @@ enum TurnMode {
 }
 
 
-## Movement provider order
-@export var order : int = 5
+## Order in which movement is processed
+@export var order: int = 5
 
-## Movement mode property
-@export var turn_mode : TurnMode = TurnMode.DEFAULT
+## Type of turning
+@export var turn_mode := TurnMode.DEFAULT
 
 ## Smooth turn speed in radians per second
-@export var smooth_turn_speed : float = 2.0
+@export_custom(PROPERTY_HINT_NONE, "suffix:rad/s") var smooth_turn_speed := 2.0
 
 ## Seconds per step (at maximum turn rate)
-@export var step_turn_delay : float = 0.2
+@export_custom(PROPERTY_HINT_NONE, "suffix:s") var step_turn_delay := 0.2
 
 ## Step turn angle in degrees
-@export var step_turn_angle : float = 20.0
+@export_range(0, 360, 1.0, "or_greater", "degrees") var step_turn_angle := 20.0
 
-## Our directional input
-@export var input_action : String = "primary"
+## Input action that determines turn direction
+@export var input_action := "primary"
+
 
 # Turn step accumulator
-var _turn_step : float = 0.0
+var _turn_step := 0.0
 
 
 # Controller node
-var _controller : XRController3D
+var _controller: XRController3D
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsMovementTurn" or super(xr_name)
-
-
-# Called when our node is added to our scene tree
-func _enter_tree():
+# When our node is added to our scene tree
+func _enter_tree() -> void:
 	_controller = XRHelpers.get_xr_controller(self)
 
 
-# Called when our node is removed from our scene tree
-func _exit_tree():
+# When our node is removed from our scene tree
+func _exit_tree() -> void:
 	_controller = null
 
 
-# Perform jump movement
-func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
-	# Skip if the controller isn't active
-	if not _controller or not _controller.get_is_active():
-		return
-
-	var deadzone = 0.1
-	if _snap_turning():
-		deadzone = XRTools.get_snap_turning_deadzone()
-
-	# Read the left/right joystick axis
-	var left_right := _controller.get_vector2(input_action).x
-	if abs(left_right) <= deadzone:
-		# Not turning
-		_turn_step = 0.0
-		return
-
-	# Handle smooth rotation
-	if !_snap_turning():
-		left_right -= deadzone * sign(left_right)
-		player_body.rotate_player(smooth_turn_speed * delta * left_right)
-		return
-
-	# Disable repeat snap turning if delay is zero
-	if step_turn_delay == 0.0 and _turn_step < 0.0:
-		return
-
-	# Update the next turn-step delay
-	_turn_step -= abs(left_right) * delta
-	if _turn_step >= 0.0:
-		return
-
-	# Turn one step in the requested direction
-	if step_turn_delay != 0.0:
-		_turn_step = step_turn_delay
-
-	player_body.rotate_player(deg_to_rad(step_turn_angle) * sign(left_right))
-
-
-# This method verifies the movement provider has a valid configuration.
+# Verifies the movement provider has a valid configuration.
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := super()
 
@@ -109,7 +65,57 @@ func _get_configuration_warnings() -> PackedStringArray:
 	return warnings
 
 
-# Test if snap turning should be used
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsMovementTurn" or super(xr_name)
+
+
+## Performs jump movement
+func physics_movement(
+		delta: float,
+		player_body: XRToolsPlayerBody,
+		_disabled: bool,
+) -> bool:
+	# Skip if the controller isn't active
+	if not _controller or not _controller.get_is_active():
+		return false
+
+	var deadzone := 0.1
+	if _snap_turning():
+		deadzone = XRTools.get_snap_turning_deadzone()
+
+	# Read the left/right joystick axis
+	var left_right := _controller.get_vector2(input_action).x
+	if abs(left_right) <= deadzone:
+		# Not turning
+		_turn_step = 0.0
+		return false
+
+	# Handle smooth rotation
+	if not _snap_turning():
+		left_right -= deadzone * sign(left_right)
+		player_body.rotate_player(smooth_turn_speed * delta * left_right)
+		return false
+
+	# Disable repeat snap turning if delay is zero
+	if step_turn_delay == 0.0 and _turn_step < 0.0:
+		return false
+
+	# Update the next turn-step delay
+	_turn_step -= abs(left_right) * delta
+	if _turn_step >= 0.0:
+		return false
+
+	# Turn one step in the requested direction
+	if step_turn_delay != 0.0:
+		_turn_step = step_turn_delay
+
+	player_body.rotate_player(deg_to_rad(step_turn_angle) * sign(left_right))
+
+	return false
+
+
+# Tests if snap turning should be used
 func _snap_turning():
 	match turn_mode:
 		TurnMode.SNAP:


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to three functions
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Replace exclamation marks with `not` keyword
- Add BBCode to class doc
- Add suffixes to three exported variables
# Testing
The **Basic Movement** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.