### PR TITLE
Better format and static type Teleport Area

### DIFF
--- a/addons/godot-xr-tools/objects/teleport_area.gd
+++ b/addons/godot-xr-tools/objects/teleport_area.gd
@@ -2,24 +2,26 @@
 class_name XRToolsTeleportArea
 extends Area3D
 
+## Checks for an [XRToolsPlayerBody] entering, and teleports them to a specific
+## [Node3D]
 
-## Target node
-@export var target : Node3D
-
-
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsTeleportArea"
+## Node at the target location
+@export var target: Node3D
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
+# When the node enters the scene tree for the first time.
+func _ready() -> void:
 	# Handle body entered
 	body_entered.connect(_on_body_entered)
 
 
-# Handle body entering area
-func _on_body_entered(body : Node3D) -> void:
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsTeleportArea"
+
+
+# Handles bodies entering this area
+func _on_body_entered(body: Node3D) -> void:
 	# Test if the body is the player
 	var player_body := body as XRToolsPlayerBody
 	if not player_body:


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Add return type to one function
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Add class doc
# Testing
The **Teleport Movement** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.