### PR TITLE
Better format and static type Snap Zone

### DIFF
--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -3,73 +3,73 @@ class_name XRToolsSnapZone
 extends Area3D
 
 
-## Signal emitted when the snap-zone picks something up
-signal has_picked_up(what)
+## Emitted when the snap-zone picks something up
+signal has_picked_up(what: Node3D)
 
-## Signal emitted when the snap-zone drops something
+## Emitted when the snap-zone drops something
 signal has_dropped
 
-# Signal emitted when the highlight state changes
-signal highlight_updated(pickable, enable)
+## Emitted when the highlight state changes
+signal highlight_updated(pickable: XRToolsSnapZone, enable: bool)
 
-# Signal emitted when the highlight state changes
-signal close_highlight_updated(pickable, enable)
+## Emitted when the highlight state changes
+signal close_highlight_updated(pickable: XRToolsSnapZone, enable: bool)
 
 
-## Enumeration of snap mode
+## When to snap objects
 enum SnapMode {
 	DROPPED,	## Snap only when the object is dropped
 	RANGE,		## Snap whenever an object is in range
 }
 
 
-## Enable or disable snap-zone
-@export var enabled : bool = true: set = _set_enabled
+## Whether to snap objects
+@export var enabled := true: set = _set_enabled
 
 ## Optional audio stream to play when a object snaps to the zone
-@export var stash_sound : AudioStream
+@export var stash_sound: AudioStream
 
-## Grab distance
-@export var grab_distance : float = 0.3: set = _set_grab_distance
+## Distance at which objects can be grabbed from this snap zone
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var grab_distance := 0.3:
+	set = _set_grab_distance
 
-## Snap mode
-@export var snap_mode : SnapMode = SnapMode.DROPPED: set = _set_snap_mode
+## When to snap objects to this zone
+@export var snap_mode := SnapMode.DROPPED: set = _set_snap_mode
 
 ## Require snap items to be in specified group
-@export var snap_require : String = ""
+@export var snap_require := ""
 
 ## Deny snapping items in the specified group
-@export var snap_exclude : String = ""
+@export var snap_exclude := ""
 
 ## Require grab-by to be in the specified group
-@export var grab_require : String = ""
+@export var grab_require := ""
 
-## Deny grab-by
-@export var grab_exclude : String= ""
+## Deny grab-by to be in the specified group
+@export var grab_exclude := ""
 
 ## Initial object in snap zone
-@export var initial_object : NodePath
+@export var initial_object: NodePath
 
 
-# Public fields
-var closest_object : Node3D = null
-var picked_up_object : Node3D = null
-var picked_up_ranged : bool = true
+## Closest object to this snap zone
+var closest_object: Node3D = null
+## Object inside snap zone
+var picked_up_object: Node3D = null
+## Whether to grab objects from afar
+var picked_up_ranged := true
 
 
-# Private fields
-var _object_in_grab_area = Array()
+var _object_in_grab_area: Array[Node3D]
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsSnapZone"
+@onready var _collider: CollisionShape3D = $CollisionShape3D
 
 
-func _ready():
+func _ready() -> void:
 	# Set collision shape radius
-	if has_node("CollisionShape3D") and "radius" in $CollisionShape3D.shape:
-		$CollisionShape3D.shape.radius = grab_distance
+	if has_node("CollisionShape3D") and "radius" in _collider.shape:
+		_collider.shape.radius = grab_distance
 
 	# Add important connections
 	if not body_entered.is_connected(_on_snap_zone_body_entered):
@@ -86,7 +86,7 @@ func _ready():
 
 
 # Called on each frame to update the pickup
-func _process(_delta):
+func _process(_delta: float) -> void:
 	# Skip if in editor or not enabled
 	if Engine.is_editor_hint() or not enabled:
 		return
@@ -100,7 +100,7 @@ func _process(_delta):
 		return
 
 	# Check for any object in range that can be grabbed
-	for o in _object_in_grab_area:
+	for o: Node3D in _object_in_grab_area:
 		# skip objects that can not be picked up
 		if not o.can_pick_up(self):
 			continue
@@ -110,7 +110,12 @@ func _process(_delta):
 		return
 
 
-# Pickable Method: snap-zone can be grabbed if holding object
+## Stops controller actions from doing anything to snap zones
+func action() -> void:
+	pass
+
+
+## Allows objects in snap-zone to be grabbed
 func can_pick_up(by: Node3D) -> bool:
 	# Refuse if not enabled
 	if not enabled:
@@ -132,33 +137,7 @@ func can_pick_up(by: Node3D) -> bool:
 	return true
 
 
-# Pickable Method: Snap points can't be picked up
-func is_picked_up() -> bool:
-	return false
-
-
-# Pickable Method: Gripper-actions can't occur on snap zones
-func action():
-	pass
-
-
-# Ignore highlighting requests from XRToolsFunctionPickup
-func request_highlight(from : Node, on : bool = true) -> void:
-	if is_instance_valid(picked_up_object):
-		picked_up_object.request_highlight(from, on)
-
-
-# Pickable Method: Object being grabbed from this snap zone
-func pick_up(_by: Node3D) -> void:
-	pass
-
-
-# Pickable Method: Player never graps snap-zone
-func let_go(_by: Node3D, _p_linear_velocity: Vector3, _p_angular_velocity: Vector3) -> void:
-	pass
-
-
-# Pickup Method: Drop the currently picked up object
+## Drops the currently picked-up object
 func drop_object() -> void:
 	if not is_instance_valid(picked_up_object):
 		return
@@ -170,7 +149,75 @@ func drop_object() -> void:
 	highlight_updated.emit(self, enabled)
 
 
-# Check for an initial object pickup
+## Tests if this snap zone has a picked up object
+func has_snapped_object() -> bool:
+	return is_instance_valid(picked_up_object)
+
+
+## Stops the snap zone itself from being picked up
+func is_picked_up() -> bool:
+	return false
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsSnapZone"
+
+
+## Stops this snap zone from being dropped (not that it ever gets picked up)
+func let_go(
+		_by: Node3D,
+		_p_linear_velocity: Vector3,
+		_p_angular_velocity: Vector3,
+) -> void:
+	pass
+
+
+## Stops this snap zone from being grabbed
+func pick_up(_by: Node3D) -> void:
+	pass
+
+
+## Picks up the specified object
+func pick_up_object(target: Node3D) -> void:
+	# check if already holding an object
+	if is_instance_valid(picked_up_object):
+		# skip if holding the target object
+		if picked_up_object == target:
+			return
+		# holding something else? drop it
+		drop_object()
+
+	# skip if target null or freed
+	if not is_instance_valid(target):
+		return
+
+	# Pick up our target. Note, target may do instant drop_and_free
+	picked_up_object = target
+	if has_node("AudioStreamPlayer3D"):
+		var player = get_node("AudioStreamPlayer3D")
+		if is_instance_valid(player):
+			if player.playing:
+				player.stop()
+
+			player.stream = stash_sound
+			player.play()
+
+	target.pick_up(self)
+
+	# If object picked up then emit signal
+	if is_instance_valid(picked_up_object):
+		has_picked_up.emit(picked_up_object)
+		highlight_updated.emit(self, false)
+
+
+## Ignores highlighting requests from XRToolsFunctionPickup
+func request_highlight(from: Node, on: bool = true) -> void:
+	if is_instance_valid(picked_up_object):
+		picked_up_object.request_highlight(from, on)
+
+
+# Checks for an initial object pickup
 func _initial_object_check() -> void:
 	# Check for an initial object
 	if initial_object:
@@ -181,14 +228,18 @@ func _initial_object_check() -> void:
 		highlight_updated.emit(self, enabled)
 
 	# Stop any audio from initial pickup
-	var audio := get_node("AudioStreamPlayer3D") if has_node("AudioStreamPlayer3D") else null
+	var audio := (
+			get_node("AudioStreamPlayer3D")
+			if has_node("AudioStreamPlayer3D")
+			else null
+	)
 
 	# Only stop if the user doesn't intend to auto-play
 	if audio is AudioStreamPlayer3D and !audio.autoplay:
 		audio.stop()
 
 
-# Called when a body enters the snap zone
+# CWhen a body enters the snap zone
 func _on_snap_zone_body_entered(target: Node3D) -> void:
 	# Ignore objects already known about
 	if _object_in_grab_area.find(target) >= 0:
@@ -223,13 +274,16 @@ func _on_snap_zone_body_entered(target: Node3D) -> void:
 		close_highlight_updated.emit(self, enabled)
 
 
-# Called when a body leaves the snap zone
+# When a body leaves the snap zone
 func _on_snap_zone_body_exited(target: Node3D) -> void:
 	# Ensure the object is not in our list
 	_object_in_grab_area.erase(target)
 
 	# Stop listening for dropped signals
-	if target.has_signal("dropped") and target.is_connected("dropped", _on_target_dropped):
+	if (
+			target.has_signal("dropped")
+			and target.is_connected("dropped", _on_target_dropped)
+	):
 		target.disconnect("dropped", _on_target_dropped)
 
 	# Hide highlight when nothing could be snapped
@@ -237,87 +291,7 @@ func _on_snap_zone_body_exited(target: Node3D) -> void:
 		close_highlight_updated.emit(self, false)
 
 
-# Test if this snap zone has a picked up object
-func has_snapped_object() -> bool:
-	return is_instance_valid(picked_up_object)
-
-
-# Pick up the specified object
-func pick_up_object(target: Node3D) -> void:
-	# check if already holding an object
-	if is_instance_valid(picked_up_object):
-		# skip if holding the target object
-		if picked_up_object == target:
-			return
-		# holding something else? drop it
-		drop_object()
-
-	# skip if target null or freed
-	if not is_instance_valid(target):
-		return
-
-	# Pick up our target. Note, target may do instant drop_and_free
-	picked_up_object = target
-	if has_node("AudioStreamPlayer3D"):
-		var player = get_node("AudioStreamPlayer3D")
-		if is_instance_valid(player):
-			if player.playing:
-				player.stop()
-			player.stream = stash_sound
-			player.play()
-
-	target.pick_up(self)
-
-	# If object picked up then emit signal
-	if is_instance_valid(picked_up_object):
-		has_picked_up.emit(picked_up_object)
-		highlight_updated.emit(self, false)
-
-
-# Called when the enabled property has been modified
-func _set_enabled(p_enabled: bool) -> void:
-	enabled = p_enabled
-	if is_inside_tree:
-		highlight_updated.emit(
-			self,
-			enabled and not is_instance_valid(picked_up_object))
-
-
-# Called when the grab distance has been modified
-func _set_grab_distance(new_value: float) -> void:
-	grab_distance = new_value
-	if is_inside_tree() and $CollisionShape3D:
-		$CollisionShape3D.shape.radius = grab_distance
-
-
-# Called when the snap mode property has been modified
-func _set_snap_mode(new_value: SnapMode) -> void:
-	snap_mode = new_value
-	if is_inside_tree():
-		_update_snap_mode()
-
-
-# Handle changes to the snap mode
-func _update_snap_mode() -> void:
-	match snap_mode:
-		SnapMode.DROPPED:
-			# Disable _process as we aren't using RANGE pickups
-			set_process(false)
-
-			# Start monitoring all objects in range for drop
-			for o in _object_in_grab_area:
-				o.connect("dropped", _on_target_dropped, CONNECT_DEFERRED)
-
-		SnapMode.RANGE:
-			# Enable _process to scan for RANGE pickups
-			set_process(true)
-
-			# Clear any dropped signal hooks
-			for o in _object_in_grab_area:
-				o.disconnect("dropped", _on_target_dropped)
-
-
-# Called when a target in our grab area is dropped
+# When a target in our grab area is dropped
 func _on_target_dropped(target: Node3D) -> void:
 	# Skip if not enabled
 	if not enabled:
@@ -334,3 +308,47 @@ func _on_target_dropped(target: Node3D) -> void:
 	# Pick up the target if we can
 	if target.can_pick_up(self):
 		pick_up_object(target)
+
+
+# When the enabled property has been modified
+func _set_enabled(p_enabled: bool) -> void:
+	enabled = p_enabled
+	if is_inside_tree:
+		highlight_updated.emit(
+				self,
+				enabled and not is_instance_valid(picked_up_object),
+		)
+
+
+# When the grab distance has been modified
+func _set_grab_distance(new_value: float) -> void:
+	grab_distance = new_value
+	if is_inside_tree() and _collider:
+		_collider.shape.radius = grab_distance
+
+
+# When the snap mode property has been modified
+func _set_snap_mode(new_value: SnapMode) -> void:
+	snap_mode = new_value
+	if is_inside_tree():
+		_update_snap_mode()
+
+
+# Handles changes to the snap mode
+func _update_snap_mode() -> void:
+	match snap_mode:
+		SnapMode.DROPPED:
+			# Disable _process as we aren't using RANGE pickups
+			set_process(false)
+
+			# Start monitoring all objects in range for drop
+			for o: Node3D in _object_in_grab_area:
+				o.connect("dropped", _on_target_dropped, CONNECT_DEFERRED)
+
+		SnapMode.RANGE:
+			# Enable _process to scan for RANGE pickups
+			set_process(true)
+
+			# Clear any dropped signal hooks
+			for o: Node3D in _object_in_grab_area:
+				o.disconnect("dropped", _on_target_dropped)

--- a/addons/godot-xr-tools/objects/snap_zone.tscn
+++ b/addons/godot-xr-tools/objects/snap_zone.tscn
@@ -4,7 +4,7 @@
 
 [sub_resource type="SphereShape3D" id="1"]
 resource_local_to_scene = true
-radius = 0.1
+radius = 0.3
 
 [node name="SnapZone" type="Area3D"]
 collision_layer = 4


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to three functions
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Add type to `Array`
- Add types to `for` loop variables
- Add types to signal parameters
# Note
I wanted to set the type of the `Array` to `XRToolsPickable`, but considering several methods check for signals that this class should have, I decided to err on the side of caution and set it to `Node3D`. If this is wrong, please let me know.

I also set the default radius in the `snap_zone.tscn` scene to be 0.3, simply because that's the default in `snap_zone.gd` as well.
# Testing
The **Pickables** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.