### PR TITLE
Better format and static type Interactable Body

### DIFF
--- a/addons/godot-xr-tools/objects/interactable_body.gd
+++ b/addons/godot-xr-tools/objects/interactable_body.gd
@@ -1,7 +1,11 @@
 class_name XRToolsInteractableBody
 extends Node3D
-# This should extend from PhysicsBody3D but https://github.com/godotengine/godot/issues/46073
+## [PhysicsBody3D] that emits [XRToolsPointerEvent]s when pointed at by
+## [XRToolsFunctionPointer]s.
+##
+## Note: This should extend from [PhysicsBody3D],
+## but [url]https://github.com/godotengine/godot/issues/46073[/url]
 
 
-## Signal when pointer event occurs on body
-signal pointer_event(event)
+## Emitted when pointer event occurs on body
+signal pointer_event(event: XRToolsPointerEvent)


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Add class doc
- Add type to signal `pointer_event` parameter
- Clarify comments of methods and signals
# Note
Despite the fact godotengine/godot#46073 is labelled as closed, I can confirm that this has not been fixed, and this class will not show up in the `Create New Node` dialogue if extending from `PhysicsBody3D`.
# Testing
This is not used anywhere in the Godot XR Tools demo. In the future, this should be added to the **Pointer** demo.
# Disclaimer
No generative AI was used to enhance or create the code given here.