### PR TITLE
Better format and static type Fade Collision

### DIFF
--- a/addons/godot-xr-tools/player/fade/fade_collision.gd
+++ b/addons/godot-xr-tools/player/fade/fade_collision.gd
@@ -3,35 +3,27 @@ class_name XRToolsFadeCollision
 extends Node3D
 
 
-
-@export_category("Collison")
-
 ## Layers to collide with
-@export_flags_3d_physics var collision_layers : int = 3
+@export_flags_3d_physics var collision_layers := 3
 
 ## Collision distance at which fading begins
-@export var fade_start_distance : float = 0.3
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var fade_start_distance := 0.3
 
 ## Collision distance for totally obscuring the view
-@export var fade_full_distance : float = 0.15
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var fade_full_distance := 0.15
 
 
 # Shape to use for collision detection
-var _collision_shape : Shape3D
+var _collision_shape: Shape3D
 
 # Parameters to use for collision detection
-var _collision_parameters : PhysicsShapeQueryParameters3D
+var _collision_parameters: PhysicsShapeQueryParameters3D
 
 # World space to use for collision detection
-var _space : PhysicsDirectSpaceState3D
+var _space: PhysicsDirectSpaceState3D
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsFadeCollision"
-
-
-# Called when the node enters the scene tree for the first time.
+# When the node enters the scene tree for the first time.
 func _ready() -> void:
 	# Construct a sphere for the collision shape
 	_collision_shape = SphereShape3D.new()
@@ -47,16 +39,16 @@ func _ready() -> void:
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _physics_process(_delta : float) -> void:
+func _physics_process(_delta: float) -> void:
 	# Update the collision parameters to include our global location
 	_collision_parameters.transform = global_transform
 
 	# Find closest collision
-	var results = _space.get_rest_info(_collision_parameters)
+	var results := _space.get_rest_info(_collision_parameters)
 	if "point" in results:
 		# Collision detected, calculate distance to closet collision point
-		var delta_pos = global_transform.origin - results["point"]
-		var length = delta_pos.length()
+		var delta_pos: Vector3 = global_transform.origin - results["point"]
+		var length := delta_pos.length()
 
 		# Fade based on distance
 		var alpha := inverse_lerp(fade_start_distance, fade_full_distance, length)
@@ -64,3 +56,8 @@ func _physics_process(_delta : float) -> void:
 	else:
 		# No collision
 		XRToolsFade.set_fade(self, Color(0, 0, 0, 0))
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsFadeCollision"


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Add suffixes to two export variables
# Testing
The **Basic Movement** demo had no issues not present in `master`. Do note that `master` currently has a bug where it is possible to peek through the wall and see the outside world clearly.
# Disclaimer
No generative AI was used to enhance or create the code given here.