### PR TITLE
Better format and static type Rumble Manager Queue

### DIFF
--- a/addons/godot-xr-tools/rumble/rumble_manager_queue.gd
+++ b/addons/godot-xr-tools/rumble/rumble_manager_queue.gd
@@ -1,12 +1,17 @@
 class_name XRToolsRumbleManagerQueue
 extends Resource
 
-# All currently-active events (Dictionary<Variant, XRToolsRumbleEvent>)
-var events: Dictionary
+## XR Tools Rumble Manager Queue
+##
+## Used to sort rumble events in order of arrival
 
-# All currently-active events' time remaining (Dictionary<Variant, int>)
-var time_remaining: Dictionary
+## All currently-active events
+var events: Dictionary[Variant, XRToolsRumbleEvent]
 
-func _init():
+## All currently-active events' remaining time
+var time_remaining: Dictionary[Variant, int]
+
+
+func _init() -> void:
 	events = {}
 	time_remaining = {}


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Clarify comments of variables and methods
- Add return type to one method
- Add types to `Dictionary`s
- Add class doc
# Testing
The **Rumble Manager** demo had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.