### PR TITLE
Better format and static type World Grab

### DIFF
--- a/addons/godot-xr-tools/functions/movement_world_grab.gd
+++ b/addons/godot-xr-tools/functions/movement_world_grab.gd
@@ -2,27 +2,26 @@
 class_name XRToolsMovementWorldGrab
 extends XRToolsMovementProvider
 
-
 ## XR Tools Movement Provider for World-Grab
 ##
 ## This script provides world-grab movement for the player. To add world-grab
 ## support, the player must also have [XRToolsFunctionPickup] nodes attached
 ## to the left and right controllers, and an [XRToolsPlayerBody] under the
-## [XROrigin3D].
+## [XROrigin3D].[br][br]
 ##
 ## World-Grab areas inherit from the world_grab_area scene, or be [Area3D]
 ## nodes with the [XRToolsWorldGrabArea] script attached to them.
 
 
-## Signal invoked when the player starts world-grab movement
+## Emitted when the player starts world-grab movement
 signal player_world_grab_start
 
-## Signal invoked when the player ends world-grab movement
+## Emitted when the player ends world-grab movement
 signal player_world_grab_end
 
 
-## Movement provider order
-@export var order : int = 15
+## Order in which movement is processed
+@export var order: int = 15
 
 ## Smallest world scale
 @export var world_scale_min := 0.5
@@ -32,10 +31,10 @@ signal player_world_grab_end
 
 
 # Left world-grab handle
-var _left_handle : Node3D
+var _left_handle: Node3D
 
 # Right world-grab handle
-var _right_handle : Node3D
+var _right_handle: Node3D
 
 
 # Left pickup node
@@ -51,13 +50,8 @@ var _right_handle : Node3D
 @onready var _right_controller := XRHelpers.get_right_controller(self)
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsMovementGrabWorld" or super(xr_name)
-
-
-# Called when the node enters the scene tree for the first time.
-func _ready():
+# When the node enters the scene tree for the first time.
+func _ready() -> void:
 	# In Godot 4 we must now manually call our super class ready function
 	super()
 
@@ -66,22 +60,48 @@ func _ready():
 		return
 
 	# Connect pickup funcitons
-	if _left_pickup_node.connect("has_picked_up", _on_left_picked_up):
+	if _left_pickup_node.has_picked_up.connect(_on_left_picked_up):
 		push_error("Unable to connect left picked up signal")
-	if _right_pickup_node.connect("has_picked_up", _on_right_picked_up):
+	if _right_pickup_node.has_picked_up.connect(_on_right_picked_up):
 		push_error("Unable to connect right picked up signal")
-	if _left_pickup_node.connect("has_dropped", _on_left_dropped):
+
+	if _left_pickup_node.has_dropped.connect(_on_left_dropped):
 		push_error("Unable to connect left dropped signal")
-	if _right_pickup_node.connect("has_dropped", _on_right_dropped):
+	if _right_pickup_node.has_dropped.connect(_on_right_dropped):
 		push_error("Unable to connect right dropped signal")
 
 
-## Perform player physics movement
-func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bool):
+# Verifies the movement provider has a valid configuration.
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := super()
+
+	# Verify the left controller pickup
+	if not XRToolsFunctionPickup.find_left(self):
+		warnings.append("Unable to find left XRToolsFunctionPickup node")
+
+	# Verify the right controller pickup
+	if not XRToolsFunctionPickup.find_right(self):
+		warnings.append("Unable to find right XRToolsFunctionPickup node")
+
+	# Return warnings
+	return warnings
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsMovementGrabWorld" or super(xr_name)
+
+
+## Performs player physics movement
+func physics_movement(
+		delta: float,
+		player_body: XRToolsPlayerBody,
+		disabled: bool,
+) -> bool:
 	# Disable world-grab movement if requested
-	if disabled or !enabled:
+	if disabled or not enabled:
 		_set_world_grab_moving(false)
-		return
+		return false
 
 	# Always set velocity to zero if enabled
 	player_body.velocity = Vector3.ZERO
@@ -95,7 +115,7 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	# Disable world-grab movement if not holding the world
 	if not _left_handle and not _right_handle:
 		_set_world_grab_moving(false)
-		return
+		return false
 
 	# World grabbed
 	_set_world_grab_moving(true)
@@ -116,13 +136,17 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 		# Get the world-grab handle positions
 		var left_grab_pos := _left_handle.global_position
 		var right_grab_pos := _right_handle.global_position
-		var grab_l2r := (right_grab_pos - left_grab_pos).slide(player_body.up_player)
+		var grab_l2r := (right_grab_pos - left_grab_pos).slide(
+				player_body.up_player
+		)
 		var grab_mid := (left_grab_pos + right_grab_pos) * 0.5
 
 		# Get the pickup positions
 		var left_pickup_pos := _left_controller.global_position
 		var right_pickup_pos := _right_controller.global_position
-		var pickup_l2r := (right_pickup_pos - left_pickup_pos).slide(player_body.up_player)
+		var pickup_l2r := (right_pickup_pos - left_pickup_pos).slide(
+				player_body.up_player
+		)
 		var pickup_mid := (left_pickup_pos + right_pickup_pos) * 0.5
 
 		# Apply rotation
@@ -130,9 +154,11 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 		player_body.rotate_player(angle)
 
 		# Apply scale
-		var new_world_scale := XRServer.world_scale * grab_l2r.length() / pickup_l2r.length()
-		new_world_scale = clamp(new_world_scale, world_scale_min, world_scale_max)
-		XRServer.world_scale = new_world_scale
+		XRServer.world_scale = clampf(
+				XRServer.world_scale * grab_l2r.length() / pickup_l2r.length(),
+				world_scale_min,
+				world_scale_max,
+		)
 
 		# Apply offset
 		offset = pickup_mid - grab_mid
@@ -141,13 +167,12 @@ func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bo
 	var old_position := player_body.global_position
 	player_body.move_player(-offset / delta)
 	player_body.velocity = Vector3.ZERO
-	#player_body.move_and_collide(-offset)
 
 	# Report exclusive motion performed (to bypass gravity)
 	return true
 
 
-## Start or stop world-grab movement
+# Toggles world grab movement
 func _set_world_grab_moving(active: bool) -> void:
 	# Skip if no change
 	if active == is_active:
@@ -158,13 +183,19 @@ func _set_world_grab_moving(active: bool) -> void:
 
 	# Handle state change
 	if is_active:
-		emit_signal("player_world_grab_start")
+		player_world_grab_start.emit()
 	else:
-		emit_signal("player_world_grab_end")
+		player_world_grab_end.emit()
 
 
-## Handler for left controller picked up
-func _on_left_picked_up(what : Node3D) -> void:
+# When the left controller drops something
+func _on_left_dropped() -> void:
+	# Release handle and transfer dominance
+	_left_handle = null
+
+
+# When the left controller picks something up
+func _on_left_picked_up(what: Node3D) -> void:
 	# Get the world-grab area
 	var world_grab_area = what as XRToolsWorldGrabArea
 	if not world_grab_area:
@@ -176,8 +207,14 @@ func _on_left_picked_up(what : Node3D) -> void:
 		return
 
 
-## Handler for right controller picked up
-func _on_right_picked_up(what : Node3D) -> void:
+# When the right controller drops something
+func _on_right_dropped() -> void:
+	# Release handle and transfer dominance
+	_right_handle = null
+
+
+# When the right controller picks something up
+func _on_right_picked_up(what: Node3D) -> void:
 	# Get the world-grab area
 	var world_grab_area = what as XRToolsWorldGrabArea
 	if not world_grab_area:
@@ -187,31 +224,3 @@ func _on_right_picked_up(what : Node3D) -> void:
 	_right_handle = world_grab_area.get_grab_handle(_right_pickup_node)
 	if not _right_handle:
 		return
-
-
-## Handler for left controller dropped
-func _on_left_dropped() -> void:
-	# Release handle and transfer dominance
-	_left_handle = null
-
-
-## Handler for righ controller dropped
-func _on_right_dropped() -> void:
-	# Release handle and transfer dominance
-	_right_handle = null
-
-
-# This method verifies the movement provider has a valid configuration.
-func _get_configuration_warnings() -> PackedStringArray:
-	var warnings := super()
-
-	# Verify the left controller pickup
-	if !XRToolsFunctionPickup.find_left(self):
-		warnings.append("Unable to find left XRToolsFunctionPickup node")
-
-	# Verify the right controller pickup
-	if !XRToolsFunctionPickup.find_right(self):
-		warnings.append("Unable to find right XRToolsFunctionPickup node")
-
-	# Return warnings
-	return warnings


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to two functions
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Replace exclamation marks with `not` keyword
- Add BBCode to class doc
- Replace `connect(signal, Callable)` with `signal.connect(Callable)`
# Testing
The **World Grab** demo had no issues not present in `master`. `master` currently has a bug where the world scale remains changed even after returning to the main menu.
# Disclaimer
No generative AI was used to enhance or create the code given here.