### PR TITLE
Better format and static type Scene Base

### DIFF
--- a/addons/godot-xr-tools/staging/scene_base.gd
+++ b/addons/godot-xr-tools/staging/scene_base.gd
@@ -2,90 +2,140 @@
 class_name XRToolsSceneBase
 extends Node3D
 
-
 ## XR Tools Scene Base Class
 ##
 ## This is our base scene for all our levels.  It ensures that we have all bits
-## in place to load our scene into our staging scene.
+## in place to load our scene into our staging scene.[br][br]
 ##
 ## Developers can customize scene transitions by extending from this class and
 ## overriding the [method scene_loaded] behavior.
 
 
-## This signal is used to request the staging transition to the main-menu
-## scene. Developers should use [method exit_to_main_menu] rather than
+## Emitted when requesting the staging transition to the main-menu scene.[br][br]
+## [b]Note[/b]: Developers should use [method exit_to_main_menu], rather than
 ## emitting this signal directly.
 signal request_exit_to_main_menu
 
-## This signal is used to request the staging transition to the specified
-## scene. Developers should use [method load_scene] rather than emitting
+## Emitted when requesting the staging transition to the specified scene, with
+## the [param user_data] parameter passed through staging to the new scenes.[br][br]
+## [b]Note[/b]: Developers should use [method load_scene], rather than emitting
 ## this signal directly.
-##
-## The [param user_data] parameter is passed through staging to the new scenes.
-signal request_load_scene(p_scene_path, user_data)
+signal request_load_scene(p_scene_path: String, user_data: Variant)
 
-## This signal is used to request the staging reload this scene. Developers
-## should use [method reset_scene] rather than emitting this signal directly.
-##
-## The [param user_data] parameter is passed through staging to the new scenes.
-signal request_reset_scene(user_data)
+## Emitted when requesting the staging to reload this scene, with the
+## [param user_data] parameter is passed through staging to the new scenes.[br][br]
+## [b]Note[/b]: Developers should use [method reset_scene], rather than emitting
+## this signal directly
+signal request_reset_scene(user_data: Variant)
 
-## This signal is used to request the staging quit the XR experience. Developers
-## should use [method quit] rather than emitting this signal directly.
+## Emitted when requesting the staging to quit the XR experience.[br][br]
+## [b]Note[/b]: Developers should use [method quit], rather than emitting this
+## signal directly.
 signal request_quit
 
 
 # This file contains methods with parameters that are unused, however they are
-# documented and intended to be overridden in derived classes. As such unused
+# documented and intended to be overridden in derived classes. As such, unused
 # parameter warnings need to be disabled.
 #
 # warning-ignore:unused_parameter
 # gdlint:disable=unused-argument
 
+var _camera: XRCamera3D
+var _xr_origin: XROrigin3D
 
-## Interface
 
 func _ready() -> void:
-	pass
+	_camera = $XROrigin3D/XRCamera3D
+	_xr_origin = $XROrigin3D
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
-	return xr_name == "XRToolsSceneBase"
-
-
-## This method center the player on the [param p_transform] transform.
-func center_player_on(p_transform : Transform3D):
+## Centers the player on the [param p_transform] transform.
+func center_player_on(p_transform: Transform3D) -> void:
 	# In order to center our player so the players feet are at the location
 	# indicated by p_transform, and having our player looking in the required
 	# direction, we must offset this transform using the cameras transform.
 
 	# So we get our current camera transform in local space
-	var camera_transform = $XROrigin3D/XRCamera3D.transform
+	var camera_transform: Transform3D = _camera.transform
 
 	# We obtain our view direction and zero out our height
-	var view_direction = camera_transform.basis.z
+	var view_direction: Vector3 = camera_transform.basis.z
 	view_direction.y = 0
 
 	# Now create the transform that we will use to offset our input with
-	var transform : Transform3D
+	var transform: Transform3D
 	transform = transform.looking_at(-view_direction, Vector3.UP)
 	transform.origin = camera_transform.origin
 	transform.origin.y = 0
 
 	# And now update our origin point
-	$XROrigin3D.global_transform = (p_transform * transform.inverse()).orthonormalized()
+	_xr_origin.global_transform = (
+			p_transform * transform.inverse()
+	).orthonormalized()
 
 	# If we have a player body, we need to set its starting position too.
-	var player_body : XRToolsPlayerBody = XRToolsPlayerBody.find_instance($XROrigin3D)
+	var player_body := XRToolsPlayerBody.find_instance(_xr_origin)
 	if player_body:
 		player_body.global_transform = p_transform
 
 
-## This method is called when the scene is loaded, but before it becomes visible.
+## Transitions to the main menu scene. The default implementation sends the
+## [signal request_exit_to_main_menu] signal.[br][br]
+##
+## Custom scene classes can override this function to add their logic, but
+## should usually call this super method.
+func exit_to_main_menu() -> void:
+	request_exit_to_main_menu.emit()
+
+
+## Adds support for [method is_xr_class] on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsSceneBase"
+
+
+## Transitions to the specified scene. The default implementation sends the
+## [signal request_load_scene].
+##
+## Custom scene classes can override this function to add their logic, but
+## should usually call this super method.
+##
+## The [param user_data] parameter is passed to the new scene, and can be used
+## to relay information through the transition. The default behavior of
+## [method scene_loaded] will attempt to interpret it as  a spawn-point for the
+## player as node-name, Vector3, or Transform3D.
+##
+## See [method scene_loaded] for options to provide advanced scene-transition
+## functionality.
+func load_scene(p_scene_path: String, user_data: Variant = null) -> void:
+	request_load_scene.emit(p_scene_path, user_data)
+
+
+## Resets the current scene. The default implementation sends the
+## [signal request_reset_scene], which triggers a reload of the current scene.[br][br]
+##
+## Custom scene classes can override this method to implement faster reset
+## logic than is performed by the brute-force scene-reload performed by
+## staging.[br][br]
+##
+## Any [param user_data] provided is passed into the new scene.
+func reset_scene(user_data: Variant = null) -> void:
+	request_reset_scene.emit(user_data)
+
+
+## Immediately before this scene is unloaded.[br][br]
 ##
 ## The [param user_data] parameter is an optional parameter passed in when the
-## scene is loaded - usually from the previous scene. By default the
+## scene transition is requested.
+func scene_exiting(user_data = null) -> void:
+	# Called right before we remove this scene
+	pass
+
+
+## When the scene is loaded, but before it becomes visible.[br][br]
+##
+## The [param user_data] parameter is an optional parameter passed in when the
+## scene is loaded - usually from the previous scene. By default, the
 ## user_data can be a [String] spawn-point node-name, [Vector3], [Transform3D],
 ## an object with a 'get_spawn_position' method, or null to spawn at the scenes
 ## [XROrigin3D] location.
@@ -94,20 +144,21 @@ func center_player_on(p_transform : Transform3D):
 ## method and calling the super() with any desired spawn transform. This could
 ## come from a field of an advanced user_data class-object, or from a game-state
 ## singleton.
-func scene_loaded(user_data = null):
-	# Called after scene is loaded
-
+func scene_loaded(user_data: Variant = null) -> void:
 	# Make sure our camera becomes the current camera
-	$XROrigin3D/XRCamera3D.current = true
-	$XROrigin3D.current = true
+	_camera.current = true
+	_xr_origin.current = true
 
 	# Start by assuming the user_data contains spawn position information.
-	var spawn_position = user_data
+	var spawn_position: Variant = user_data
 
-	# If the user_data is an object with a 'get_spawn_position' method then
-	# call it (with this [XRToolsSceneBase] allowing it to inspect the scene
+	# If the user_data is an object with a 'get_spawn_position' method, then
+	# call it (with this [XRToolsSceneBase], allowing it to inspect the scene
 	# if necessary) and use the return value as the spawn position information.
-	if typeof(user_data) == TYPE_OBJECT and user_data.has_method("get_spawn_position"):
+	if (
+			typeof(user_data) == TYPE_OBJECT
+			and user_data.has_method("get_spawn_position")
+	):
 		spawn_position = user_data.get_spawn_position(self)
 
 	# Get the spawn [Transform3D] by inspecting the spawn position value for
@@ -116,10 +167,10 @@ func scene_loaded(user_data = null):
 	# - String name of a Node3D to spawn at
 	# - Vector3 to spawn at
 	# - Transform3D to spawn at
-	var spawn_transform : Transform3D = $XROrigin3D.global_transform
+	var spawn_transform := _xr_origin.global_transform
 	match typeof(spawn_position):
 		TYPE_STRING: # Name of Node3D to spawn at
-			var node = find_child(spawn_position)
+			var node := find_child(spawn_position)
 			if node is Node3D:
 				spawn_transform = node.global_transform
 
@@ -133,80 +184,27 @@ func scene_loaded(user_data = null):
 	center_player_on(spawn_transform)
 
 
-## This method is called when the scene becomes fully visible to the user.
-##
-## The [param user_data] parameter is an optional parameter passed in when the
-## scene is loaded - usually from the previous scene.
-func scene_visible(user_data = null):
-	# Called after the scene becomes fully visible
-	pass
-
-
-## This method is called before the start of transition from this scene to a
-## new scene.
+## Before the start of transition from this scene to a new scene.[br][br]
 ##
 ## The [param user_data] parameter is an optional parameter passed in when the
 ## scene transition is requested.
-func scene_pre_exiting(user_data = null):
+func scene_pre_exiting(user_data: Variant = null) -> void:
 	# Called before we start fading out and removing our scene
 	pass
 
 
-## This method is called immediately before this scene is unloaded.
-##
+## When the scene becomes fully visible to the user.[br][br]
 ##
 ## The [param user_data] parameter is an optional parameter passed in when the
-## scene transition is requested.
-func scene_exiting(user_data = null):
-	# called right before we remove this scene
+## scene is loaded - usually from the previous scene.
+func scene_visible(user_data: Variant = null) -> void:
+	# Called after the scene becomes fully visible
 	pass
 
 
-## Transition to the main menu scene
-##
-## This function is used to transition to the main menu scene. The default
-## implementation sends the [signal request_exit_to_main_menu].
-##
-## Custom scene classes can override this function to add their logic, but
-## should usually call this super method.
-func exit_to_main_menu() -> void:
-	emit_signal("request_exit_to_main_menu")
-
-
-## This function is used to transition to the specified scene. The default
-## implementation sends the [signal request_load_scene].
-##
-## Custom scene classes can override this function to add their logic, but
-## should usually call this super method.
-##
-## The [param user_data] parameter is passed to the new scene, and can be used
-## to relay information through the transition. The default behavior of
-## [method scene_loaded] will attempt to interpret it as  a spawn-point for the
-## player as node-name, Vector3, or Transform3D.
-##
-## See [method scene_loaded] for options to provide advanced scene-transition
-## functionality.
-func load_scene(p_scene_path : String, user_data = null) -> void:
-	emit_signal("request_load_scene", p_scene_path, user_data)
-
-
-## This function is used to reset the current scene. The default
-## implementation sends the [signal request_reset_scene] which triggers
-## a reload of the current scene.
-##
-## Custom scene classes can override this method to implement faster reset
-## logic than is performed by the brute-force scene-reload performed by
-## staging.
-##
-## Any [param user_data] provided is passed into the new scene.
-func reset_scene(user_data = null) -> void:
-	emit_signal("request_reset_scene", user_data)
-
-
-## This function is used to quit the XR experience. The default
-## implementation sends the [signal request_quit] which triggers
-## the XR experience to end.
+## Quits the XR experience. The default implementation sends the
+## [signal request_quit] signal, which triggers the XR experience to end.[br][br]
 ##
 ## Custom scene classes can override this method to add their logic.
 func quit() -> void:
-	emit_signal("request_quit")
+	request_quit.emit()


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Format multiline statements for better readability
- Add types to local variables
- Add return type to five methods
- Add BBCode to class doc
- Add types to signal parameters
- Replace repeated node paths with onready variables
- Replace `emit_signal(signal, Callable)` with `signal.emit(Callable)`
# Note
I've left the variable `user_data` as Variant, since that seems to be custom data that can be overridden by the user.
# Testing
The **Main Menu** scene had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.