### PR TITLE
Better format and static type Grab

### DIFF
--- a/addons/godot-xr-tools/objects/grab_points/grab.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grab.gd
@@ -1,11 +1,10 @@
 class_name Grab
 extends Grabber
 
-
 ## Grab Class
 ##
-## This class encodes information about an active grab. Additionally it applies
-## hand poses and collision exceptions as appropriate.
+## This class encodes information about an active grab. Additionally, it applies
+## hand poses and collision exceptions when appropriate.
 
 
 ## Priority for grip poses
@@ -16,39 +15,64 @@ const GRIP_TARGET_PRIORITY := 100
 
 
 ## Grab target
-var what : XRToolsPickable
+var what: XRToolsPickable
 
 ## Grab point information
-var point : XRToolsGrabPoint
+var point: XRToolsGrabPoint
 
 ## Hand grab point information
-var hand_point : XRToolsGrabPointHand
+var hand_point: XRToolsGrabPointHand
 
 ## Grab transform
-var transform : Transform3D
+var transform: Transform3D
 
 ## Position drive strength
-var drive_position : float = 1.0
+var drive_position := 1.0
 
 ## Angle drive strength
-var drive_angle : float = 1.0
+var drive_angle := 1.0
 
 ## Aim drive strength
-var drive_aim : float = 0.0
+var drive_aim := 0.0
 
-## Has target arrived at grab point
-var _arrived : bool = false
+## Whether target has arrived at grab point
+var _arrived := false
 
 ## Collision exceptions we manage
-var _collision_exceptions : Array[RID]
+var _collision_exceptions: Array[RID]
 
 
-## Initialize the grab
+# Removes the exceptions in our passed array, after a small delay to give an
+# object a chance to drop away from the hand before it starts colliding.
+# It is possible that another object is picked up in the meanwhile
+# and we thus fill _collision_exceptions with new content.
+# Hence using a copy of this list at the time of dropping the object.
+#
+# Note: this is static because our grab object gets destroyed before this code gets run.
+static func _remove_collision_exceptions(
+		on_collision_hand: RID,
+		exceptions: Array[RID],
+) -> void:
+
+	# This can be improved by checking if we're still colliding and only
+	# removing those objects from our exception list that are not.
+	# If any are left, we can restart a new timer.
+	# This will also allow us to use a much smaller timer interval
+
+	# For now we'll remove all.
+
+	for body: RID in exceptions:
+		PhysicsServer3D.body_remove_collision_exception(on_collision_hand, body)
+		PhysicsServer3D.body_remove_collision_exception(body, on_collision_hand)
+
+
+# Initialises the grab
 func _init(
-	p_grabber : Grabber,
-	p_what : XRToolsPickable,
-	p_point : XRToolsGrabPoint,
-	p_precise : bool) -> void:
+		p_grabber: Grabber,
+		p_what: XRToolsPickable,
+		p_point: XRToolsGrabPoint,
+		p_precise: bool,
+) -> void:
 
 	# Copy the grabber information
 	by = p_grabber.by
@@ -85,7 +109,31 @@ func _init(
 		_add_collision_exceptions(what)
 
 
-## Set the target as arrived at the grab-point
+## Releases the grip
+func release() -> void:
+	# Clear any hand pose
+	_clear_hand_pose()
+
+	# Remove collision exceptions with a small delay
+	if is_instance_valid(collision_hand) and not _collision_exceptions.is_empty():
+		# Use RIDs instead of the objects directly in case they get freed while
+		# we are waiting for the object to fall away
+		var copy: Array[RID] = _collision_exceptions.duplicate()
+		_collision_exceptions.clear()
+
+		# Delay removing our exceptions to give the object time to fall away
+		collision_hand.get_tree().create_timer(0.5).timeout.connect(
+				_remove_collision_exceptions
+				.bind(copy)
+				.bind(collision_hand.get_rid())
+		)
+
+	# Report the release
+	print_verbose("%s> released by %s", [what.name, by.name])
+	what.released.emit(what, by)
+
+
+## Sets the target as arrived at the grab-point
 func set_arrived() -> void:
 	# Ignore if already arrived
 	if _arrived:
@@ -101,8 +149,8 @@ func set_arrived() -> void:
 	what.grabbed.emit(what, by)
 
 
-## Set the grab point
-func set_grab_point(p_point : XRToolsGrabPoint) -> void:
+## Sets the grab point
+func set_grab_point(p_point: XRToolsGrabPoint) -> void:
 	# Skip if no change
 	if p_point == point:
 		return
@@ -135,50 +183,33 @@ func set_grab_point(p_point : XRToolsGrabPoint) -> void:
 	what.grabbed.emit(what, by)
 
 
-## Release the grip
-func release() -> void:
-	# Clear any hand pose
-	_clear_hand_pose()
-
-	# Remove collision exceptions with a small delay
-	if is_instance_valid(collision_hand) and not _collision_exceptions.is_empty():
-		# Use RIDs instead of the objects directly in case they get freed while
-		# we are waiting for the object to fall away
-		var copy : Array[RID] = _collision_exceptions.duplicate()
-		_collision_exceptions.clear()
-
-		# Delay removing our exceptions to give the object time to fall away
-		collision_hand.get_tree().create_timer(0.5).timeout \
-			.connect(_remove_collision_exceptions \
-				.bind(copy) \
-				.bind(collision_hand.get_rid()))
-
-	# Report the release
-	print_verbose("%s> released by %s", [what.name, by.name])
-	what.released.emit(what, by)
-
-
-# Hand has moved too far away from object, can no longer hold on to it.
-func _on_max_distance_reached() -> void:
-	pickup.drop_object()
-
-
-# Set hand-pose overrides
-func _set_hand_pose() -> void:
-	# Skip if not hand
-	if not is_instance_valid(hand) or not is_instance_valid(hand_point):
+# Adds collision exceptions for the grabbed object and any of its children
+func _add_collision_exceptions(from: Node) -> void:
+	if not is_instance_valid(collision_hand):
 		return
 
-	# Apply the hand-pose
-	if hand_point.hand_pose:
-		hand.add_pose_override(hand_point, GRIP_POSE_PRIORITY, hand_point.hand_pose)
+	if not is_instance_valid(from):
+		return
 
-	# Apply hand snapping
-	if hand_point.snap_hand:
-		hand.add_target_override(hand_point, GRIP_TARGET_PRIORITY)
+	# If this is a physics body, add an exception
+	if from is PhysicsBody3D:
+		# Make sure we don't collide with what we're holding
+		_collision_exceptions.push_back(from.get_rid())
+		PhysicsServer3D.body_add_collision_exception(
+				collision_hand.get_rid(),
+				from.get_rid(),
+		)
+		PhysicsServer3D.body_add_collision_exception(
+				from.get_rid(),
+				collision_hand.get_rid(),
+		)
+
+	# Check all children
+	for child: Node in from.get_children():
+		_add_collision_exceptions(child)
 
 
-# Clear any hand-pose overrides
+# Clears any hand-pose overrides
 func _clear_hand_pose() -> void:
 	# Skip if not hand
 	if not is_instance_valid(hand) or not is_instance_valid(hand_point):
@@ -191,45 +222,21 @@ func _clear_hand_pose() -> void:
 	hand.remove_target_override(hand_point)
 
 
-# Add collision exceptions for the grabbed object and any of its children
-func _add_collision_exceptions(from : Node):
-	if not is_instance_valid(collision_hand):
+# When the hand has moved too far away from object & can no longer hold on to it.
+func _on_max_distance_reached() -> void:
+	pickup.drop_object()
+
+
+# Sets hand-pose overrides
+func _set_hand_pose() -> void:
+	# Skip if not hand
+	if not is_instance_valid(hand) or not is_instance_valid(hand_point):
 		return
 
-	if not is_instance_valid(from):
-		return
+	# Apply the hand-pose
+	if hand_point.hand_pose:
+		hand.add_pose_override(hand_point, GRIP_POSE_PRIORITY, hand_point.hand_pose)
 
-	# If this is a physics body, add an exception
-	if from is PhysicsBody3D:
-		# Make sure we don't collide with what we're holding
-		_collision_exceptions.push_back(from.get_rid())
-		PhysicsServer3D.body_add_collision_exception(collision_hand.get_rid(), from.get_rid())
-		PhysicsServer3D.body_add_collision_exception(from.get_rid(), collision_hand.get_rid())
-
-	# Check all children
-	for child in from.get_children():
-		_add_collision_exceptions(child)
-
-
-# Remove the exceptions in our passed array. We call this with a small delay
-# to give an object a chance to drop away from the hand before it starts
-# colliding.
-# It is possible that another object is picked up in the meanwhile
-# and we thus fill _collision_exceptions with new content.
-# Hence using a copy of this list at the time of dropping the object.
-#
-# Note, this is static because our grab object gets destroyed before this code gets run.
-static func _remove_collision_exceptions( \
-	on_collision_hand : RID, \
-	exceptions : Array[RID]):
-
-	# This can be improved by checking if we're still colliding and only
-	# removing those objects from our exception list that are not.
-	# If any are left, we can restart a new timer.
-	# This will also allow us to use a much smaller timer interval
-
-	# For now we'll remove all.
-
-	for body : RID in exceptions:
-		PhysicsServer3D.body_remove_collision_exception(on_collision_hand, body)
-		PhysicsServer3D.body_remove_collision_exception(body, on_collision_hand)
+	# Apply hand snapping
+	if hand_point.snap_hand:
+		hand.add_target_override(hand_point, GRIP_TARGET_PRIORITY)


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to one function
- Reorder functions in accordance with the style guide above
- Format multiline statements for better readability
- Clarify comments of variables and methods
- Add type to `for` loop variable
# Testing
I couldn't find any place where the class `Grab` was used. Nevertheless, the **Pickables** demo and the **Interactables** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.