### PR TITLE
Better format and static type Pickable

### DIFF
--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -2,54 +2,55 @@
 class_name XRToolsPickable
 extends RigidBody3D
 
-
 ## XR Tools Pickable Object
 ##
 ## This script allows a [RigidBody3D] to be picked up by an
-## [XRToolsFunctionPickup] attached to a players controller.
+## [XRToolsFunctionPickup] attached to a player's controller.
 ##
-## Additionally pickable objects may support being snapped into
+## Additionally, pickable objects may support being snapped into
 ## [XRToolsSnapZone] areas.
 ##
 ## Grab-points can be defined by adding different types of [XRToolsGrabPoint]
 ## child nodes controlling hand and snap-zone grab locations.
 
 
-# Signal emitted when this object is picked up (held by a player or snap-zone)
-signal picked_up(pickable)
+## Emitted when this object is picked up (held by a player or snap-zone)
+signal picked_up(pickable: XRToolsPickable)
 
-# Signal emitted when this object is dropped
-signal dropped(pickable)
+## Emitted when this object is dropped
+signal dropped(pickable: XRToolsPickable)
 
-# Signal emitted when this object is grabbed (primary or secondary)
-signal grabbed(pickable, by)
+## Emitted when this object is grabbed (primary or secondary)
+signal grabbed(pickable: XRToolsPickable, by: Node3D)
 
-# Signal emitted when this object is released (primary or secondary)
-signal released(pickable, by)
+## Emitted when this object is released (primary or secondary)
+signal released(pickable: XRToolsPickable, by: Node3D)
 
-# Signal emitted when the user presses the action button while holding this object
-signal action_pressed(pickable)
+## Emitted when the user presses the action button while holding this object
+signal action_pressed(pickable: XRToolsPickable)
 
-# Signal emitted when the user releases the action button while holding this object
-signal action_released(pickable)
+## Emitted when the user releases the action button while holding this object
+signal action_released(pickable: XRToolsPickable)
 
-# Signal emitted when the highlight state changes
-signal highlight_updated(pickable, enable)
+## Emitted when the highlight state changes
+signal highlight_updated(pickable: XRToolsPickable, enable: bool)
 
 
-## Method used to grab object at range
+## How to grab objects from afar
 enum RangedMethod {
 	NONE,				## Ranged grab is not supported
 	SNAP,				## Object snaps to holder
 	LERP,				## Object lerps to holder
 }
 
+## How to release held objects
 enum ReleaseMode {
 	ORIGINAL = -1,		## Preserve original mode when picked up
 	UNFROZEN = 0,		## Release and unfreeze
 	FROZEN = 1,			## Release and freeze
 }
 
+## How objects held by one hand should react when grabbed by another hand
 enum SecondHandGrab {
 	IGNORE,				## Ignore second grab
 	SWAP,				## Swap to second hand
@@ -57,81 +58,77 @@ enum SecondHandGrab {
 }
 
 
-# Default layer for held objects is 17:held-object
+## Default layer for held objects is 17:held-object
 const DEFAULT_LAYER := 0b0000_0000_0000_0001_0000_0000_0000_0000
 
 
-## If true, the pickable supports being picked up
-@export var enabled : bool = true
+## Whether the pickable supports being picked up
+@export var enabled := true
 
-## If true, the grip control must be held to keep the object picked up
-@export var press_to_hold : bool = true
+## Whether the grip control must be held to keep the object picked up
+@export var press_to_hold := true
 
 ## Layer for this object while picked up
-@export_flags_3d_physics var picked_up_layer : int = DEFAULT_LAYER
+@export_flags_3d_physics var picked_up_layer := DEFAULT_LAYER
 
-## Release mode to use when releasing the object
-@export var release_mode : ReleaseMode = ReleaseMode.ORIGINAL
+## How to treat objects released from being grabbed
+@export var release_mode := ReleaseMode.ORIGINAL
 
-## Method used to perform a ranged grab
-@export var ranged_grab_method : RangedMethod = RangedMethod.SNAP: set = _set_ranged_grab_method
+## How objects can be grabbed from afar
+@export var ranged_grab_method := RangedMethod.SNAP: set = _set_ranged_grab_method
 
-## Second hand grab mode
-@export var second_hand_grab : SecondHandGrab = SecondHandGrab.IGNORE
+## How objects held by one hand should react when grabbed by another hand
+@export var second_hand_grab := SecondHandGrab.IGNORE
 
-## Speed for ranged grab
-@export var ranged_grab_speed : float = 20.0
+## Speed for grabbing objects from afar
+@export var ranged_grab_speed := 20.0
 
 ## Refuse pick-by when in the specified group
-@export var picked_by_exclude : String = ""
+@export var picked_by_exclude := ""
 
 ## Require pick-by to be in the specified group
-@export var picked_by_require : String = ""
+@export var picked_by_require := ""
 
 
-## If true, the object can be picked up at range
-var can_ranged_grab: bool = true
+## Whether the object can be picked up at range
+var can_ranged_grab := true
 
 ## Frozen state to restore to when dropped
-var restore_freeze : bool = false
+var restore_freeze := false
 
 # Count of 'is_closest' grabbers
-var _closest_count: int = 0
+var _closest_count := 0
 
 # Grab Driver to control position while grabbed
 var _grab_driver: XRToolsGrabDriver = null
 
 # Array of grab points
-var _grab_points : Array[XRToolsGrabPoint] = []
+var _grab_points: Array[XRToolsGrabPoint] = []
 
 # Dictionary of nodes requesting highlight
-var _highlight_requests : Dictionary = {}
+var _highlight_requests: Dictionary[Node, Node] = {}
 
-# Is this node highlighted
-var _highlighted : bool = false
-
-
-# Remember some state so we can return to it when the user drops the object
-@onready var original_collision_mask : int = collision_mask
-@onready var original_collision_layer : int = collision_layer
+# Whether this node is highlighted
+var _highlighted := false
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsPickable"
+## Original collision mask of objects that are picked up
+@onready var original_collision_mask := collision_mask
+## Original collision layer of objects that are picked up
+@onready var original_collision_layer := collision_layer
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
+# When the node enters the scene tree for the first time.
+func _ready() -> void:
 	# Get all grab points
-	for child in get_children():
+	for child: Node in get_children():
 		var grab_point := child as XRToolsGrabPoint
 		if grab_point:
 			_grab_points.push_back(grab_point)
 
 
-# Called when the node exits the tree
-func _exit_tree():
+# When the node exits the tree
+func _exit_tree() -> void:
 	# Skip if not picked up
 	if not is_instance_valid(_grab_driver):
 		return
@@ -145,7 +142,19 @@ func _exit_tree():
 		_grab_driver.secondary.release()
 
 
-# Test if this object can be picked up
+## When user presses the action button while holding this object
+func action() -> void:
+	# let interested parties know
+	action_pressed.emit(self)
+
+
+## When user releases the action button while holding this object
+func action_release() -> void:
+	# let interested parties know
+	action_released.emit(self)
+
+
+## Tests if this object can be picked up
 func can_pick_up(by: Node3D) -> bool:
 	# Refuse if not enabled
 	if not enabled:
@@ -167,77 +176,44 @@ func can_pick_up(by: Node3D) -> bool:
 	return true
 
 
-# Test if this object is picked up
-func is_picked_up() -> bool:
-	return _grab_driver and _grab_driver.primary
-
-
-# action is called when user presses the action button while holding this object
-func action():
-	# let interested parties know
-	action_pressed.emit(self)
-
-
-func controller_action(controller : XRController3D):
+## When the controller holding this object presses the action button
+func controller_action(controller: XRController3D) -> void:
 	# Let the grab points know about the action
 	if (
-		_grab_driver.primary and _grab_driver.primary.point
-		and _grab_driver.primary.controller == controller
+			_grab_driver.primary
+			and _grab_driver.primary.point
+			and _grab_driver.primary.controller == controller
 	):
 		_grab_driver.primary.point.action(self)
 
 	if (
-		_grab_driver.secondary and _grab_driver.secondary.point
-		and _grab_driver.secondary.controller == controller
+			_grab_driver.secondary
+			and _grab_driver.secondary.point
+			and _grab_driver.secondary.controller == controller
 	):
 		_grab_driver.secondary.point.action(self)
 
 
-# action_release is called when user releases the action button while holding this object
-func action_release():
-	# let interested parties know
-	action_released.emit(self)
-
-
-func controller_action_release(controller : XRController3D):
+## When the controller holding this object releases the action button
+func controller_action_release(controller: XRController3D) -> void:
 	# Let the grab points know about the action release
 	if (
-		_grab_driver.primary and _grab_driver.primary.point
-		and _grab_driver.primary.controller == controller
+			_grab_driver.primary
+			and _grab_driver.primary.point
+			and _grab_driver.primary.controller == controller
 	):
 		_grab_driver.primary.point.action_release(self)
 
 	if (
-		_grab_driver.secondary and _grab_driver.secondary.point
-		and _grab_driver.secondary.controller == controller
+			_grab_driver.secondary
+			and _grab_driver.secondary.point
+			and _grab_driver.secondary.controller == controller
 	):
 		_grab_driver.secondary.point.action_release(self)
 
 
-## This method requests highlighting of the [XRToolsPickable].
-## If [param from] is null then all highlighting requests are cleared,
-## otherwise the highlight request is associated with the specified node.
-func request_highlight(from : Node, on : bool = true) -> void:
-	# Save if we are highlighted
-	var old_highlighted := _highlighted
-
-	# Update the highlight requests dictionary
-	if not from:
-		_highlight_requests.clear()
-	elif on:
-		_highlight_requests[from] = from
-	else:
-		_highlight_requests.erase(from)
-
-	# Update the highlighted state
-	_highlighted = _highlight_requests.size() > 0
-
-	# Report any changes
-	if _highlighted != old_highlighted:
-		highlight_updated.emit(self, _highlighted)
-
-
-func drop():
+## When this object is dropped
+func drop() -> void:
 	# Skip if not picked up
 	if not is_picked_up():
 		return
@@ -250,12 +226,105 @@ func drop():
 	_grab_driver.primary.by.drop_object()
 
 
-func drop_and_free():
+## When the object is dropped and deleted
+func drop_and_free() -> void:
 	drop()
 	queue_free()
 
 
-# Called when this object is picked up
+## Gets the active grab-point this object is held by
+func get_active_grab_point() -> XRToolsGrabPoint:
+	# Skip if not picked up
+	if not is_picked_up():
+		return null
+
+	return _grab_driver.primary.point
+
+
+## Gets the node currently holding this object
+func get_picked_up_by() -> Node3D:
+	# Skip if not picked up
+	if not is_picked_up():
+		return null
+
+	# Get the primary pickup
+	return _grab_driver.primary.by
+
+
+## Gets the controller currently holding this object
+func get_picked_up_by_controller() -> XRController3D:
+	# Skip if not picked up
+	if not is_picked_up():
+		return null
+
+	# Get the primary pickup controller
+	return _grab_driver.primary.controller
+
+
+## Tests if this object is picked up
+func is_picked_up() -> bool:
+	return _grab_driver and _grab_driver.primary
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsPickable"
+
+
+## When this object is dropped
+func let_go(
+		by: Node3D,
+		p_linear_velocity: Vector3,
+		p_angular_velocity: Vector3
+) -> void:
+	# Skip if not picked up
+	if not is_picked_up():
+		return
+
+	# Get the grab information
+	var grab := _grab_driver.get_grab(by)
+	if not grab:
+		return
+
+	# Remove the grab from the driver and release the grab
+	_grab_driver.remove_grab(grab)
+	grab.release()
+
+	# Test if still grabbing
+	if _grab_driver.primary:
+		# Test if we need to swap grab-points
+		if is_instance_valid(_grab_driver.primary.hand_point):
+			# Verify the current primary grab point is a valid primary grab point
+			if _grab_driver.primary.hand_point.mode != XRToolsGrabPointHand.Mode.SECONDARY:
+				return
+
+			# Find a more suitable grab-point
+			var new_grab_point := _get_grab_point(_grab_driver.primary.by, null)
+			print_verbose("%s> held only by secondary, swapping grab points" % name)
+			switch_active_grab_point(new_grab_point)
+
+		# Grab is still good
+		return
+
+	# Drop the grab-driver
+	print_verbose("%s> dropping" % name)
+	_grab_driver.discard()
+	_grab_driver = null
+
+	# Restore RigidBody mode
+	freeze = restore_freeze
+	collision_mask = original_collision_mask
+	collision_layer = original_collision_layer
+
+	# Set velocity
+	linear_velocity = p_linear_velocity
+	angular_velocity = p_angular_velocity
+
+	# let interested parties know
+	dropped.emit(self)
+
+
+## When this object is picked up
 func pick_up(by: Node3D) -> void:
 	# Skip if not enabled
 	if not enabled:
@@ -311,11 +380,10 @@ func pick_up(by: Node3D) -> void:
 
 	# Construct the grab driver
 	if by.picked_up_ranged:
+		var grab := Grab.new(grabber, self, by_grab_point, false)
 		if ranged_grab_method == RangedMethod.LERP:
-			var grab := Grab.new(grabber, self, by_grab_point, false)
 			_grab_driver = XRToolsGrabDriver.create_lerp(self, grab, ranged_grab_speed)
 		else:
-			var grab := Grab.new(grabber, self, by_grab_point, false)
 			_grab_driver = XRToolsGrabDriver.create_snap(self, grab)
 	else:
 		var grab := Grab.new(grabber, self, by_grab_point, true)
@@ -326,100 +394,48 @@ func pick_up(by: Node3D) -> void:
 	grabbed.emit(self, by)
 
 
-# Called when this object is dropped
-func let_go(by: Node3D, p_linear_velocity: Vector3, p_angular_velocity: Vector3) -> void:
+## Requests highlighting of the [XRToolsPickable].
+## If [param from] is null, then all highlighting requests are cleared,
+## otherwise the highlight request is associated with the specified node.
+func request_highlight(from: Node, on: bool = true) -> void:
+	# Save if we are highlighted
+	var old_highlighted := _highlighted
+
+	# Update the highlight requests dictionary
+	if not from:
+		_highlight_requests.clear()
+	elif on:
+		_highlight_requests[from] = from
+	else:
+		_highlight_requests.erase(from)
+
+	# Update the highlighted state
+	_highlighted = _highlight_requests.size() > 0
+
+	# Report any changes
+	if _highlighted != old_highlighted:
+		highlight_updated.emit(self, _highlighted)
+
+
+## Switches the active grab-point for this object
+func switch_active_grab_point(grab_point: XRToolsGrabPoint) -> void:
 	# Skip if not picked up
 	if not is_picked_up():
 		return
-
-	# Get the grab information
-	var grab := _grab_driver.get_grab(by)
-	if not grab:
-		return
-
-	# Remove the grab from the driver and release the grab
-	_grab_driver.remove_grab(grab)
-	grab.release()
-
-	# Test if still grabbing
-	if _grab_driver.primary:
-		# Test if we need to swap grab-points
-		if is_instance_valid(_grab_driver.primary.hand_point):
-			# Verify the current primary grab point is a valid primary grab point
-			if _grab_driver.primary.hand_point.mode != XRToolsGrabPointHand.Mode.SECONDARY:
-				return
-
-			# Find a more suitable grab-point
-			var new_grab_point := _get_grab_point(_grab_driver.primary.by, null)
-			print_verbose("%s> held only by secondary, swapping grab points" % name)
-			switch_active_grab_point(new_grab_point)
-
-		# Grab is still good
-		return
-
-	# Drop the grab-driver
-	print_verbose("%s> dropping" % name)
-	_grab_driver.discard()
-	_grab_driver = null
-
-	# Restore RigidBody mode
-	freeze = restore_freeze
-	collision_mask = original_collision_mask
-	collision_layer = original_collision_layer
-
-	# Set velocity
-	linear_velocity = p_linear_velocity
-	angular_velocity = p_angular_velocity
-
-	# let interested parties know
-	dropped.emit(self)
-
-
-## Get the node currently holding this object
-func get_picked_up_by() -> Node3D:
-	# Skip if not picked up
-	if not is_picked_up():
-		return null
-
-	# Get the primary pickup
-	return _grab_driver.primary.by
-
-
-## Get the controller currently holding this object
-func get_picked_up_by_controller() -> XRController3D:
-	# Skip if not picked up
-	if not is_picked_up():
-		return null
-
-	# Get the primary pickup controller
-	return _grab_driver.primary.controller
-
-
-## Get the active grab-point this object is held by
-func get_active_grab_point() -> XRToolsGrabPoint:
-	# Skip if not picked up
-	if not is_picked_up():
-		return null
-
-	return _grab_driver.primary.point
-
-
-## Switch the active grab-point for this object
-func switch_active_grab_point(grab_point : XRToolsGrabPoint):
-	# Skip if not picked up
-	if not is_picked_up():
-		return null
 
 	# Apply the grab point
 	_grab_driver.primary.set_grab_point(grab_point)
 
 
-## Find the most suitable grab-point for the grabber
-func _get_grab_point(grabber : Node3D, current : XRToolsGrabPoint) -> XRToolsGrabPoint:
+# Finds the most suitable grab-point for the grabber
+func _get_grab_point(
+		grabber: Node3D,
+		current: XRToolsGrabPoint,
+) -> XRToolsGrabPoint:
 	# Find the best grab-point
 	var fitness := 0.0
 	var point : XRToolsGrabPoint = null
-	for p in _grab_points:
+	for p: XRToolsGrabPoint in _grab_points:
 		var f := p.can_grab(grabber, current)
 		if f > fitness:
 			fitness = f


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to nine functions
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Add type to `Dictionary`
- Add types to `for` loop variables
- Add types to signal parameters
# Note
We are using a `Dictionary` for highlight requests, when we should really be using an `Array`. This is out of scope for this PR, though.
# Testing
The **Pickables** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.