### PR TITLE
Better format and static type Ground Physics

### DIFF
--- a/addons/godot-xr-tools/overrides/ground_physics.gd
+++ b/addons/godot-xr-tools/overrides/ground_physics.gd
@@ -2,10 +2,9 @@
 class_name XRToolsGroundPhysics
 extends Node
 
-
 ## XR Tools Ground Physics Data
 ##
-## This script override the default ground physics settings of the
+## This script overrides the default ground physics settings of the
 ## [XRToolsPlayerBody] when they are standing on a specific type of ground.
 ##
 ## In order to override the ground physics properties, the user must add a
@@ -13,29 +12,31 @@ extends Node
 ## enable the appropriate flags and provide new values.
 
 
-## XRToolsGroundPhysicsSettings to apply
-@export var physics : XRToolsGroundPhysicsSettings
+## [XRToolsGroundPhysicsSettings] to apply
+@export var physics: XRToolsGroundPhysicsSettings
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
+## Gets the physics from a ground physics node
+static func get_physics(
+		node: XRToolsGroundPhysics,
+		default: XRToolsGroundPhysicsSettings,
+) -> XRToolsGroundPhysicsSettings:
+	return node.physics as XRToolsGroundPhysicsSettings if node else default
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
 	return xr_name == "XRToolsGroundPhysics"
 
 
-# This method verifies the ground physics has a valid configuration.
+# Verifies the ground physics has a valid configuration.
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := PackedStringArray()
 
 	# Verify physics specified
-	if !physics:
+	if not physics:
 		warnings.append("Physics must be specified")
-	elif !physics is XRToolsGroundPhysicsSettings:
+	elif not physics is XRToolsGroundPhysicsSettings:
 		warnings.append("Physics must be an XRToolsGroundPhysicsSettings")
 
 	return warnings
-
-# Get the physics from a ground physics node
-static func get_physics(
-		node: XRToolsGroundPhysics,
-		default: XRToolsGroundPhysicsSettings) -> XRToolsGroundPhysicsSettings:
-	return node.physics as XRToolsGroundPhysicsSettings if node else default


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Reorder functions in accordance with the style guide above
- Format multiline statement for better readability
# Testing
Technically, this node is not used anywhere, but the **Sprinting** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.