### PR TITLE
Don't await process_frame

### DIFF
--- a/addons/godot-xr-tools/functions/function_pointer.gd
+++ b/addons/godot-xr-tools/functions/function_pointer.gd
@@ -121,11 +121,11 @@ var _controller_right_node: XRController3D
 # Currently active controller
 var _active_controller: XRController3D
 
-@onready var _laser: MeshInstance3D = $Laser
-@onready var _ray: RayCast3D = $RayCast
-@onready var _suppress_area: Area3D = $SuppressArea
-@onready var _suppress_collider: CollisionShape3D = $SuppressArea/CollisionShape3D
-@onready var _target: MeshInstance3D = $Target
+var _laser: MeshInstance3D
+var _ray: RayCast3D
+var _suppress_area: Area3D
+var _suppress_collider: CollisionShape3D
+var _target: MeshInstance3D
 
 
 # Called when the node enters the scene tree for the first time.
@@ -172,8 +172,14 @@ func _enter_tree() -> void:
 				_on_button_released.bind(_controller_right_node)
 		)
 
+	# Get child nodes
+	_laser = $Laser
+	_ray = $RayCast
+	_suppress_area = $SuppressArea
+	_suppress_collider = $SuppressArea/CollisionShape3D
+	_target = $Target
+
 	# init our state
-	await get_tree().process_frame
 	_update_y_offset()
 	_update_distance()
 	_update_pointer()

--- a/addons/godot-xr-tools/functions/function_pose_detector.gd
+++ b/addons/godot-xr-tools/functions/function_pose_detector.gd
@@ -17,22 +17,21 @@ const DEFAULT_MASK := 0b0000_0000_0010_0000_0000_0000_0000_0000
 @export_flags_3d_physics var collision_mask := DEFAULT_MASK: set = set_collision_mask
 
 
-## Hand to control
+# Hand to control
 var _hand: XRToolsHand
+# Area3D to sense hand poses
+var _sense_area: Area3D
 
 
-@onready var _sense_area: Area3D = $SenseArea
-
-
-# Called when we enter our tree
+# When we enter our tree
 func _enter_tree() -> void:
 	super._enter_tree()
 
 	_hand = XRToolsHand.find_instance(self)
 
-	# Connect signals (if controller and hand are valid)
-	await get_tree().process_frame
+	_sense_area = $SenseArea
 
+	# Connect signals (if controller and hand are valid)
 	if _controller and _hand:
 		if _sense_area.area_entered.connect(_on_area_entered):
 			push_error("Unable to connect area_entered signal")

--- a/addons/godot-xr-tools/hands/hand.gd
+++ b/addons/godot-xr-tools/hands/hand.gd
@@ -69,9 +69,6 @@ var _target_overrides: Array[TargetOverride]
 var _target: Node3D
 
 
-@onready var _anim_tree: AnimationTree = $AnimationTree
-
-
 ## Finds an [XRToolsHand] node by searching from the specified node for an
 ## [XRToolsHand], assuming the node is a sibling of the hand under an
 ## [XROrigin3D].
@@ -188,8 +185,8 @@ func _physics_process(_delta: float) -> void:
 		if _force_trigger >= 0.0:
 			trigger = _force_trigger
 
-		_anim_tree.set("parameters/Grip/blend_amount", grip)
-		_anim_tree.set("parameters/Trigger/blend_amount", trigger)
+		_animation_tree.set("parameters/Grip/blend_amount", grip)
+		_animation_tree.set("parameters/Trigger/blend_amount", trigger)
 
 	# Move to target
 	var target_transform: Transform3D
@@ -284,10 +281,10 @@ func force_grip_trigger(grip: float = -1.0, trigger: float = -1.0) -> void:
 	_force_trigger = trigger
 
 	# Update the animation if forcing to specific values
-	if grip >= 0.0:
-		_anim_tree.set("parameters/Grip/blend_amount", grip)
-	if trigger >= 0.0:
-		_anim_tree.set("parameters/Trigger/blend_amount", trigger)
+	if grip >= 0.0 and _animation_tree:
+		_animation_tree.set("parameters/Grip/blend_amount", grip)
+	if trigger >= 0.0 and _animation_tree:
+		_animation_tree.set("parameters/Trigger/blend_amount", trigger)
 
 
 func remove_pose_override(who: Node) -> void:

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -121,19 +121,23 @@ var scene_proxy_configuration: Dictionary = {}
 var viewport_texture: ViewportTexture
 var time_since_last_update := 0.0
 
-var _screen_material: StandardMaterial3D
+var _collider: CollisionShape3D
 var _dirty := _DIRTY_ALL
-
-
-@onready var _collider: CollisionShape3D = $StaticBody3D/CollisionShape3D
-@onready var _screen: MeshInstance3D = $Screen
-@onready var _static_body: StaticBody3D = $StaticBody3D
-@onready var _viewport: SubViewport = $Viewport
+var _screen: MeshInstance3D
+var _screen_material: StandardMaterial3D
+var _static_body: StaticBody3D
+var _viewport: SubViewport
 
 
 # When the node enters the scene tree for the first time.
 func _ready() -> void:
 	is_ready = true
+
+	# Get child nodes
+	_collider = $StaticBody3D/CollisionShape3D
+	_screen = $Screen
+	_static_body = $StaticBody3D
+	_viewport = $Viewport
 
 	# Listen for pointer events on the screen body
 	_static_body.connect("pointer_event", _on_pointer_event)
@@ -148,7 +152,6 @@ func _ready() -> void:
 
 	# Update the render objects
 	await RenderingServer.frame_post_draw
-	await get_tree().process_frame
 	_update_render()
 
 


### PR DESCRIPTION
I used `await get_tree().process_frame` to stop onready variables from throwing errors, but I found a better way of retrieving them that doesn't require any awaits.
# Testing
The `Main Menu` scene had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.