### PR TITLE
Save and load settings from a ConfigFile

### DIFF
--- a/addons/godot-xr-tools/user_settings/user_settings.gd
+++ b/addons/godot-xr-tools/user_settings/user_settings.gd
@@ -37,7 +37,7 @@ enum WebXRPrimary {
 
 
 ## File name to persist user settings
-var settings_file_name := "user://xtools_user_settings.json"
+var settings_file_name := "user://xr_tools_user_settings.cfg"
 
 ## Records the first input to generate input (thumbstick or trackpad).
 var webxr_auto_primary := 0
@@ -106,36 +106,23 @@ func reset_to_defaults() -> void:
 	haptics_scale = XRToolsRumbleManager.get_default_haptics_scale()
 
 
-## Saves the settings to file
+## Saves the settings to a .cfg file
 func save() -> void:
-	# Convert the settings to a dictionary
-	var settings := {
-		"input": {
-			"default_snap_turning": snap_turning,
-			"y_axis_dead_zone": y_axis_dead_zone,
-			"x_axis_dead_zone": x_axis_dead_zone,
-			"haptics_scale": haptics_scale,
-		},
-		"player": {
-			"height": player_height,
-		},
-		"webxr": {
-			"webxr_primary": webxr_primary,
-		}
-	}
+	# Create a new Config File
+	var config := ConfigFile.new()
 
-	# Convert the settings dictionary to text
-	var settings_text := JSON.stringify(settings)
+	# Add the settings to the Config File
+	config.set_value("input", "default_snap_turning", snap_turning)
+	config.set_value("input", "x_axis_dead_zone", x_axis_dead_zone)
+	config.set_value("input", "y_axis_dead_zone", y_axis_dead_zone)
+	config.set_value("input", "haptics_scale", haptics_scale)
 
-	# Attempt to open the settings file for writing
-	var file := FileAccess.open(settings_file_name, FileAccess.WRITE)
-	if not file:
-		push_warning("Unable to write to %s" % settings_file_name)
-		return
+	config.set_value("player", "height", player_height)
 
-	# Write the settings text to the file
-	file.store_line(settings_text)
-	file.close()
+	config.set_value("webxr", "primary", webxr_primary)
+
+	# Save the Config File
+	config.save(settings_file_name)
 
 
 ## Sets the player's height
@@ -156,7 +143,7 @@ func set_webxr_primary(new_value: WebXRPrimary) -> void:
 		webxr_primary_changed.emit(webxr_primary)
 
 
-# Loads the settings from file
+# Loads the settings from the Config File
 func _load() -> void:
 	# First reset our values
 	reset_to_defaults()
@@ -166,45 +153,42 @@ func _load() -> void:
 		return
 
 	# Attempt to open the settings file for reading
-	var file := FileAccess.open(settings_file_name, FileAccess.READ)
-	if not file:
+	var config := ConfigFile.new()
+	var err = config.load(settings_file_name)
+
+	if err != OK:
 		push_warning("Unable to read from %s" % settings_file_name)
 		return
 
-	# Read the settings text
-	var settings_text := file.get_as_text()
-	file.close()
+	# Load the settings from the Config File
+	snap_turning = config.get_value(
+			"input",
+			"default_snap_turning",
+			XRTools.get_default_snap_turning(),
+	)
+	x_axis_dead_zone = config.get_value(
+			"input",
+			"x_axis_dead_zone",
+			XRTools.get_x_axis_dead_zone(),
+	)
+	y_axis_dead_zone = config.get_value(
+			"input",
+			"y_axis_dead_zone",
+			XRTools.get_y_axis_dead_zone(),
+	)
+	haptics_scale = config.get_value(
+			"input",
+			"haptics_scale",
+			XRToolsRumbleManager.get_default_haptics_scale(),
+	)
 
-	# Parse the settings text and verify it's a dictionary
-	var settings_raw = JSON.parse_string(settings_text)
-	if typeof(settings_raw) != TYPE_DICTIONARY:
-		push_warning("Settings file %s is corrupt" % settings_file_name)
-		return
+	player_height = config.get_value(
+			"player",
+			"height",
+			XRTools.get_player_standard_height(),
+	)
 
-	# Parse our input settings
-	var settings: Dictionary = settings_raw
-	if settings.has("input"):
-		var input: Dictionary = settings["input"]
-		if input.has("default_snap_turning"):
-			snap_turning = input["default_snap_turning"]
-		if input.has("y_axis_dead_zone"):
-			y_axis_dead_zone = input["y_axis_dead_zone"]
-		if input.has("x_axis_dead_zone"):
-			x_axis_dead_zone = input["x_axis_dead_zone"]
-		if input.has("haptics_scale"):
-			haptics_scale = input["haptics_scale"]
-
-	# Parse our player settings
-	if settings.has("player"):
-		var player: Dictionary = settings["player"]
-		if player.has("height"):
-			player_height = player["height"]
-
-	# Parse our WebXR settings
-	if settings.has("webxr"):
-		var webxr: Dictionary = settings["webxr"]
-		if webxr.has("webxr_primary"):
-			webxr_primary = webxr["webxr_primary"]
+	webxr_primary = config.get_value("webxr", "primary", WebXRPrimary.AUTO)
 
 
 # Connects to tracker events when using WebXR.


### PR DESCRIPTION
Before, we used JSON encoding to write settings to a text file, but it looks quite ugly, and the code was very messy. [Godot now recommends using the `ConfigFile` class for user configurations](https://docs.godotengine.org/en/stable/tutorials/io/saving_games.html#introduction), which ends up looking much nicer, and the code is a lot cleaner too. As an added bonus, we can also specify defaults here.

| Old Settings File | New Settings File |
| ----------------------- | -------------------------- |
|<img width="1694" height="91" alt="image" src="https://github.com/user-attachments/assets/ed9ce5ee-6068-4b8a-82b7-22ad155c67b0" />|<img width="481" height="548" alt="image" src="https://github.com/user-attachments/assets/9e1de57e-eaad-4bf4-a590-6652e2b316b3" />|

> [!NOTE]
> I understand that this doesn't change much, other than formatting, but it does make adding new settings much easier.
# Testing
The `Main Menu` scene had no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.