### PR TITLE
Better format and static type Highlight Visible

### DIFF
--- a/addons/godot-xr-tools/objects/highlight/highlight_visible.gd
+++ b/addons/godot-xr-tools/objects/highlight/highlight_visible.gd
@@ -2,34 +2,39 @@
 class_name XRToolsHighlightVisible
 extends Node3D
 
-
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsHighlightVisible"
+var _parent: Node
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
+# When the node enters the scene tree for the first time.
+func _ready() -> void:
+	# Get the parent node
+	_parent = get_parent()
+
 	# Turn off until requested
 	if not Engine.is_editor_hint():
 		visible = false
 
 	# Hook the highlight update
-	get_parent().connect("highlight_updated", _on_highlight_updated)
+	if _parent.has_signal("highlight_updated"):
+		_parent.highlight_updated.connect(_on_highlight_updated)
 
 
-# Called when the pickable highlight changes
-func _on_highlight_updated(_pickable, enable: bool) -> void:
-	visible = enable
-
-
-# This method verifies the node
+# Verifies the node
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := PackedStringArray()
 
 	# Verify parent supports highlighting
-	var parent := get_parent()
-	if not parent or not parent.has_signal("highlight_updated"):
+	if not _parent or not _parent.has_signal("highlight_updated"):
 		warnings.append("Parent does not support highlighting")
 
 	return warnings
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsHighlightVisible"
+
+
+# When the pickable highlight changes
+func _on_highlight_updated(_pickable: XRToolsPickable, enable: bool) -> void:
+	visible = enable


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to one function
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Add check for whether the parent node has signal `highlight_updated` before connecting to it
# Note
This is pretty much the same code as `XRToolsHighlightRing`. We should deprecate one of these in the next minor release.
# Testing
The **Pickables** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.