### PR TITLE
Better format and static type Grab Point

### DIFF
--- a/addons/godot-xr-tools/objects/grab_points/grab_point.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grab_point.gd
@@ -1,27 +1,38 @@
 class_name XRToolsGrabPoint
 extends Marker3D
 
-
 ## XR Tools Grab Point Base Script
 ##
-## This script is the base for all grab points. Pickable object extending from
+## This script is the base for all grab points. Pickable objects extending from
 ## [XRToolsPickable] can have numerous grab points to control where the object
 ## is grabbed from.
 
 
-# Signal emitted when the user presses the action button while holding this grab point
-signal action_pressed(pickable, grab_point)
+## Emitted when the user presses the action button while holding this grab point
+signal action_pressed(pickable: XRToolsPickable, grab_point: XRToolsGrabPoint)
 
-# Signal emitted when the user releases the action button while holding this grab point
-signal action_released(pickable, grab_point)
-
-
-## If true, the grab point is enabled for grabbing
-@export var enabled : bool = true
+## Emitted when the user releases the action button while holding this grab point
+signal action_released(pickable: XRToolsPickable, grab_point: XRToolsGrabPoint)
 
 
-## Evaluate fitness of the proposed grab, with 0.0 for not allowed.
-func can_grab(grabber : Node3D, _current : XRToolsGrabPoint) -> float:
+## Whether the grab point is enabled for grabbing
+@export var enabled := true
+
+
+## When the user presses the action button while holding this grab point
+func action(pickable: XRToolsPickable) -> void:
+	# let interested parties know
+	action_pressed.emit(pickable, self)
+
+
+## When the user releases the action button while holding this grab point
+func action_release(pickable: XRToolsPickable) -> void:
+	# let interested parties know
+	action_released.emit(pickable, self)
+
+
+## Evaluates fitness of the proposed grab, with 0.0 for not allowed.
+func can_grab(grabber: Node3D, _current: XRToolsGrabPoint) -> float:
 	if not enabled:
 		return 0.0
 
@@ -29,19 +40,7 @@ func can_grab(grabber : Node3D, _current : XRToolsGrabPoint) -> float:
 	return _weight(grabber)
 
 
-# Return a distance-weighted fitness weight in the range (0.0 - max]
-func _weight(grabber : Node3D, max : float = 1.0) -> float:
+# Returns a distance-weighted fitness weight in the range (0.0 - max]
+func _weight(grabber: Node3D, max: float = 1.0) -> float:
 	var distance := global_position.distance_to(grabber.global_position)
 	return max / (1.0 + distance)
-
-
-# action is called when user presses the action button while holding this grab point
-func action(pickable : XRToolsPickable):
-	# let interested parties know
-	action_pressed.emit(pickable, self)
-
-
-# action_release is called when user releases the action button while holding this grab point
-func action_release(pickable : XRToolsPickable):
-	# let interested parties know
-	action_released.emit(pickable, self)


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to two functions
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Add types to signal parameters
# Testing
The **Pickables** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.