### PR TITLE
Better format and static type Climbable

### DIFF
--- a/addons/godot-xr-tools/objects/climbable.gd
+++ b/addons/godot-xr-tools/objects/climbable.gd
@@ -3,7 +3,6 @@
 class_name XRToolsClimbable
 extends Node3D
 
-
 ## XR Tools Climbable Object
 ##
 ## This script adds climbing support to any [StaticBody3D].
@@ -12,54 +11,64 @@ extends Node3D
 ## configured appropriately.
 
 
-## If true, the grip control must be held to keep holding the climbable
-var press_to_hold : bool = true
+## Whether the grip control must be held to keep holding the climbable
+var press_to_hold := true
+
+# Array of permanent grab points.
+var _grab_points: Array[XRToolsGrabPoint] = []
+
+# Dictionary of temporary grabs keyed by the pickup node
+var _grab_temps: Dictionary[Node3D, Node3D] = {}
+
+# Dictionary of active grabs keyed by the pickup node
+var _grabs: Dictionary[Node3D, Node3D] = {}
 
 
-## Array of permanent grab points.
-var _grab_points : Array[XRToolsGrabPoint] = []
-
-## Dictionary of temporary grabs keyed by the pickup node
-var _grab_temps : Dictionary = {}
-
-## Dictionary of active grabs keyed by the pickup node
-var _grabs : Dictionary = {}
-
-
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsClimbable"
-
-
-# Called when the node becomes "ready"
+# When the node becomes "ready"
 func _ready() -> void:
 	# Get all grab points
-	for child in get_children():
+	for child: Node in get_children():
 		var grab_point := child as XRToolsGrabPoint
 		if grab_point:
 			_grab_points.push_back(grab_point)
 
 
-# Called by XRToolsFunctionPickup
-func is_picked_up() -> bool:
-	return false
+## Called by XRToolsFunctionPickup when user presses the action button
+## while holding this object
+func action() -> void:
+	pass
 
 
+## Whether this can be picked up by [XRToolsFunctionPickup]
 func can_pick_up(_by: Node3D) -> bool:
 	return true
 
 
-# Called by XRToolsFunctionPickup when user presses the action button while holding this object
-func action():
-	pass
+## Gets the grab handle
+func get_grab_handle(by: Node3D) -> Node3D:
+	return _grabs.get(by)
 
 
-# Ignore highlighting requests from XRToolsFunctionPickup
-func request_highlight(_from, _on) -> void:
-	pass
+## Whether this is picked up
+func is_picked_up() -> bool:
+	return false
 
 
-# Called by XRToolsFunctionPickup when this is picked up by a controller
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsClimbable"
+
+
+## Called by XRToolsFunctionPickup when this is let go by a controller
+func let_go(
+		by: Node3D,
+		_p_linear_velocity: Vector3,
+		_p_angular_velocity: Vector3,
+) -> void:
+	_grabs.erase(by)
+
+
+## Called by XRToolsFunctionPickup when this is picked up by a controller
 func pick_up(by: Node3D) -> void:
 	# Get the best permanent grab-point
 	var point := _get_grab_point(by)
@@ -79,22 +88,17 @@ func pick_up(by: Node3D) -> void:
 	_grabs[by] = point
 
 
-# Called by XRToolsFunctionPickup when this is let go by a controller
-func let_go(by: Node3D, _p_linear_velocity: Vector3, _p_angular_velocity: Vector3) -> void:
-	_grabs.erase(by)
+## Ignores highlighting requests from XRToolsFunctionPickup
+func request_highlight(_from: XRToolsFunctionPickup, _on: bool) -> void:
+	pass
 
 
-# Get the grab handle
-func get_grab_handle(by: Node3D) -> Node3D:
-	return _grabs.get(by)
-
-
-## Find the most suitable grab-point for the grabber
-func _get_grab_point(by : Node3D) -> Node3D:
+# Finds the most suitable grab-point for the grabber
+func _get_grab_point(by: Node3D) -> Node3D:
 	# Find the best grab-point
 	var fitness := 0.0
-	var point : XRToolsGrabPoint = null
-	for p in _grab_points:
+	var point: XRToolsGrabPoint = null
+	for p: XRToolsGrabPoint in _grab_points:
 		var f := p.can_grab(by, null)
 		if f > fitness:
 			fitness = f


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to one function
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Add types to `Dictionary`s
- Add types to `for` loop variables
# Testing
The **Climbing & Gliding** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.