### PR TITLE
Better format Grabber

### DIFF
--- a/addons/godot-xr-tools/objects/grab_points/grabber.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grabber.gd
@@ -1,6 +1,5 @@
 class_name Grabber
 
-
 ## Grabber Class
 ##
 ## This class contains relevant information for a grabber including any
@@ -8,22 +7,23 @@ class_name Grabber
 
 
 ## Grabber node
-var by : Node3D
+var by: Node3D
 
 ## Pickup associated with the grabber
-var pickup : XRToolsFunctionPickup
+var pickup: XRToolsFunctionPickup
 
 ## Controller associated with the grabber
-var controller : XRController3D
+var controller: XRController3D
 
 ## Hand associated with the grabber
-var hand : XRToolsHand
+var hand: XRToolsHand
 
 ## Collision hand associated with the grabber
-var collision_hand : XRToolsCollisionHand
+var collision_hand: XRToolsCollisionHand
 
-## Initialize the grabber
-func _init(p_by : Node3D) -> void:
+
+# Initialises the grabber
+func _init(p_by: Node3D) -> void:
 	by = p_by
 	pickup = p_by as XRToolsFunctionPickup
 	controller = pickup.get_controller() if pickup else null


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove doc comment for private method
# Testing
I couldn't find any place where the class `Grabber` was used. Nevertheless, the **Pickables** demo and the **Interactables** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.