### PR TITLE
Better format and static type Wall Walk

### DIFF
--- a/addons/godot-xr-tools/functions/movement_wall_walk.gd
+++ b/addons/godot-xr-tools/functions/movement_wall_walk.gd
@@ -2,29 +2,42 @@
 class_name XRToolsMovementWallWalk
 extends XRToolsMovementProvider
 
+##  XR Tools Movement Provider for Wall-Walking
+##
+## Wall walking is a common feature in many 2D and 3D games, and has started
+## appearing in VR games (for players with strong stomachs).[br][br]
+##
+## This movement provider allows the player to walk on objects that have a
+## physics layer matching the provider’s mask.
 
-# Default wall-walk mask of 4:wall-walk
+
+## Default wall-walk mask of 4:wall-walk
 const DEFAULT_MASK := 0b0000_0000_0000_0000_0000_0000_0000_1000
 
 
-## Wall walking provider order
-@export var order : int = 25
+## Order in which movement is processed
+@export var order: int = 25
 
-## Set our follow layer mask
-@export_flags_3d_physics var follow_mask : int = DEFAULT_MASK
+## Physics layers that support wall walking
+@export_flags_3d_physics var follow_mask := DEFAULT_MASK
 
-## Wall stick distance
-@export var stick_distance : float = 1.0
+## How far away from the wall the player can jump
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var stick_distance := 1.0
 
-## Wall stick strength
-@export var stick_strength : float = 9.8
+## Pseudo-gravity exerted on the player while wall-walking
+@export_custom(PROPERTY_HINT_NONE, "suffix:m/s^2") var stick_strength := 9.8
 
 
-func physics_pre_movement(_delta: float, player_body: XRToolsPlayerBody):
+func physics_pre_movement(
+		_delta: float,
+		player_body: XRToolsPlayerBody,
+) -> void:
 	# Test for collision with wall under feet
 	var wall_collision := player_body.move_and_collide(
-		player_body.up_player * -stick_distance, true)
-	if !wall_collision:
+			player_body.up_player * -stick_distance,
+			true,
+	)
+	if not wall_collision:
 		return
 
 	# Get the wall information
@@ -36,7 +49,7 @@ func physics_pre_movement(_delta: float, player_body: XRToolsPlayerBody):
 		return
 
 	# Skip if the wall doesn't match the follow layer
-	var wall_layer : int = wall_node.collision_layer
+	var wall_layer: int = wall_node.collision_layer
 	if (wall_layer & follow_mask) == 0:
 		return
 


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to one function
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Replace exclamation marks with `not` keyword
- Add class doc
- Add suffixes to two exported variables
# Testing
The **Origin Gravity** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.