### PR TITLE
Better format and static type User Settings UI

### DIFF
--- a/addons/godot-xr-tools/user_settings/user_settings_ui.gd
+++ b/addons/godot-xr-tools/user_settings/user_settings_ui.gd
@@ -1,15 +1,65 @@
 extends TabContainer
 
-signal player_height_changed(new_height)
+signal player_height_changed(new_height: float)
 
-@onready var snap_turning_button = $Input/InputVBox/SnapTurning/SnapTurningCB
-@onready var haptics_scale_slider = $Input/InputVBox/HapticsScale/HapticsScaleSlider
-@onready var y_deadzone_slider = $Input/InputVBox/yAxisDeadZone/yAxisDeadZoneSlider
-@onready var x_deadzone_slider = $Input/InputVBox/xAxisDeadZone/xAxisDeadZoneSlider
-@onready var player_height_slider = $Player/PlayerVBox/PlayerHeight/PlayerHeightSlider
-@onready var webxr_primary_button = $WebXR/WebXRVBox/WebXR/WebXRPrimary
+@onready var snap_turning_button: CheckBox = $Input/InputVBox/SnapTurning/SnapTurningCB
+@onready var haptics_scale_slider: HSlider = $Input/InputVBox/HapticsScale/HapticsScaleSlider
+@onready var y_deadzone_slider: HSlider = $Input/InputVBox/yAxisDeadZone/yAxisDeadZoneSlider
+@onready var x_deadzone_slider: HSlider = $Input/InputVBox/xAxisDeadZone/xAxisDeadZoneSlider
+@onready var player_height_slider: HSlider = $Player/PlayerVBox/PlayerHeight/PlayerHeightSlider
+@onready var webxr_primary_button: OptionButton = $WebXR/WebXRVBox/WebXR/WebXRPrimary
 
-func _update():
+
+# When the node enters the scene tree for the first time.
+func _ready() -> void:
+	var webxr_interface := XRServer.find_interface("WebXR")
+	set_tab_hidden(2, webxr_interface == null)
+
+	if XRToolsUserSettings:
+		_update()
+	else:
+		$Save/Button.disabled = true
+
+
+func _on_haptics_scale_slider_value_changed(value: float) -> void:
+	XRToolsUserSettings.haptics_scale = value
+
+
+func _on_PlayerHeightSlider_drag_ended(_value_changed: bool) -> void:
+	XRToolsUserSettings.player_height = player_height_slider.value
+	player_height_changed.emit(XRToolsUserSettings.player_height)
+
+
+func _on_Reset_pressed() -> void:
+	if XRToolsUserSettings:
+		XRToolsUserSettings.reset_to_defaults()
+		_update()
+		player_height_changed.emit(XRToolsUserSettings.player_height)
+
+
+func _on_Save_pressed() -> void:
+	if XRToolsUserSettings:
+		# Save
+		XRToolsUserSettings.save()
+
+
+func _on_SnapTurningCB_pressed() -> void:
+	XRToolsUserSettings.snap_turning = snap_turning_button.button_pressed
+
+
+func _on_web_xr_primary_item_selected(index: int) -> void:
+	XRToolsUserSettings.webxr_primary = index
+
+
+func _on_x_axis_dead_zone_slider_value_changed(value: float) -> void:
+	XRToolsUserSettings.x_axis_dead_zone = x_deadzone_slider.value
+
+
+func _on_y_axis_dead_zone_slider_value_changed(value: float) -> void:
+	XRToolsUserSettings.y_axis_dead_zone = y_deadzone_slider.value
+
+
+func _update() -> void:
 	# Input
 	snap_turning_button.button_pressed = XRToolsUserSettings.snap_turning
 	y_deadzone_slider.value = XRToolsUserSettings.y_axis_dead_zone
@@ -21,54 +71,3 @@ func _update():
 
 	# WebXR
 	webxr_primary_button.selected = XRToolsUserSettings.webxr_primary
-
-
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	var webxr_interface = XRServer.find_interface("WebXR")
-	set_tab_hidden(2, webxr_interface == null)
-
-	if XRToolsUserSettings:
-		_update()
-	else:
-		$Save/Button.disabled = true
-
-
-func _on_Save_pressed():
-	if XRToolsUserSettings:
-		# Save
-		XRToolsUserSettings.save()
-
-
-func _on_Reset_pressed():
-	if XRToolsUserSettings:
-		XRToolsUserSettings.reset_to_defaults()
-		_update()
-		emit_signal("player_height_changed", XRToolsUserSettings.player_height)
-
-
-# Input settings changed
-func _on_SnapTurningCB_pressed():
-	XRToolsUserSettings.snap_turning = snap_turning_button.button_pressed
-
-
-# Player settings changed
-func _on_PlayerHeightSlider_drag_ended(_value_changed):
-	XRToolsUserSettings.player_height = player_height_slider.value
-	emit_signal("player_height_changed", XRToolsUserSettings.player_height)
-
-
-func _on_web_xr_primary_item_selected(index: int) -> void:
-	XRToolsUserSettings.webxr_primary = index
-
-
-func _on_y_axis_dead_zone_slider_value_changed(value):
-	XRToolsUserSettings.y_axis_dead_zone = y_deadzone_slider.value
-
-
-func _on_x_axis_dead_zone_slider_value_changed(value):
-	XRToolsUserSettings.x_axis_dead_zone = x_deadzone_slider.value
-
-
-func _on_haptics_scale_slider_value_changed(value):
-	XRToolsUserSettings.haptics_scale = value

--- a/addons/godot-xr-tools/user_settings/user_settings_ui.tscn
+++ b/addons/godot-xr-tools/user_settings/user_settings_ui.tscn
@@ -8,6 +8,7 @@ offset_bottom = 126.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 12
+current_tab = 0
 script = ExtResource("1")
 
 [node name="Input" type="MarginContainer" parent="."]
@@ -16,6 +17,7 @@ theme_override_constants/margin_left = 5
 theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
+metadata/_tab_index = 0
 
 [node name="InputVBox" type="VBoxContainer" parent="Input"]
 layout_mode = 2
@@ -100,6 +102,7 @@ theme_override_constants/margin_left = 5
 theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
+metadata/_tab_index = 1
 
 [node name="PlayerVBox" type="VBoxContainer" parent="Player"]
 layout_mode = 2
@@ -144,6 +147,7 @@ theme_override_constants/margin_left = 5
 theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
+metadata/_tab_index = 2
 
 [node name="WebXRVBox" type="VBoxContainer" parent="WebXR"]
 layout_mode = 2
@@ -159,8 +163,8 @@ text = "WebXR primary:"
 [node name="WebXRPrimary" type="OptionButton" parent="WebXR/WebXRVBox/WebXR"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
-item_count = 3
 selected = 0
+item_count = 3
 popup/item_0/text = "Auto"
 popup/item_0/id = 0
 popup/item_1/text = "Thumbstick"
@@ -194,6 +198,6 @@ text = "Reset"
 [connection signal="drag_ended" from="Player/PlayerVBox/PlayerHeight/PlayerHeightSlider" to="." method="_on_PlayerHeightSlider_drag_ended"]
 [connection signal="pressed" from="Player/PlayerVBox/Buttons/Save" to="." method="_on_Save_pressed"]
 [connection signal="pressed" from="Player/PlayerVBox/Buttons/Reset" to="." method="_on_Reset_pressed"]
-[connection signal="item_selected" from="WebXR/WebXRVBox/WebXR/WebXRPrimary" to="." method="_on_PlayerHeightSlider_drag_ended"]
+[connection signal="item_selected" from="WebXR/WebXRVBox/WebXR/WebXRPrimary" to="." method="_on_web_xr_primary_item_selected"]
 [connection signal="pressed" from="WebXR/WebXRVBox/Buttons/Save" to="." method="_on_Save_pressed"]
 [connection signal="pressed" from="WebXR/WebXRVBox/Buttons/Reset" to="." method="_on_Reset_pressed"]


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons whenever types must be specified
- Remove types whenever inferring is possible
- Reorder functions in accordance with the style guide above
- Clarify comments of variables and methods
- Add return type to eight methods
- Add type to signal parameter
- Replace `emit_signal(signal, Callable)` with `signal.emit(Callable)`
- Connect WebXR primary `OptionButton` to `_on_web_xr_primary_item_selected()` instead of `_on_PlayerHeightSlider_drag_ended()`
# Testing
The **Main Menu** scene had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.