### PR TITLE
Better format Physics Hand

### DIFF
--- a/addons/godot-xr-tools/hands/physics_hand.gd
+++ b/addons/godot-xr-tools/hands/physics_hand.gd
@@ -2,7 +2,6 @@
 class_name XRToolsPhysicsHand
 extends XRToolsHand
 
-
 ## XR Tools Physics Hand Script
 ##
 ## This script extends from the standard [XRToolsHand] and adds settings to
@@ -10,31 +9,26 @@ extends XRToolsHand
 ## attached to the hand.
 
 
-# Default hand bone layer of 18:player-hand
+## Default hand bone layer of 18:player-hand
 const DEFAULT_LAYER := 0b0000_0000_0000_0010_0000_0000_0000_0000
 
 
 ## Collision layer applied to all [XRToolsHandPhysicsBone] children.
 ##
-## This is used to set physics collision layers for every bone in a hand.
-## Additionally [XRToolsHandPhysicsBone] nodes can specify additional
-## bone-specific collision layers - for example to give the fore-finger bone
+## Sets physics collision layers for every bone in a hand.
+## Additionally, [XRToolsHandPhysicsBone] nodes can specify additional
+## bone-specific collision layers - for example, to give the fore-finger bone
 ## additional collision capabilities.
-@export_flags_3d_physics var collision_layer : int = DEFAULT_LAYER
+@export_flags_3d_physics var collision_layer := DEFAULT_LAYER
 
-## Bone collision margin applied to all [XRToolsHandPhysicsBone] children.
-##
-## This is used for fine-tuning the collision margins for all
-## [XRToolsHandPhysicsBone] children in the hand.
-@export var margin : float = 0.004
+## Bone collision margin applied to all [XRToolsHandPhysicsBone] children
+@export var margin := 0.004
 
-## Group applied to all [XRToolsHandPhysicsBone] children.
-##
-## This is used to set groups for every bone in the hand. Additionally
+## Group applied to all [XRToolsHandPhysicsBone] children. Additionally,
 ## [XRToolsHandPhysicsBone] nodes can specify additional bone-specific groups.
-@export var bone_group : String = ""
+@export var bone_group := ""
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
 	return xr_name == "XRToolsPhysicsHand" or super(xr_name)


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Clarify comments of variables and methods
- Add BBCode to doc comment for method `is_xr_class()`
# Testing
The **Audio** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.