### PR TITLE
Better format and static type Hand Aim Offset

### DIFF
--- a/addons/godot-xr-tools/hands/hand_aim_offset.gd
+++ b/addons/godot-xr-tools/hands/hand_aim_offset.gd
@@ -2,50 +2,33 @@
 class_name XRToolsHandAimOffset
 extends Node3D
 
-## XRToolsHandAimOffset will automatically adjust its position,
-## to the aim position (within limits).
+## Automatically adjusts its position, to the aim position (within limits).
 
-## Hand offset to apply based on our controller pose
-## You can use auto if you're using the default aim_pose or grip_pose poses.
-@export_enum("auto", "aim", "grip", "palm", "disable") var hand_offset_mode : int = 0:
+## Hand offset to apply based on our controller pose. Use [member auto]
+## if you're using the default [member aim_pose] or [member grip_pose] poses.
+@export_enum("auto", "aim", "grip", "palm", "disable") var hand_offset_mode: int = 0:
 	set(value):
 		hand_offset_mode = value
 		notify_property_list_changed()
 		if is_inside_tree():
 			_update_transform()
 
+
 # Controller
-var _controller : XRController3D
+var _controller: XRController3D
 
-# Keep track of our tracker and pose
-var _controller_tracker_and_pose : String = ""
+# Keeps track of our tracker and pose
+var _controller_tracker_and_pose := ""
 
-# Which node are we applying our transform on?
-var _apply_to : Node3D
+# Node that we apply our transform on
+var _apply_to: Node3D
 
 # Additional transform to apply
-var _base_transform : Transform3D = Transform3D()
-
-## Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsHandAimOffset"
+var _base_transform: Transform3D = Transform3D()
 
 
-## Set the node we apply our transform to
-## Must be set before _enter_tree is called for the first time.
-func set_apply_to(node : Node3D) -> void:
-	_apply_to = node
-
-
-## Set a base transform to apply
-func set_base_transform(base_transform : Transform3D) -> void:
-	_base_transform = base_transform
-	if is_inside_tree():
-		_update_transform()
-
-
-# Called when we're added to the tree
-func _enter_tree():
+# When we're added to the tree
+func _enter_tree() -> void:
 	if not _apply_to:
 		_apply_to = self
 
@@ -54,43 +37,69 @@ func _enter_tree():
 	_update_transform()
 
 
-# Called when we exit the tree
-func _exit_tree():
-	if _controller:
-		_controller = null
-
-
-# Check property config
-func _validate_property(property):
-	if hand_offset_mode != 4 and (property.name == "position" or property.name == "rotation" or property.name == "scale" or property.name == "rotation_edit_mode" or property.name == "rotation_order"):
-		# We control these, don't let the user set them.
-		property.usage = PROPERTY_USAGE_NONE
-
-
-# This method verifies the hand has a valid configuration.
-func _get_configuration_warnings() -> PackedStringArray:
-	var warnings := PackedStringArray()
-
-	# Check for XR Controller
-	var controller = XRHelpers.get_xr_controller(self)
-	if not controller:
-		warnings.append("Hand should descent from an XRController3D node")
-
-	return warnings
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(_delta):
+func _process(_delta: float) -> void:
 	# If we have a controller, make sure our hand transform is updated when needed.
 	if _controller:
-		var tracker_and_pose = _controller.tracker + "." + _controller.pose
+		var tracker_and_pose: String = _controller.tracker + "." + _controller.pose
 		if _controller_tracker_and_pose != tracker_and_pose:
 			_controller_tracker_and_pose = tracker_and_pose
 			if hand_offset_mode == 0:
 				_update_transform()
 
 
-# Update our transform so we are positioned on our aim pose
+# When we exit the tree
+func _exit_tree() -> void:
+	if _controller:
+		_controller = null
+
+
+# Verifies the hand has a valid configuration.
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := PackedStringArray()
+
+	# Check for XR Controller
+	var controller := XRHelpers.get_xr_controller(self)
+	if not controller:
+		warnings.append("Hand should descent from an XRController3D node")
+
+	return warnings
+
+
+# Checks property config
+func _validate_property(property: Dictionary[String, Variant]) -> void:
+	if hand_offset_mode != 4 and (
+			property.name == "position"
+			or property.name == "rotation"
+			or property.name == "scale"
+			or property.name == "rotation_edit_mode"
+			or property.name == "rotation_order"
+	):
+		# We control these, don't let the user set them.
+		property.usage = PROPERTY_USAGE_NONE
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsHandAimOffset"
+
+
+## Sets the node we apply our transform to
+## Must be set before [method _enter_tree] is called for the first time.
+func set_apply_to(node: Node3D) -> void:
+	_apply_to = node
+
+
+## Sets a base transform to apply
+func set_base_transform(base_transform: Transform3D) -> void:
+	_base_transform = base_transform
+	if is_inside_tree():
+		_update_transform()
+
+
+# Updates our transform so we are positioned on our aim pose
 func _update_transform() -> void:
 	if _apply_to and hand_offset_mode != 4:
-		_apply_to.transform = XRTools.get_aim_offset(hand_offset_mode, _controller) * _base_transform
+		_apply_to.transform = XRTools.get_aim_offset(
+				hand_offset_mode,
+				_controller,
+		) * _base_transform


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to four functions
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Add BBCode to class doc
- Add type to `Dictionary`
# Testing
The **Pointer** demo had no issues not present in `master`. The **Pointer** demo currently has a bug where the virtual keyboard does nothing, but there's already a PR (#793) to fix this.
# Disclaimer
No generative AI was used to enhance or create the code given here.