### PR TITLE
Better format Rumbler

### DIFF
--- a/addons/godot-xr-tools/rumble/rumbler.gd
+++ b/addons/godot-xr-tools/rumble/rumbler.gd
@@ -5,65 +5,16 @@ extends Node
 
 ## XR Tools Rumbler
 ##
-## A node you attach to handle (contain and make easy to activate/cancel)
-## a particular rumble event.
+## Attaches to a node to contain, activate or cancel rumble events.
 
-## The details of this rumbler
-@export var event: XRToolsRumbleEvent : set = _set_event
+## Details of this rumbler
+@export var event: XRToolsRumbleEvent: set = _set_event
 
+## Controller to rumble
 @export var target: XRNode3D
 
-## Activate the event
-func rumble() -> void:
-	if is_instance_valid(target):
-		XRToolsRumbleManager.add(self, event, [target.tracker])
 
-
-## Cancel the event
-func cancel() -> void:
-	XRToolsRumbleManager.clear(self)
-
-
-## Rumble on the hand which owns the node
-func rumble_hand(hand_child: Node3D) -> void:
-	var hand: XRNode3D = XRHelpers.get_xr_controller(hand_child)
-	if is_instance_valid(hand):
-		XRToolsRumbleManager.add(self, event, [hand.tracker])
-
-
-## Cancel rumble for the hand which owns the node
-func cancel_hand(hand_child: Node3D) -> void:
-	var hand: XRNode3D = XRHelpers.get_xr_controller(hand_child)
-	if is_instance_valid(hand):
-		XRToolsRumbleManager.clear(self, [hand.tracker])
-
-
-## Activate the event, if provided the XR player body
-func rumble_if_player_body(body: Node3D) -> void:
-	if is_instance_valid(body) and body is XRToolsPlayerBody:
-		rumble()
-
-
-## Cancel rumble for the event, if provided the XR player body
-func cancel_if_player_body(body: Node3D) -> void:
-	if is_instance_valid(body) and body is XRToolsPlayerBody:
-		cancel()
-
-
-## Activate the event during an active pointer event
-func rumble_pointer(event : XRToolsPointerEvent) -> void:
-	if event.event_type == XRToolsPointerEvent.Type.PRESSED:
-		rumble_hand(event.pointer)
-	elif event.event_type == XRToolsPointerEvent.Type.RELEASED:
-		cancel_hand(event.pointer)
-
-
-func _set_event(p_event: XRToolsRumbleEvent) -> void:
-	event = p_event
-	update_configuration_warnings()
-
-
-# This method verifies the hand has a valid configuration.
+# Verifies the hand has a valid configuration.
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := PackedStringArray()
 
@@ -74,3 +25,52 @@ func _get_configuration_warnings() -> PackedStringArray:
 	# Return warnings
 	return warnings
 
+
+## Cancels the rumble event
+func cancel() -> void:
+	XRToolsRumbleManager.clear(self)
+
+
+## Cancels rumble for the hand which owns the node
+func cancel_hand(hand_child: Node3D) -> void:
+	var hand: XRNode3D = XRHelpers.get_xr_controller(hand_child)
+	if is_instance_valid(hand):
+		XRToolsRumbleManager.clear(self, [hand.tracker])
+
+
+## Cancels rumble for the event, if provided the [XRPlayerBody]
+func cancel_if_player_body(body: Node3D) -> void:
+	if is_instance_valid(body) and body is XRToolsPlayerBody:
+		cancel()
+
+
+## Activates the rumble event
+func rumble() -> void:
+	if is_instance_valid(target):
+		XRToolsRumbleManager.add(self, event, [target.tracker])
+
+
+## Rumbles on the hand which owns the node
+func rumble_hand(hand_child: Node3D) -> void:
+	var hand: XRNode3D = XRHelpers.get_xr_controller(hand_child)
+	if is_instance_valid(hand):
+		XRToolsRumbleManager.add(self, event, [hand.tracker])
+
+
+## Activates the event, if provided the [XRPlayerBody]
+func rumble_if_player_body(body: Node3D) -> void:
+	if is_instance_valid(body) and body is XRToolsPlayerBody:
+		rumble()
+
+
+## Activates the event during an active pointer event
+func rumble_pointer(event: XRToolsPointerEvent) -> void:
+	if event.event_type == XRToolsPointerEvent.Type.PRESSED:
+		rumble_hand(event.pointer)
+	elif event.event_type == XRToolsPointerEvent.Type.RELEASED:
+		cancel_hand(event.pointer)
+
+
+func _set_event(p_event: XRToolsRumbleEvent) -> void:
+	event = p_event
+	update_configuration_warnings()


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
# Testing
This node is not a part of any scene. I'm unsure on how to test this.
# Disclaimer
No generative AI was used to enhance or create the code given here.