### PR TITLE
Better format and static type Viewport 2D in 3D Body

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
@@ -1,36 +1,36 @@
 extends XRToolsInteractableBody
 
 
-## Screen size
-@export var screen_size = Vector2(3.0, 2.0)
+## Size of the 3D quad
+@export var screen_size := Vector2(3.0, 2.0)
 
-## Viewport size
-@export var viewport_size = Vector2(100.0, 100.0)
+## How much of the scene to display
+@export var viewport_size := Vector2(100.0, 100.0)
 
 
 # Current mouse mask
 var _mouse_mask := 0
 
 # Viewport node
-var _viewport : Viewport
+var _viewport: Viewport
 
-# Dictionary of pointers to touch-index
-var _touches := {}
+# Dictionary of pointers and their touch-index
+var _touches: Dictionary[Node3D, int] = {}
 
-# Dictionary of pressed pointers
-var _presses := {}
+# Dictionary of pointers and whether they're pressed
+var _presses: Dictionary[Node3D, bool] = {}
 
 # Dominant pointer (index == 0)
-var _dominant : Node3D
+var _dominant: Node3D
 
 # Mouse pointer
-var _mouse : Node3D
+var _mouse: Node3D
 
 # Last mouse position
 var _mouse_last := Vector2.ZERO
 
 
-func _ready():
+func _ready() -> void:
 	# Get viewport node
 	_viewport = get_node("../Viewport")
 
@@ -38,8 +38,8 @@ func _ready():
 	pointer_event.connect(_on_pointer_event)
 
 
-## Convert intersection point to screen coordinate
-func global_to_viewport(p_at : Vector3) -> Vector2:
+## Converts intersection point to screen coordinates
+func global_to_viewport(p_at: Vector3) -> Vector2:
 	var t = $CollisionShape3D.global_transform
 	var at = t.affine_inverse() * p_at
 
@@ -50,8 +50,8 @@ func global_to_viewport(p_at : Vector3) -> Vector2:
 	return Vector2(at.x, at.y)
 
 
-# Pointer event handler
-func _on_pointer_event(event : XRToolsPointerEvent) -> void:
+# Handles pointer events
+func _on_pointer_event(event: XRToolsPointerEvent) -> void:
 	# Ignore if we have no viewport
 	if not is_instance_valid(_viewport):
 		return
@@ -61,7 +61,7 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 	var type := event.event_type
 
 	# Get the touch-index [0..]
-	var index : int = _touches.get(pointer, -1)
+	var index: int = _touches.get(pointer, -1)
 
 	# Create a new touch-index if necessary
 	if index < 0 or type == XRToolsPointerEvent.Type.ENTERED:
@@ -82,7 +82,7 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 	var last := global_to_viewport(event.last_position)
 
 	# Get/update pressed state
-	var pressed : bool
+	var pressed: bool
 	match type:
 		XRToolsPointerEvent.Type.PRESSED:
 			_presses[pointer] = true
@@ -141,36 +141,23 @@ func _on_pointer_event(event : XRToolsPointerEvent) -> void:
 			_mouse = null
 
 
-# Report touch-down event
-func _report_touch_down(index : int, at : Vector2) -> void:
-	var event := InputEventScreenTouch.new()
-	event.index = index
-	event.position = at
-	event.pressed = true
-	_viewport.push_input(event)
+# Finds the next free touch index
+func _next_touch_index() -> int:
+	# Get the current touches
+	var current := _touches.values()
+	current.sort()
+
+	# Look for a hole
+	for touch: int in current.size():
+		if current[touch] != touch:
+			return touch
+
+	# No hole, so add to end
+	return current.size()
 
 
-# Report touch-up event
-func _report_touch_up(index : int, at : Vector2) -> void:
-	var event := InputEventScreenTouch.new()
-	event.index = index
-	event.position = at
-	event.pressed = false
-	_viewport.push_input(event)
-
-
-# Report touch-move event
-func _report_touch_move(index : int, pressed : bool, from : Vector2, to : Vector2) -> void:
-	var event := InputEventScreenDrag.new()
-	event.index = index
-	event.position = to
-	event.pressure = 1.0 if pressed else 0.0
-	event.relative = to - from
-	_viewport.push_input(event)
-
-
-# Report mouse-down event
-func _report_mouse_down(at : Vector2) -> void:
+# Reports a mouse button press event
+func _report_mouse_down(at: Vector2) -> void:
 	var event := InputEventMouseButton.new()
 	event.button_index = 1
 	event.pressed = true
@@ -180,19 +167,8 @@ func _report_mouse_down(at : Vector2) -> void:
 	_viewport.push_input(event)
 
 
-# Report mouse-up event
-func _report_mouse_up(at : Vector2) -> void:
-	var event := InputEventMouseButton.new()
-	event.button_index = 1
-	event.pressed = false
-	event.position = at
-	event.global_position = at
-	event.button_mask = 0
-	_viewport.push_input(event)
-
-
-# Report mouse-move event
-func _report_mouse_move(pressed : bool, from : Vector2, to : Vector2) -> void:
+# Reports a mouse movement event
+func _report_mouse_move(pressed: bool, from: Vector2, to: Vector2) -> void:
 	var event := InputEventMouseMotion.new()
 	event.position = to
 	event.global_position = to
@@ -202,16 +178,45 @@ func _report_mouse_move(pressed : bool, from : Vector2, to : Vector2) -> void:
 	_viewport.push_input(event)
 
 
-# Find the next free touch index
-func _next_touch_index() -> int:
-	# Get the current touches
-	var current := _touches.values()
-	current.sort()
+# Reports a mouse button release event
+func _report_mouse_up(at: Vector2) -> void:
+	var event := InputEventMouseButton.new()
+	event.button_index = 1
+	event.pressed = false
+	event.position = at
+	event.global_position = at
+	event.button_mask = 0
+	_viewport.push_input(event)
 
-	# Look for a hole
-	for touch in current.size():
-		if current[touch] != touch:
-			return touch
 
-	# No hole so add to end
-	return current.size()
+# Reports a screen touch press event
+func _report_touch_down(index: int, at: Vector2) -> void:
+	var event := InputEventScreenTouch.new()
+	event.index = index
+	event.position = at
+	event.pressed = true
+	_viewport.push_input(event)
+
+
+# Reports  a screen drag event
+func _report_touch_move(
+		index: int,
+		pressed: bool,
+		from: Vector2,
+		to: Vector2,
+) -> void:
+	var event := InputEventScreenDrag.new()
+	event.index = index
+	event.position = to
+	event.pressure = 1.0 if pressed else 0.0
+	event.relative = to - from
+	_viewport.push_input(event)
+
+
+# Reports a screen touch release event
+func _report_touch_up(index: int, at: Vector2) -> void:
+	var event := InputEventScreenTouch.new()
+	event.index = index
+	event.position = at
+	event.pressed = false
+	_viewport.push_input(event)


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to one function
- Format multiline statement for better readability
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Add types to `Dictionary`s
- Add type to `for` loop variable
# Testing
The **Main Menu** scene and the **Pointer** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.