### PR TITLE
Better format and static type User Settings

### DIFF
--- a/addons/godot-xr-tools/user_settings/user_settings.gd
+++ b/addons/godot-xr-tools/user_settings/user_settings.gd
@@ -1,8 +1,7 @@
 extends Node
 
-
-## Emitted when the WebXR primary is changed (either by the user or auto detected).
-signal webxr_primary_changed (value)
+## Emitted when the WebXR primary is changed (either by the user or auto-detected).
+signal webxr_primary_changed(value: WebXRPrimary)
 
 
 enum WebXRPrimary {
@@ -14,46 +13,87 @@ enum WebXRPrimary {
 
 @export_group("Input")
 
-## User setting for snap-turn
-@export var snap_turning : bool = true
+## Whether the user wants snap-turning instead of smooth turning
+@export var snap_turning := true
 
-## User setting for y axis dead zone
-@export var y_axis_dead_zone : float = 0.1
+## Y-axis deadzone for controller joysticks
+@export var y_axis_dead_zone := 0.1
 
-## User setting for y axis dead zone
-@export var x_axis_dead_zone : float = 0.2
+## X-axis deadzone for controller joysticks
+@export var x_axis_dead_zone := 0.2
 
-## Used to control rumble like volume
+## Intensity of rumble (where 1.0 is the highest and 0.0 is none at all)
 @export_range(0.0, 1.0, 0.05) var haptics_scale := 1.0
 
 @export_group("Player")
 
-## User setting for player height
-@export var player_height : float = 1.85: set = set_player_height
+## Player's height from the floor
+@export var player_height := 1.85: set = set_player_height
 
 @export_group("WebXR")
 
 ## User setting for WebXR primary
-@export var webxr_primary : WebXRPrimary = WebXRPrimary.AUTO: set = set_webxr_primary
+@export var webxr_primary := WebXRPrimary.AUTO: set = set_webxr_primary
 
 
-## Settings file name to persist user settings
-var settings_file_name : String = "user://xtools_user_settings.json"
+## File name to persist user settings
+var settings_file_name := "user://xtools_user_settings.json"
 
 ## Records the first input to generate input (thumbstick or trackpad).
 var webxr_auto_primary := 0
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	var webxr_interface = XRServer.find_interface("WebXR")
+# When the node enters the scene tree for the first time.
+func _ready() -> void:
+	var webxr_interface := XRServer.find_interface("WebXR")
 	if webxr_interface:
 		XRServer.tracker_added.connect(self._on_webxr_tracker_added)
 
 	_load()
 
 
-## Reset to default values
+## Helps remap input vector with deadzone values
+func get_adjusted_vector2(
+		p_controller: XRController3D,
+		p_input_action: String,
+) -> Vector2:
+	var vector := Vector2.ZERO
+	var original_vector := p_controller.get_vector2(p_input_action)
+
+	if abs(original_vector.y) > y_axis_dead_zone:
+		vector.y = remap(abs(original_vector.y), y_axis_dead_zone, 1, 0, 1)
+		if original_vector.y < 0:
+			vector.y *= -1
+
+	if abs(original_vector.x) > x_axis_dead_zone:
+		vector.x = remap(abs(original_vector.x), x_axis_dead_zone, 1, 0, 1)
+		if original_vector.x < 0:
+			vector.x *= -1
+
+	return vector
+
+
+## Gets the WebXR primary (taking into account auto-detection).
+func get_real_webxr_primary() -> WebXRPrimary:
+	if webxr_primary == WebXRPrimary.AUTO:
+		return webxr_auto_primary
+	return webxr_primary
+
+
+## Gets the action associated with a WebXR primary choice
+func get_webxr_primary_action(primary: WebXRPrimary) -> String:
+	match primary:
+		WebXRPrimary.THUMBSTICK:
+			return "thumbstick"
+
+		WebXRPrimary.TRACKPAD:
+			return "trackpad"
+
+		_:
+			return "auto"
+
+
+## Resets settings to default values
 func reset_to_defaults() -> void:
 	# Reset to defaults.
 	# Where applicable we obtain our project settings
@@ -65,45 +105,22 @@ func reset_to_defaults() -> void:
 	webxr_auto_primary = 0
 	haptics_scale = XRToolsRumbleManager.get_default_haptics_scale()
 
-## Set the player height property
-func set_player_height(new_value : float) -> void:
-	player_height = clamp(new_value, 1.0, 2.5)
 
-## Set the WebXR primary
-func set_webxr_primary(new_value : WebXRPrimary) -> void:
-	webxr_primary = new_value
-	if webxr_primary == WebXRPrimary.AUTO:
-		if webxr_auto_primary == 0:
-			# Don't emit the signal yet, wait until we detect which to use.
-			pass
-		else:
-			webxr_primary_changed.emit(webxr_auto_primary)
-	else:
-		webxr_primary_changed.emit(webxr_primary)
-
-
-## Gets the WebXR primary (taking into account auto detection).
-func get_real_webxr_primary() -> WebXRPrimary:
-	if webxr_primary == WebXRPrimary.AUTO:
-		return webxr_auto_primary
-	return webxr_primary
-
-
-## Save the settings to file
+## Saves the settings to file
 func save() -> void:
 	# Convert the settings to a dictionary
 	var settings := {
-		"input" : {
-			"default_snap_turning" : snap_turning,
-			"y_axis_dead_zone" : y_axis_dead_zone,
-			"x_axis_dead_zone" : x_axis_dead_zone,
-			"haptics_scale": haptics_scale
+		"input": {
+			"default_snap_turning": snap_turning,
+			"y_axis_dead_zone": y_axis_dead_zone,
+			"x_axis_dead_zone": x_axis_dead_zone,
+			"haptics_scale": haptics_scale,
 		},
-		"player" : {
-			"height" : player_height
+		"player": {
+			"height": player_height,
 		},
-		"webxr" : {
-			"webxr_primary" : webxr_primary,
+		"webxr": {
+			"webxr_primary": webxr_primary,
 		}
 	}
 
@@ -121,26 +138,31 @@ func save() -> void:
 	file.close()
 
 
-## Get the action associated with a WebXR primary choice
-func get_webxr_primary_action(primary : WebXRPrimary) -> String:
-	match primary:
-		WebXRPrimary.THUMBSTICK:
-			return "thumbstick"
-
-		WebXRPrimary.TRACKPAD:
-			return "trackpad"
-
-		_:
-			return "auto"
+## Sets the player's height
+func set_player_height(new_value: float) -> void:
+	player_height = clampf(new_value, 1.0, 2.5)
 
 
-## Load the settings from file
+## Sets the WebXR primary
+func set_webxr_primary(new_value: WebXRPrimary) -> void:
+	webxr_primary = new_value
+	if webxr_primary == WebXRPrimary.AUTO:
+		if webxr_auto_primary == 0:
+			# Don't emit the signal yet, wait until we detect which to use.
+			pass
+		else:
+			webxr_primary_changed.emit(webxr_auto_primary)
+	else:
+		webxr_primary_changed.emit(webxr_primary)
+
+
+# Loads the settings from file
 func _load() -> void:
 	# First reset our values
 	reset_to_defaults()
 
 	# Skip if no settings file found
-	if !FileAccess.file_exists(settings_file_name):
+	if not FileAccess.file_exists(settings_file_name):
 		return
 
 	# Attempt to open the settings file for reading
@@ -160,9 +182,9 @@ func _load() -> void:
 		return
 
 	# Parse our input settings
-	var settings : Dictionary = settings_raw
+	var settings: Dictionary = settings_raw
 	if settings.has("input"):
-		var input : Dictionary = settings["input"]
+		var input: Dictionary = settings["input"]
 		if input.has("default_snap_turning"):
 			snap_turning = input["default_snap_turning"]
 		if input.has("y_axis_dead_zone"):
@@ -174,25 +196,25 @@ func _load() -> void:
 
 	# Parse our player settings
 	if settings.has("player"):
-		var player : Dictionary = settings["player"]
+		var player: Dictionary = settings["player"]
 		if player.has("height"):
 			player_height = player["height"]
 
 	# Parse our WebXR settings
 	if settings.has("webxr"):
-		var webxr : Dictionary = settings["webxr"]
+		var webxr: Dictionary = settings["webxr"]
 		if webxr.has("webxr_primary"):
 			webxr_primary = webxr["webxr_primary"]
 
 
-## Used to connect to tracker events when using WebXR.
+# Connects to tracker events when using WebXR.
 func _on_webxr_tracker_added(tracker_name: StringName, _type: int) -> void:
 	if tracker_name == &"left_hand" or tracker_name == &"right_hand":
 		var tracker := XRServer.get_tracker(tracker_name)
 		tracker.input_vector2_changed.connect(self._on_webxr_vector2_changed)
 
 
-## Used to auto detect which "primary" input gets used first.
+# Auto-detects which "primary" input gets used first.
 func _on_webxr_vector2_changed(name: String, _vector: Vector2) -> void:
 	if webxr_auto_primary == 0:
 		if name == "thumbstick":
@@ -203,20 +225,3 @@ func _on_webxr_vector2_changed(name: String, _vector: Vector2) -> void:
 		if webxr_auto_primary != 0:
 			# Let the developer know which one is chosen.
 			webxr_primary_changed.emit(webxr_auto_primary)
-
-## Helper function to remap input vector with deadzone values
-func get_adjusted_vector2(p_controller, p_input_action):
-	var vector = Vector2.ZERO
-	var original_vector = p_controller.get_vector2(p_input_action)
-
-	if abs(original_vector.y) > y_axis_dead_zone:
-		vector.y = remap(abs(original_vector.y), y_axis_dead_zone, 1, 0, 1)
-		if original_vector.y < 0:
-			vector.y *= -1
-
-	if abs(original_vector.x) > x_axis_dead_zone:
-		vector.x = remap(abs(original_vector.x), x_axis_dead_zone, 1, 0, 1)
-		if original_vector.x < 0:
-			vector.x *= -1
-
-	return vector


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Format multiline statements for better readability
- Add return type to two methods
- Replace exclamation mark with `not` keyword
- Add types to signal parameter
- Add types to local variables
- Replace `clamp` with `clampf`
# Testing
The **Main Menu** scene had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.