### PR TITLE
Better format and static type World Grab Area

### DIFF
--- a/addons/godot-xr-tools/objects/world_grab_area.gd
+++ b/addons/godot-xr-tools/objects/world_grab_area.gd
@@ -3,46 +3,59 @@
 class_name XRToolsWorldGrabArea
 extends Area3D
 
-
 ## XR Tools World-Grab Area
 ##
-## This script adds world-grab areas to an environment
+## This script adds world-grab areas to an environment.
 ##
 ## For world-grab to work, the player must have an [XRToolsMovementWorldGrab]
 ## node configured appropriately.
 
 
-## If true, the grip control must be held to keep holding the climbable
-var press_to_hold : bool = true
+## Whether the grip control must be held to keep holding the world-grab area
+var press_to_hold := true
 
-## Dictionary of temporary grab-handles indexed by the pickup node.
-var grab_locations := {}
-
-
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsWorldGrabArea"
+## Dictionary of pickup nodes and their temporary grab-handles
+var grab_locations: Dictionary[int, Node3D] = {}
 
 
-# Called by XRToolsFunctionPickup
-func is_picked_up() -> bool:
-	return false
+## Ignores user pressing the action button while holding this object
+func action() -> void:
+	pass
 
+
+## Allows always being grabbed
 func can_pick_up(_by: Node3D) -> bool:
 	return true
 
-# Called by XRToolsFunctionPickup when user presses the action button while holding this object
-func action():
+
+## Gets the grab handle
+func get_grab_handle(p: Node3D) -> Node3D:
+	return grab_locations.get(p.get_instance_id())
+
+
+## Called by [XRToolsFunctionPickup] when this is let go by a controller
+func let_go(
+		_by: Node3D,
+		_p_linear_velocity: Vector3,
+		_p_angular_velocity: Vector3,
+) -> void:
 	pass
 
-# Ignore highlighting requests from XRToolsFunctionPickup
-func request_highlight(_from, _on) -> void:
-	pass
 
-# Called by XRToolsFunctionPickup when this is picked up by a controller
+## Allows always being grabbed
+func is_picked_up() -> bool:
+	return false
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsWorldGrabArea"
+
+
+## Called by [XRToolsFunctionPickup] when this is picked up by a controller
 func pick_up(by: Node3D) -> void:
 	# Get the ID to save the grab handle under
-	var id = by.get_instance_id()
+	var id := by.get_instance_id()
 
 	# Get or construct the grab handle
 	var handle = grab_locations.get(id)
@@ -55,10 +68,7 @@ func pick_up(by: Node3D) -> void:
 	# climbable it will move as the climbable moves
 	handle.global_transform = by.global_transform
 
-# Called by XRToolsFunctionPickup when this is let go by a controller
-func let_go(_by: Node3D, _p_linear_velocity: Vector3, _p_angular_velocity: Vector3) -> void:
-	pass
 
-# Get the grab handle
-func get_grab_handle(p: Node3D) -> Node3D:
-	return grab_locations.get(p.get_instance_id())
+## Ignores highlighting requests from [XRToolsFunctionPickup]
+func request_highlight(_from: XRToolsFunctionPickup, _on: bool) -> void:
+	pass


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Add return type to one function
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Add type to `Dictionary`
# Testing
The **World Grab** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.